### PR TITLE
fix: finish canvas drags when the pointer is released off the canvas

### DIFF
--- a/src/lib/components/editor/FloorPlanCanvas.svelte
+++ b/src/lib/components/editor/FloorPlanCanvas.svelte
@@ -2013,8 +2013,24 @@
 
   // pointInPolygon, pointToSegmentDist, positionOnWall imported from hitTesting.ts
 
+  /** True while a press that began on the canvas is still in progress. */
+  let canvasGestureActive = false;
+
+  // A press that starts on the canvas can end somewhere else: the selection toolbar appears
+  // over the element the moment it is selected, and a drag can also leave the canvas
+  // entirely. Finishing the gesture from the window keeps the release from being lost, which
+  // would otherwise leave the element following the pointer with no way to drop it.
+  function onWindowMouseMove(e: MouseEvent) {
+    if (canvasGestureActive && e.target !== canvas) onMouseMove(e);
+  }
+
+  function onWindowMouseUp(e: MouseEvent) {
+    if (canvasGestureActive && e.target !== canvas) onMouseUp(e);
+  }
+
   function onMouseDown(e: MouseEvent) {
     markDirty();
+    canvasGestureActive = true;
     if (e.button === 1 || (e.button === 0 && (spaceDown || $panMode || (e.shiftKey && currentTool === 'select')))) {
       isPanning = true;
       panStartX = e.clientX;
@@ -2822,6 +2838,7 @@
 
   function onMouseUp(e: MouseEvent) {
     markDirty();
+    canvasGestureActive = false;
     isPanning = false;
     draggingGuideId = null;
 
@@ -3700,7 +3717,7 @@
   );
 </script>
 
-<svelte:window on:keydown={onKeyDown} on:keyup={onKeyUp} />
+<svelte:window on:keydown={onKeyDown} on:keyup={onKeyUp} onmousemove={onWindowMouseMove} onmouseup={onWindowMouseUp} />
 
 <div class="w-full h-full relative overflow-hidden" role="application">
   <canvas


### PR DESCRIPTION
Resolves #21.

`mousemove` and `mouseup` are now also handled at the window level for the remainder of a
gesture that began on the canvas, so a release always reaches the handler and the drag state
is cleared.

The window handlers forward to the existing canvas handlers only while a canvas press is in
progress and the event target isn't the canvas itself, so canvas-targeted events are still
handled exactly once and hover behaviour outside the canvas is unchanged. Forwarding
`mousemove` as well as `mouseup` keeps a drag tracking while the pointer is over the toolbar
rather than stalling and resuming.
