### PR TITLE
fix: coalesce per-keystroke property edits into a single undo entry

### DIFF
--- a/src/lib/stores/project.ts
+++ b/src/lib/stores/project.ts
@@ -62,6 +62,27 @@ function syncHistoryStore() {
 /** Current undo action description — set before calling mutate/snapshot */
 let _nextDescription = '';
 
+// Undo coalescing: rapid consecutive edits to the same field (e.g. typing digits
+// into a dimension input, which fires `oninput` per keystroke) should collapse into
+// a single undo entry instead of one per keystroke. The first edit pushes the
+// pre-edit baseline; subsequent edits sharing the same key within the time window
+// reuse it rather than pushing a fresh snapshot.
+let _lastCoalesceKey: string | null = null;
+let _lastSnapshotTime = 0;
+const COALESCE_WINDOW_MS = 800;
+
+/** Break any active coalescing chain so the next edit starts a fresh undo entry. */
+function resetCoalescing() {
+  _lastCoalesceKey = null;
+}
+
+/** Build a coalesce key for an element edit from its type, id, and the fields changed.
+ *  Rapid edits to the same element+fields collapse into one undo entry; changing which
+ *  fields are edited (or which element) starts a new entry. */
+function coalesceKeyFor(type: string, id: string, updates: Record<string, unknown>): string {
+  return `${type}:${id}:${Object.keys(updates).sort().join(',')}`;
+}
+
 // Undo grouping: batch multiple mutations into a single undo entry
 let undoGroupSnapshot: string | null = null;
 let undoGroupDepth = 0;
@@ -85,18 +106,35 @@ export function endUndoGroup(description?: string) {
     redoStack.length = 0;
     undoGroupSnapshot = null;
     _nextDescription = '';
+    resetCoalescing();
     syncHistoryStore();
   }
 }
 
-function snapshot(description?: string) {
+function snapshot(description?: string, coalesceKey?: string) {
   // If inside an undo group, skip — the group handles the snapshot
   if (undoGroupDepth > 0) return;
   const p = get(currentProject);
-  if (p) undoStack.push({ state: JSON.stringify(p), description: description || _nextDescription || 'Edit', timestamp: Date.now() });
+  if (!p) return;
+  const now = Date.now();
+  // Coalesce rapid consecutive edits to the same field: the top-of-stack entry
+  // already holds the correct pre-edit baseline, so don't push another snapshot.
+  if (
+    coalesceKey &&
+    coalesceKey === _lastCoalesceKey &&
+    now - _lastSnapshotTime < COALESCE_WINDOW_MS &&
+    undoStack.length > 0
+  ) {
+    _lastSnapshotTime = now;
+    redoStack.length = 0;
+    return;
+  }
+  undoStack.push({ state: JSON.stringify(p), description: description || _nextDescription || 'Edit', timestamp: now });
   if (undoStack.length > 50) undoStack.shift();
   redoStack.length = 0;
   _nextDescription = '';
+  _lastCoalesceKey = coalesceKey ?? null;
+  _lastSnapshotTime = now;
   syncHistoryStore();
 }
 
@@ -107,6 +145,7 @@ function reviveDates(p: Project): Project {
 }
 
 export function undo() {
+  resetCoalescing();
   const prev = undoStack.pop();
   if (!prev) return;
   const cur = get(currentProject);
@@ -116,6 +155,7 @@ export function undo() {
 }
 
 export function redo() {
+  resetCoalescing();
   const next = redoStack.pop();
   if (!next) return;
   const cur = get(currentProject);
@@ -126,6 +166,7 @@ export function redo() {
 
 /** Jump to a specific undo history step by index (0 = oldest) */
 export function jumpToUndoStep(targetIndex: number) {
+  resetCoalescing();
   const total = undoStack.length; // total past states; current state is at index `total`
   if (targetIndex < 0 || targetIndex > total) return;
   if (targetIndex === total) return; // already at current state
@@ -148,10 +189,10 @@ export function jumpToUndoStep(targetIndex: number) {
   syncHistoryStore();
 }
 
-function mutate(fn: (floor: Floor) => void, description?: string) {
+function mutate(fn: (floor: Floor) => void, description?: string, coalesceKey?: string) {
   const p = get(currentProject);
   if (!p) return;
-  snapshot(description);
+  snapshot(description, coalesceKey);
   const floor = p.floors.find((f) => f.id === p.activeFloorId);
   if (!floor) return;
   fn(floor);
@@ -294,7 +335,7 @@ export function updateStair(id: string, updates: Partial<Stair>) {
     if (!f.stairs) return;
     const s = f.stairs.find((s) => s.id === id);
     if (s) Object.assign(s, updates);
-  });
+  }, undefined, coalesceKeyFor('stair', id, updates));
 }
 
 export function removeStair(id: string) {
@@ -345,7 +386,7 @@ export function updateColumn(id: string, updates: Partial<Column>) {
     if (!f.columns) return;
     const c = f.columns.find((c) => c.id === id);
     if (c) Object.assign(c, updates);
-  });
+  }, undefined, coalesceKeyFor('column', id, updates));
 }
 
 export function removeColumn(id: string) {
@@ -417,7 +458,7 @@ export function updateEntourageItem(id: string, updates: Partial<EntourageItem>)
   mutate((f) => {
     const e = f.entourage?.find((e) => e.id === id);
     if (e) Object.assign(e, updates);
-  });
+  }, undefined, coalesceKeyFor('entourage', id, updates));
 }
 
 /** Register an uploaded PNG as a reusable project-level entourage symbol. */
@@ -475,28 +516,28 @@ export function updateWall(id: string, updates: Partial<Wall>) {
   mutate((f) => {
     const w = f.walls.find((w) => w.id === id);
     if (w) Object.assign(w, updates);
-  });
+  }, undefined, coalesceKeyFor('wall', id, updates));
 }
 
 export function updateDoor(id: string, updates: Partial<Door>) {
   mutate((f) => {
     const d = f.doors.find((d) => d.id === id);
     if (d) Object.assign(d, updates);
-  });
+  }, undefined, coalesceKeyFor('door', id, updates));
 }
 
 export function updateWindow(id: string, updates: Partial<Win>) {
   mutate((f) => {
     const w = f.windows.find((w) => w.id === id);
     if (w) Object.assign(w, updates);
-  });
+  }, undefined, coalesceKeyFor('window', id, updates));
 }
 
 export function updateFurniture(id: string, updates: Partial<FurnitureItem>) {
   mutate((f) => {
     const fi = f.furniture.find((fi) => fi.id === id);
     if (fi) Object.assign(fi, updates);
-  });
+  }, undefined, coalesceKeyFor('furniture', id, updates));
 }
 
 export function updateRoom(id: string, updates: Partial<{ name: string; floorTexture: string; color: string; roomType: import('$lib/models/types').RoomCategory; labelOffset: import('$lib/models/types').Point | undefined }>) {
@@ -512,7 +553,7 @@ export function updateRoom(id: string, updates: Partial<{ name: string; floorTex
         f.rooms.push(newRoom);
       }
     }
-  });
+  }, undefined, coalesceKeyFor('room', id, updates));
 }
 
 export function addFloor(name?: string, copyCurrentLayout = false) {
@@ -565,6 +606,7 @@ export function updateProjectName(name: string) {
 export function loadProject(project: Project) {
   undoStack.length = 0;
   redoStack.length = 0;
+  resetCoalescing();
   currentProject.set(project);
   syncHistoryStore();
 }
@@ -790,7 +832,7 @@ export function updateAnnotation(id: string, updates: Partial<{ x1: number; y1: 
     const a = f.annotations.find(a => a.id === id);
     if (!a) return;
     Object.assign(a, updates);
-  });
+  }, undefined, coalesceKeyFor('annotation', id, updates));
 }
 
 // --- Text Annotations ---
@@ -816,7 +858,7 @@ export function updateTextAnnotation(id: string, updates: Partial<{ x: number; y
     const t = f.textAnnotations.find(t => t.id === id);
     if (!t) return;
     Object.assign(t, updates);
-  });
+  }, undefined, coalesceKeyFor('textAnnotation', id, updates));
 }
 
 export function moveTextAnnotation(id: string, position: { x: number; y: number }) {


### PR DESCRIPTION
## What

Property-panel edits now collapse into a single undo entry per logical edit, instead of one entry per keystroke.

## Why

While testing the editor in a browser, I found that undo was broken for property edits:

- Every numeric/text input in the Properties panel fires \`oninput\` on **each keystroke**, and each \`update*\` function in \`project.ts\` calls \`snapshot()\` unconditionally.
- Typing a width of \`300\` created **3** undo entries → one Cmd+Z rolled back to \`30\`, then \`3\`, then the original. Typing a room name like "Bedroom" created **7**.
- Worse: the undo stack is capped at 50, so a bit of typing silently flushes out real actions (placed walls, moved furniture), leaving them un-undoable.

## How

Added undo **coalescing** at the \`snapshot\`/\`mutate\` layer:

- A coalesce key (\`type:id:sortedFieldNames\`) identifies edits to the same element+field(s).
- The first edit records the pre-edit baseline; subsequent edits sharing the same key within an 800ms window reuse it rather than pushing a new snapshot.
- Live 2D/3D updates are untouched — only the history push is coalesced, so immediate visual feedback while typing is preserved.
- Coalescing resets on undo / redo / history-jump / undo-group boundaries and on project load, so distinct edits stay separate.

Applied to all per-keystroke-bound updates: furniture, wall, door, window, room (incl. name), stair, column, entourage, annotation, and text annotation.

## Verification

Tested against a local dev build (throwaway project):

- Typing \`555\` into Depth (3 keystrokes) now creates exactly **one** undo entry (confirmed in the Undo History panel).
- A single undo restores Depth \`555 → 90\` in one step.
- The object still resizes live as you type — feedback preserved.
- \`svelte-check\` is clean for this file (the 6 pre-existing errors are unrelated \`'annotate'\`/\`'measure'\` Tool-type issues in \`BuildPanel.svelte\`).

## Reviewer notes

- The 800ms window means two *deliberate* separate edits to the same field within 800ms would merge into one undo — an acceptable trade vs. one-entry-per-keystroke. Blur-based sealing could be added later if desired.
- Not addressed here (possibly intentional): opening the 3D view preloads all 94 furniture GLB models rather than just those in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)