### PR TITLE
fix: use per-item furniture dimensions for wall snap and hit testing

### DIFF
--- a/src/lib/components/editor/FloorPlanCanvas.svelte
+++ b/src/lib/components/editor/FloorPlanCanvas.svelte
@@ -5,7 +5,7 @@
   import type { Floor, Room } from '$lib/models/types';
   import { detectRooms, getRoomPolygon, roomCentroid } from '$lib/utils/roomDetection';
   import { getMaterial } from '$lib/utils/materials';
-  import { getCatalogItem } from '$lib/utils/furnitureCatalog';
+  import { getCatalogItem, getFurnitureSize, type FurnitureDef } from '$lib/utils/furnitureCatalog';
   import { drawFurnitureIcon } from '$lib/utils/furnitureIcons';
   import { handleGlobalShortcut } from '$lib/utils/shortcuts';
   import ContextMenu from './ContextMenu.svelte';
@@ -241,13 +241,16 @@
    * Snap furniture position so its edge is flush against the nearest wall.
    * Returns adjusted position and rotation, or null if no wall is close enough.
    */
-  function snapFurnitureToWall(pos: Point, catalogId: string, currentRotation: number): { position: Point; rotation: number; wallId: string; side: 'normal' | 'anti'; wallAngle: number } | null {
+  function snapFurnitureToWall(pos: Point, furniture: FurnitureItem | FurnitureDef, currentRotation: number): { position: Point; rotation: number; wallId: string; side: 'normal' | 'anti'; wallAngle: number } | null {
     if (!currentFloor) return null;
-    const cat = getCatalogItem(catalogId);
-    if (!cat) return null;
+
+    // A placed item carries per-item size overrides; a bare catalog def (placement
+    // preview, before the item exists) is already its own effective size.
+    const size = 'catalogId' in furniture ? getFurnitureSize(furniture) : furniture;
 
     // Furniture half-depth (the "back" dimension that goes against the wall)
-    const halfDepth = cat.depth / 2;
+    const halfDepth = size.depth / 2;
+    const halfWidth = size.width / 2;
 
     let bestDist = WALL_SNAP_DIST;
     let bestResult: { position: Point; rotation: number; wallId: string; side: 'normal' | 'anti'; wallAngle: number } | null = null;
@@ -269,7 +272,7 @@
       const perp = dx * nx + dy * ny;  // signed distance from wall center-line
 
       // Check if projection falls within wall segment (with some margin)
-      if (along < -cat.width / 2 || along > wLen + cat.width / 2) continue;
+      if (along < -halfWidth || along > wLen + halfWidth) continue;
 
       const wallHalfThickness = wall.thickness / 2;
       // Distance from furniture center to wall surface on the side the furniture is on
@@ -284,16 +287,23 @@
         const sign = perp >= 0 ? 1 : -1;
         // Position: push center so edge is flush with wall surface
         const targetPerp = sign * (wallHalfThickness + halfDepth);
-        const clampedAlong = Math.max(cat.width / 2, Math.min(wLen - cat.width / 2, along));
-        const newX = wall.start.x + ux * clampedAlong + nx * targetPerp;
-        const newY = wall.start.y + uy * clampedAlong + ny * targetPerp;
+        const clampedAlong = Math.max(halfWidth, Math.min(wLen - halfWidth, along));
+
+        // Grid-snap the position, then keep only the part of that movement that runs along
+        // the wall, so the distance to the wall stays exact and the item sits flush.
+        const gx = snap(wall.start.x + ux * clampedAlong + nx * targetPerp);
+        const gy = snap(wall.start.y + uy * clampedAlong + ny * targetPerp);
+        const gridAlong = (gx - wall.start.x) * ux + (gy - wall.start.y) * uy;
+        const finalAlong = Math.max(halfWidth, Math.min(wLen - halfWidth, gridAlong));
+        const newX = wall.start.x + ux * finalAlong + nx * targetPerp;
+        const newY = wall.start.y + uy * finalAlong + ny * targetPerp;
         // Align rotation: furniture "front" faces away from wall
         const wallAngle = Math.atan2(wy, wx) * 180 / Math.PI;
         // Furniture at 0° has depth along Y axis, so align perpendicular
         const targetRotation = perp >= 0 ? wallAngle : wallAngle + 180;
 
         bestResult = {
-          position: { x: snap(newX), y: snap(newY) },
+          position: { x: newX, y: newY },
           rotation: ((targetRotation % 360) + 360) % 360,
           wallId: wall.id,
           side,
@@ -525,7 +535,7 @@
     const cat = getCatalogItem(currentPlacingId);
     if (!cat) return;
 
-    const wallSnap = snapFurnitureToWall(mousePos, currentPlacingId, currentPlacingRotation);
+    const wallSnap = snapFurnitureToWall(mousePos, cat, currentPlacingRotation);
     placementWallSnap = wallSnap;
 
     const pos = wallSnap ? wallSnap.position : mousePos;
@@ -2204,7 +2214,8 @@
     // Column and stair placement moved earlier (before select-mode handlers)
 
     if (tool === 'furniture' && currentPlacingId) {
-      const wallSnap = snapFurnitureToWall(wp, currentPlacingId, currentPlacingRotation);
+      const placingCat = getCatalogItem(currentPlacingId);
+      const wallSnap = placingCat ? snapFurnitureToWall(wp, placingCat, currentPlacingRotation) : null;
       const pos = wallSnap ? wallSnap.position : { x: snap(wp.x), y: snap(wp.y) };
       const rot = wallSnap ? wallSnap.rotation : currentPlacingRotation;
       const id = addFurniture(currentPlacingId, pos);
@@ -2748,7 +2759,7 @@
       const basePos = { x: mousePos.x - dragOffset.x, y: mousePos.y - dragOffset.y };
       const fi = currentFloor?.furniture.find(f => f.id === draggingFurnitureId);
       if (fi) {
-        const wallSnap = snapFurnitureToWall(basePos, fi.catalogId, fi.rotation);
+        const wallSnap = snapFurnitureToWall(basePos, fi, fi.rotation);
         if (wallSnap) {
           moveFurniture(draggingFurnitureId, wallSnap.position);
           setFurnitureRotation(draggingFurnitureId, wallSnap.rotation);

--- a/src/lib/utils/alignment.ts
+++ b/src/lib/utils/alignment.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 import { activeFloor, currentProject, beginUndoGroup, endUndoGroup } from '$lib/stores/project';
-import { getCatalogItem } from '$lib/utils/furnitureCatalog';
+import { getFurnitureSize } from '$lib/utils/furnitureCatalog';
 import type { FurnitureItem, Floor } from '$lib/models/types';
 
 export type AlignmentOp =
@@ -22,10 +22,8 @@ interface Rect {
 }
 
 function getRect(item: FurnitureItem): Rect {
-  const cat = getCatalogItem(item.catalogId);
-  const w = (item.width ?? cat?.width ?? 50) * (item.scale?.x ?? 1);
-  const d = (item.depth ?? cat?.depth ?? 50) * (item.scale?.y ?? 1);
-  return { item, x: item.position.x, y: item.position.y, w, d };
+  const { width, depth } = getFurnitureSize(item);
+  return { item, x: item.position.x, y: item.position.y, w: width, d: depth };
 }
 
 function getSelectedFurniture(ids: Set<string>): FurnitureItem[] {

--- a/src/lib/utils/furnitureCatalog.ts
+++ b/src/lib/utils/furnitureCatalog.ts
@@ -1,3 +1,5 @@
+import type { FurnitureItem } from '$lib/models/types';
+
 export interface FurnitureDef {
   id: string;
   name: string;
@@ -247,6 +249,20 @@ export const furnitureCatalog: FurnitureDef[] = [
 
 export function getCatalogItem(id: string): FurnitureDef | undefined {
   return furnitureCatalog.find(f => f.id === id);
+}
+
+/**
+ * Effective footprint of a placed item in cm — per-item overrides applied over the
+ * catalog defaults, then multiplied by scale. Use this wherever geometry is derived
+ * from a FurnitureItem.
+ */
+export function getFurnitureSize(fi: FurnitureItem): { width: number; depth: number; height: number } {
+  const cat = getCatalogItem(fi.catalogId);
+  return {
+    width: (fi.width ?? cat?.width ?? 50) * Math.abs(fi.scale?.x ?? 1),
+    depth: (fi.depth ?? cat?.depth ?? 50) * Math.abs(fi.scale?.y ?? 1),
+    height: (fi.height ?? cat?.height ?? 50) * Math.abs(fi.scale?.z ?? 1),
+  };
 }
 
 export const furnitureCategories = [...new Set(furnitureCatalog.map(f => f.category))];

--- a/src/lib/utils/hitTesting.ts
+++ b/src/lib/utils/hitTesting.ts
@@ -5,7 +5,7 @@
  */
 import type { Point, Wall, Door, Window as Win, FurnitureItem, Stair, Column, Floor, Measurement, Annotation, TextAnnotation, EntourageItem } from '$lib/models/types';
 import type { Room } from '$lib/models/types';
-import { getCatalogItem } from '$lib/utils/furnitureCatalog';
+import { getCatalogItem, getFurnitureSize } from '$lib/utils/furnitureCatalog';
 import { getRoomPolygon } from '$lib/utils/roomDetection';
 import { wallPointAt } from '$lib/utils/canvasRenderer';
 import type { HandleType } from '$lib/utils/canvasInteraction';
@@ -78,8 +78,9 @@ export function findHandleAt(
   const angle = -(fi.rotation * Math.PI) / 180;
   const rx = dx * Math.cos(angle) - dy * Math.sin(angle);
   const ry = dx * Math.sin(angle) + dy * Math.cos(angle);
-  const hw = cat.width * Math.abs(fi.scale?.x ?? 1) / 2;
-  const hd = cat.depth * Math.abs(fi.scale?.y ?? 1) / 2;
+  const size = getFurnitureSize(fi);
+  const hw = size.width / 2;
+  const hd = size.depth / 2;
   const ht = 8 / zoom;
 
   const rotHandleDist = 18 / zoom;
@@ -108,8 +109,9 @@ export function findFurnitureAt(p: Point, furniture: FurnitureItem[]): Furniture
     const angle = -(fi.rotation * Math.PI) / 180;
     const rx = dx * Math.cos(angle) - dy * Math.sin(angle);
     const ry = dx * Math.sin(angle) + dy * Math.cos(angle);
-    const hw = cat.width * Math.abs(fi.scale?.x ?? 1) / 2;
-    const hd = cat.depth * Math.abs(fi.scale?.y ?? 1) / 2;
+    const size = getFurnitureSize(fi);
+    const hw = size.width / 2;
+    const hd = size.depth / 2;
     if (Math.abs(rx) < hw && Math.abs(ry) < hd) return fi;
   }
   return null;


### PR DESCRIPTION
Resolves #16.

- `snapFurnitureToWall` takes the placed item — or a bare catalog def during the placement
  preview, before an item exists — instead of a catalog id, and resolves its footprint
  through a new `getFurnitureSize` helper. Resized items are now captured at the right
  distance and come to rest flush.
- Grid snapping is applied along the wall only. The distance to the wall is left exact, so
  the grid no longer rounds the item clear of the wall or into it.
- `findFurnitureAt` and `findHandleAt` use the same helper, so click targets and resize
  handles match the item as drawn.
- `getRect` in `alignment.ts` is now a thin wrapper over the helper, which additionally
  guards against negative extents from a mirrored scale.

The exclusive `if (wallSnap) … else` at both call sites already gave wall snap precedence
over grid snap; the `snap()` applied inside the function worked against that. This keeps the
existing precedence and makes it hold.

Verified against `npm run check` — the 6 pre-existing `setTool` errors remain, no new ones.
