### PR TITLE
fix: make furniture wall snapping optional and resize handles edge-anchored

### DIFF
--- a/src/lib/components/editor/FloorPlanCanvas.svelte
+++ b/src/lib/components/editor/FloorPlanCanvas.svelte
@@ -5,7 +5,7 @@
   import type { Floor, Room } from '$lib/models/types';
   import { detectRooms, getRoomPolygon, roomCentroid } from '$lib/utils/roomDetection';
   import { getMaterial } from '$lib/utils/materials';
-  import { getCatalogItem } from '$lib/utils/furnitureCatalog';
+  import { getCatalogItem, getFurnitureSize, type FurnitureDef } from '$lib/utils/furnitureCatalog';
   import { drawFurnitureIcon } from '$lib/utils/furnitureIcons';
   import { handleGlobalShortcut } from '$lib/utils/shortcuts';
   import ContextMenu from './ContextMenu.svelte';
@@ -241,13 +241,16 @@
    * Snap furniture position so its edge is flush against the nearest wall.
    * Returns adjusted position and rotation, or null if no wall is close enough.
    */
-  function snapFurnitureToWall(pos: Point, catalogId: string, currentRotation: number): { position: Point; rotation: number; wallId: string; side: 'normal' | 'anti'; wallAngle: number } | null {
+  function snapFurnitureToWall(pos: Point, furniture: FurnitureItem | FurnitureDef, currentRotation: number): { position: Point; rotation: number; wallId: string; side: 'normal' | 'anti'; wallAngle: number } | null {
     if (!currentFloor) return null;
-    const cat = getCatalogItem(catalogId);
-    if (!cat) return null;
+
+    // A placed item carries per-item size overrides; a bare catalog def (placement
+    // preview, before the item exists) is already its own effective size.
+    const size = 'catalogId' in furniture ? getFurnitureSize(furniture) : furniture;
 
     // Furniture half-depth (the "back" dimension that goes against the wall)
-    const halfDepth = cat.depth / 2;
+    const halfDepth = size.depth / 2;
+    const halfWidth = size.width / 2;
 
     let bestDist = WALL_SNAP_DIST;
     let bestResult: { position: Point; rotation: number; wallId: string; side: 'normal' | 'anti'; wallAngle: number } | null = null;
@@ -269,7 +272,7 @@
       const perp = dx * nx + dy * ny;  // signed distance from wall center-line
 
       // Check if projection falls within wall segment (with some margin)
-      if (along < -cat.width / 2 || along > wLen + cat.width / 2) continue;
+      if (along < -halfWidth || along > wLen + halfWidth) continue;
 
       const wallHalfThickness = wall.thickness / 2;
       // Distance from furniture center to wall surface on the side the furniture is on
@@ -284,16 +287,23 @@
         const sign = perp >= 0 ? 1 : -1;
         // Position: push center so edge is flush with wall surface
         const targetPerp = sign * (wallHalfThickness + halfDepth);
-        const clampedAlong = Math.max(cat.width / 2, Math.min(wLen - cat.width / 2, along));
-        const newX = wall.start.x + ux * clampedAlong + nx * targetPerp;
-        const newY = wall.start.y + uy * clampedAlong + ny * targetPerp;
+        const clampedAlong = Math.max(halfWidth, Math.min(wLen - halfWidth, along));
+
+        // Grid-snap the position, then keep only the part of that movement that runs along
+        // the wall, so the distance to the wall stays exact and the item sits flush.
+        const gx = snap(wall.start.x + ux * clampedAlong + nx * targetPerp);
+        const gy = snap(wall.start.y + uy * clampedAlong + ny * targetPerp);
+        const gridAlong = (gx - wall.start.x) * ux + (gy - wall.start.y) * uy;
+        const finalAlong = Math.max(halfWidth, Math.min(wLen - halfWidth, gridAlong));
+        const newX = wall.start.x + ux * finalAlong + nx * targetPerp;
+        const newY = wall.start.y + uy * finalAlong + ny * targetPerp;
         // Align rotation: furniture "front" faces away from wall
         const wallAngle = Math.atan2(wy, wx) * 180 / Math.PI;
         // Furniture at 0° has depth along Y axis, so align perpendicular
         const targetRotation = perp >= 0 ? wallAngle : wallAngle + 180;
 
         bestResult = {
-          position: { x: snap(newX), y: snap(newY) },
+          position: { x: newX, y: newY },
           rotation: ((targetRotation % 360) + 360) % 360,
           wallId: wall.id,
           side,
@@ -525,7 +535,7 @@
     const cat = getCatalogItem(currentPlacingId);
     if (!cat) return;
 
-    const wallSnap = snapFurnitureToWall(mousePos, currentPlacingId, currentPlacingRotation);
+    const wallSnap = snapFurnitureToWall(mousePos, cat, currentPlacingRotation);
     placementWallSnap = wallSnap;
 
     const pos = wallSnap ? wallSnap.position : mousePos;
@@ -2204,7 +2214,8 @@
     // Column and stair placement moved earlier (before select-mode handlers)
 
     if (tool === 'furniture' && currentPlacingId) {
-      const wallSnap = snapFurnitureToWall(wp, currentPlacingId, currentPlacingRotation);
+      const placingCat = getCatalogItem(currentPlacingId);
+      const wallSnap = placingCat ? snapFurnitureToWall(wp, placingCat, currentPlacingRotation) : null;
       const pos = wallSnap ? wallSnap.position : { x: snap(wp.x), y: snap(wp.y) };
       const rot = wallSnap ? wallSnap.rotation : currentPlacingRotation;
       const id = addFurniture(currentPlacingId, pos);
@@ -2748,7 +2759,7 @@
       const basePos = { x: mousePos.x - dragOffset.x, y: mousePos.y - dragOffset.y };
       const fi = currentFloor?.furniture.find(f => f.id === draggingFurnitureId);
       if (fi) {
-        const wallSnap = snapFurnitureToWall(basePos, fi.catalogId, fi.rotation);
+        const wallSnap = snapFurnitureToWall(basePos, fi, fi.rotation);
         if (wallSnap) {
           moveFurniture(draggingFurnitureId, wallSnap.position);
           setFurnitureRotation(draggingFurnitureId, wallSnap.rotation);

--- a/src/lib/components/editor/FloorPlanCanvas.svelte
+++ b/src/lib/components/editor/FloorPlanCanvas.svelte
@@ -13,7 +13,7 @@
   import { getWallTextureCanvas, getFloorTextureCanvas, setTextureLoadCallback } from '$lib/utils/textureGenerator';
   import { projectSettings, formatLength, formatArea } from '$lib/stores/settings';
   import type { ProjectSettings } from '$lib/stores/settings';
-  import type { CanvasState } from '$lib/utils/canvasInteraction';
+  import { WALL_SNAP_DIST, resizeFurnitureFromHandle, type CanvasState } from '$lib/utils/canvasInteraction';
   import { drawWall as _drawWall, drawDoorOnWall as _drawDoorOnWall, drawWindowOnWall as _drawWindowOnWall, drawDoorDistanceDimensions as _drawDoorDistanceDimensions, drawWindowDistanceDimensions as _drawWindowDistanceDimensions, drawFurnitureItem, drawStair as _drawStair, drawColumn as _drawColumn, drawGuides as _drawGuides, drawPersistedMeasurements as _drawPersistedMeasurements, drawTextAnnotations as _drawTextAnnotations, drawAnnotation as _drawAnnotation, drawAnnotations as _drawAnnotations, drawRooms as _drawRooms, drawWallJoints as _drawWallJoints, drawSnapPoints as _drawSnapPoints, drawMinimap as _drawMinimap, drawEntourageItems as _drawEntourageItems, drawEntourageGhost as _drawEntourageGhost, entourageAspect } from '$lib/utils/canvasRenderer';
   import { getEntourageDef } from '$lib/utils/entourageCatalog';
   import { pointInPolygon, positionOnWall, findWallAt as _findWallAt, findHandleAt as _findHandleAt, findFurnitureAt as _findFurnitureAt, findColumnAt as _findColumnAt, findStairAt as _findStairAt, findDoorAt as _findDoorAt, findWindowAt as _findWindowAt, findRoomAt as _findRoomAt, hitTestMeasurement as _hitTestMeasurement, hitTestAnnotation as _hitTestAnnotation, hitTestTextAnnotation as _hitTestTextAnnotation, findEntourageAt } from '$lib/utils/hitTesting';
@@ -112,7 +112,7 @@
     units: 'metric', showDimensions: true, showExternalDimensions: true,
     showInternalDimensions: false, showExtensionLines: true,
     showObjectDistance: true, dimensionLineColor: '#1e293b',
-    wallMeasureMode: 'centerline', snapToGrid: true, gridSize: 25,
+    wallMeasureMode: 'centerline', snapToGrid: true, snapToWalls: true, gridSize: 25,
   });
   projectSettings.subscribe((s) => {
     dimSettings = s;
@@ -131,8 +131,6 @@
   const GRID = 20;
   const SNAP = 10;
   const MAGNETIC_SNAP = 15;
-  const WALL_SNAP_DIST = 30; // cm — distance threshold to snap furniture to wall
-
   // Store subscriptions
   let currentFloor: Floor | null = $state(null);
   let currentSelectedId: string | null = $state(null);
@@ -144,6 +142,7 @@
   let currentWindowType: Win['type'] = $state('standard');
   let currentSnapEnabled: boolean = $state(true);
   let currentSnapToGrid: boolean = $state(true);
+  let currentSnapToWalls: boolean = $state(true);
   let currentGridSize: number = $state(25);
   let isPlacingStair: boolean = $state(false);
   let draggingStairId: string | null = $state(null);
@@ -174,9 +173,10 @@
   // Resize/rotate handle drag state
   type HandleType = 'resize-tl' | 'resize-tr' | 'resize-bl' | 'resize-br' | 'resize-t' | 'resize-b' | 'resize-l' | 'resize-r' | 'rotate';
   let draggingHandle = $state<HandleType | null>(null);
-  let handleDragStart: Point = { x: 0, y: 0 };
   let handleOrigScale: { x: number; y: number } = { x: 1, y: 1 };
   let handleOrigRotation: number = 0;
+  let handleOrigPosition: Point = { x: 0, y: 0 };
+  let handleOrigBaseSize: { width: number; depth: number } = { width: 50, depth: 50 };
 
   // Wall parallel drag state (drag midpoint to move wall parallel)
   let draggingWallParallel: { wallId: string; startMousePos: Point; origStart: Point; origEnd: Point; origCurve?: Point; connectedStart: { wallId: string; endpoint: 'start' | 'end' }[]; connectedEnd: { wallId: string; endpoint: 'start' | 'end' }[] } | null = $state(null);
@@ -242,7 +242,7 @@
    * Returns adjusted position and rotation, or null if no wall is close enough.
    */
   function snapFurnitureToWall(pos: Point, furniture: FurnitureItem | FurnitureDef, currentRotation: number): { position: Point; rotation: number; wallId: string; side: 'normal' | 'anti'; wallAngle: number } | null {
-    if (!currentFloor) return null;
+    if (!currentFloor || !currentSnapToWalls) return null;
 
     // A placed item carries per-item size overrides; a bare catalog def (placement
     // preview, before the item exists) is already its own effective size.
@@ -1790,7 +1790,7 @@
     const unsub8 = placingDoorType.subscribe((t) => { currentDoorType = t; markDirty(); });
     const unsub9 = placingWindowType.subscribe((t) => { currentWindowType = t; markDirty(); });
     const unsub10 = snapEnabled.subscribe((v) => { currentSnapEnabled = v; markDirty(); });
-    const unsub_snapgrid = projectSettings.subscribe((s) => { currentSnapToGrid = s.snapToGrid; currentGridSize = s.gridSize; markDirty(); });
+    const unsub_snapgrid = projectSettings.subscribe((s) => { currentSnapToGrid = s.snapToGrid; currentSnapToWalls = s.snapToWalls; currentGridSize = s.gridSize; markDirty(); });
     const unsub11 = placingStair.subscribe((v) => { isPlacingStair = v; markDirty(); });
     const unsubEnt1 = placingEntourageId.subscribe((id) => { currentEntourageDefId = id; markDirty(); });
     const unsubEnt2 = currentProject.subscribe((pr) => { customEntourageDefs = pr?.customEntourage; markDirty(); });
@@ -2313,9 +2313,13 @@
         const fi = currentFloor.furniture.find(f => f.id === currentSelectedId);
         if (fi) {
           draggingHandle = handle;
-          handleDragStart = { ...wp };
+          handleOrigPosition = { ...fi.position };
           handleOrigScale = { x: fi.scale?.x ?? 1, y: fi.scale?.y ?? 1 };
           handleOrigRotation = fi.rotation;
+          const scaleX = Math.abs(handleOrigScale.x) || 1;
+          const scaleY = Math.abs(handleOrigScale.y) || 1;
+          const size = getFurnitureSize(fi);
+          handleOrigBaseSize = { width: size.width / scaleX, depth: size.depth / scaleY };
           commitFurnitureMove(); // snapshot for undo
           return;
         }
@@ -2675,51 +2679,29 @@
     if (draggingHandle && currentSelectedId && currentFloor) {
       const fi = currentFloor.furniture.find(f => f.id === currentSelectedId);
       if (fi) {
-        const cat = getCatalogItem(fi.catalogId);
-        if (cat) {
-          if (draggingHandle === 'rotate') {
-            // Rotate based on angle from furniture center to mouse
-            const dx = mousePos.x - fi.position.x;
-            const dy = mousePos.y - fi.position.y;
-            let angle = Math.atan2(dx, -dy) * 180 / Math.PI; // 0° = up
-            // Hold Shift to snap to 15° increments; otherwise free rotation
-            if (shiftDown) {
-              angle = Math.round(angle / 15) * 15;
-            }
-            setFurnitureRotation(currentSelectedId, ((angle % 360) + 360) % 360);
-          } else {
-            // Resize: compute delta in furniture-local coords
-            const dx = mousePos.x - fi.position.x;
-            const dy = mousePos.y - fi.position.y;
-            const ang = -(fi.rotation * Math.PI) / 180;
-            const localX = dx * Math.cos(ang) - dy * Math.sin(ang);
-            const localY = dx * Math.sin(ang) + dy * Math.cos(ang);
-            const minScale = 10 / Math.max(cat.width, cat.depth); // 10cm minimum
-            let newSx = fi.scale?.x ?? 1;
-            let newSy = fi.scale?.y ?? 1;
-            const isEdge = ['resize-t', 'resize-b', 'resize-l', 'resize-r'].includes(draggingHandle);
-            const resizesX = !isEdge || draggingHandle === 'resize-l' || draggingHandle === 'resize-r';
-            const resizesY = !isEdge || draggingHandle === 'resize-t' || draggingHandle === 'resize-b';
-            if (resizesX) {
-              newSx = Math.abs(localX * 2) / cat.width;
-              newSx = Math.max(minScale, Math.round(newSx * 20) / 20);
-            }
-            if (resizesY) {
-              newSy = Math.abs(localY * 2) / cat.depth;
-              newSy = Math.max(minScale, Math.round(newSy * 20) / 20);
-            }
-            // Shift: maintain aspect ratio
-            if (shiftDown && resizesX && resizesY) {
-              const origRatio = (handleOrigScale.x * cat.width) / (handleOrigScale.y * cat.depth);
-              const currentRatio = (newSx * cat.width) / (newSy * cat.depth);
-              if (currentRatio > origRatio) {
-                newSy = (newSx * cat.width) / (origRatio * cat.depth);
-              } else {
-                newSx = (newSy * cat.depth * origRatio) / cat.width;
-              }
-            }
-            scaleFurniture(currentSelectedId, { x: newSx, y: newSy });
+        if (draggingHandle === 'rotate') {
+          // Rotate based on angle from furniture center to mouse
+          const dx = mousePos.x - fi.position.x;
+          const dy = mousePos.y - fi.position.y;
+          let angle = Math.atan2(dx, -dy) * 180 / Math.PI; // 0° = up
+          // Hold Shift to snap to 15° increments; otherwise free rotation
+          if (shiftDown) {
+            angle = Math.round(angle / 15) * 15;
           }
+          setFurnitureRotation(currentSelectedId, ((angle % 360) + 360) % 360);
+        } else {
+          const resized = resizeFurnitureFromHandle({
+            position: handleOrigPosition,
+            rotation: handleOrigRotation,
+            width: handleOrigBaseSize.width,
+            depth: handleOrigBaseSize.depth,
+            scale: handleOrigScale,
+            handle: draggingHandle,
+            pointer: mousePos,
+            preserveAspectRatio: shiftDown,
+          });
+          moveFurniture(currentSelectedId, resized.position);
+          scaleFurniture(currentSelectedId, resized.scale);
         }
       }
     }

--- a/src/lib/components/toolbar/SettingsDialog.svelte
+++ b/src/lib/components/toolbar/SettingsDialog.svelte
@@ -96,6 +96,7 @@
     dimensionLineColor: '#1e293b',
     wallMeasureMode: 'centerline',
     snapToGrid: true,
+    snapToWalls: true,
     gridSize: 25,
   });
 
@@ -180,6 +181,20 @@
           </div>
 
         {:else if activeTab === 'dimensions'}
+          <!-- Snapping controls -->
+          <div class="bg-gray-50 dark:bg-gray-700/50 rounded-xl divide-y divide-gray-200 dark:divide-gray-600 mb-5">
+            <label class="flex items-center justify-between px-4 py-3.5 cursor-pointer">
+              <span class="text-sm text-gray-700 dark:text-gray-300" title="Furniture automatically aligns its back edge with nearby walls">Wall snapping</span>
+              <input
+                type="checkbox"
+                checked={settings.snapToWalls}
+                onchange={(e) => updateSetting('snapToWalls', (e.target as HTMLInputElement).checked)}
+                class="w-10 h-5 rounded-full appearance-none cursor-pointer bg-gray-300 checked:bg-slate-700 relative transition-colors
+                  before:content-[''] before:absolute before:w-4 before:h-4 before:rounded-full before:bg-white before:top-0.5 before:left-0.5 before:transition-transform checked:before:translate-x-5"
+              />
+            </label>
+          </div>
+
           <!-- Metrics Unit Toggle -->
           <div class="flex items-center justify-between mb-5">
             <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Metrics unit</span>

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -10,6 +10,7 @@ export interface ProjectSettings {
   dimensionLineColor: string;            // color for dimension lines/text
   wallMeasureMode: 'centerline' | 'edge'; // measure walls center-to-center or edge-to-edge (clear span)
   snapToGrid: boolean;                   // snap elements to grid when dragging
+  snapToWalls: boolean;                  // snap furniture to nearby walls when dragging
   gridSize: number;                      // grid snap size in cm (default 25)
 }
 
@@ -23,6 +24,7 @@ const defaultSettings: ProjectSettings = {
   dimensionLineColor: '#1e293b',
   wallMeasureMode: 'centerline',
   snapToGrid: true,
+  snapToWalls: true,
   gridSize: 25,
 };
 

--- a/src/lib/utils/alignment.ts
+++ b/src/lib/utils/alignment.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 import { activeFloor, currentProject, beginUndoGroup, endUndoGroup } from '$lib/stores/project';
-import { getCatalogItem } from '$lib/utils/furnitureCatalog';
+import { getFurnitureSize } from '$lib/utils/furnitureCatalog';
 import type { FurnitureItem, Floor } from '$lib/models/types';
 
 export type AlignmentOp =
@@ -22,10 +22,8 @@ interface Rect {
 }
 
 function getRect(item: FurnitureItem): Rect {
-  const cat = getCatalogItem(item.catalogId);
-  const w = (item.width ?? cat?.width ?? 50) * (item.scale?.x ?? 1);
-  const d = (item.depth ?? cat?.depth ?? 50) * (item.scale?.y ?? 1);
-  return { item, x: item.position.x, y: item.position.y, w, d };
+  const { width, depth } = getFurnitureSize(item);
+  return { item, x: item.position.x, y: item.position.y, w: width, d: depth };
 }
 
 function getSelectedFurniture(ids: Set<string>): FurnitureItem[] {

--- a/src/lib/utils/canvasInteraction.ts
+++ b/src/lib/utils/canvasInteraction.ts
@@ -17,7 +17,7 @@ export interface CanvasState {
 export const GRID = 20;
 export const SNAP = 10;
 export const MAGNETIC_SNAP = 15;
-export const WALL_SNAP_DIST = 30;
+export const WALL_SNAP_DIST = 12;
 
 export function screenToWorld(cs: CanvasState, sx: number, sy: number): Point {
   return { x: (sx - cs.width / 2) / cs.zoom + cs.camX, y: (sy - cs.height / 2) / cs.zoom + cs.camY };
@@ -70,6 +70,72 @@ export function angleSnap(start: Point, end: Point, enabled: boolean): Point {
     }
   }
   return end;
+}
+
+export interface FurnitureResizeInput {
+  position: Point;
+  rotation: number;
+  width: number;
+  depth: number;
+  scale: { x: number; y: number };
+  handle: Exclude<HandleType, 'rotate'>;
+  pointer: Point;
+  preserveAspectRatio: boolean;
+  minSize?: number;
+}
+
+export interface FurnitureResizeResult {
+  position: Point;
+  scale: { x: number; y: number };
+}
+
+/**
+ * Resize a furniture rectangle from a handle while keeping the opposite edge
+ * or corner fixed. All geometry is calculated in the item's local coordinates,
+ * so the same rule works for rotated furniture.
+ */
+export function resizeFurnitureFromHandle(input: FurnitureResizeInput): FurnitureResizeResult {
+  const minSize = input.minSize ?? 10;
+  const originalScaleX = Math.abs(input.scale.x) || 1;
+  const originalScaleY = Math.abs(input.scale.y) || 1;
+  const originalWidth = input.width * originalScaleX;
+  const originalDepth = input.depth * originalScaleY;
+  const halfWidth = originalWidth / 2;
+  const halfDepth = originalDepth / 2;
+  const angle = -(input.rotation * Math.PI) / 180;
+  const dx = input.pointer.x - input.position.x;
+  const dy = input.pointer.y - input.position.y;
+  const localX = dx * Math.cos(angle) - dy * Math.sin(angle);
+  const localY = dx * Math.sin(angle) + dy * Math.cos(angle);
+  const horizontal = !['resize-t', 'resize-b'].includes(input.handle);
+  const vertical = !['resize-l', 'resize-r'].includes(input.handle);
+  const handleSignX = input.handle.includes('-l') || input.handle === 'resize-l' ? -1 : 1;
+  const handleSignY = input.handle.includes('-t') || input.handle === 'resize-t' ? -1 : 1;
+  const anchorX = horizontal ? -handleSignX * halfWidth : 0;
+  const anchorY = vertical ? -handleSignY * halfDepth : 0;
+
+  let newWidth = horizontal ? Math.max(minSize, Math.abs(localX - anchorX)) : originalWidth;
+  let newDepth = vertical ? Math.max(minSize, Math.abs(localY - anchorY)) : originalDepth;
+
+  if (input.preserveAspectRatio && horizontal && vertical) {
+    const originalRatio = originalWidth / originalDepth;
+    if (newWidth / newDepth > originalRatio) newDepth = newWidth / originalRatio;
+    else newWidth = newDepth * originalRatio;
+  }
+
+  const edgeX = horizontal ? anchorX + handleSignX * newWidth : 0;
+  const edgeY = vertical ? anchorY + handleSignY * newDepth : 0;
+  const centerX = (anchorX + edgeX) / 2;
+  const centerY = (anchorY + edgeY) / 2;
+  const worldAngle = -angle;
+
+  return {
+    position: {
+      x: input.position.x + centerX * Math.cos(worldAngle) - centerY * Math.sin(worldAngle),
+      y: input.position.y + centerX * Math.sin(worldAngle) + centerY * Math.cos(worldAngle),
+    },
+    scale: { x: newWidth / input.width, y: newDepth / input.depth },
+  };
 }
 
 export function findConnectedEndpoints(pt: Point, excludeWallId: string, walls: Wall[]): { wallId: string; endpoint: 'start' | 'end' }[] {

--- a/src/lib/utils/furnitureCatalog.ts
+++ b/src/lib/utils/furnitureCatalog.ts
@@ -1,3 +1,5 @@
+import type { FurnitureItem } from '$lib/models/types';
+
 export interface FurnitureDef {
   id: string;
   name: string;
@@ -247,6 +249,20 @@ export const furnitureCatalog: FurnitureDef[] = [
 
 export function getCatalogItem(id: string): FurnitureDef | undefined {
   return furnitureCatalog.find(f => f.id === id);
+}
+
+/**
+ * Effective footprint of a placed item in cm — per-item overrides applied over the
+ * catalog defaults, then multiplied by scale. Use this wherever geometry is derived
+ * from a FurnitureItem.
+ */
+export function getFurnitureSize(fi: FurnitureItem): { width: number; depth: number; height: number } {
+  const cat = getCatalogItem(fi.catalogId);
+  return {
+    width: (fi.width ?? cat?.width ?? 50) * Math.abs(fi.scale?.x ?? 1),
+    depth: (fi.depth ?? cat?.depth ?? 50) * Math.abs(fi.scale?.y ?? 1),
+    height: (fi.height ?? cat?.height ?? 50) * Math.abs(fi.scale?.z ?? 1),
+  };
 }
 
 export const furnitureCategories = [...new Set(furnitureCatalog.map(f => f.category))];

--- a/src/lib/utils/hitTesting.ts
+++ b/src/lib/utils/hitTesting.ts
@@ -5,7 +5,7 @@
  */
 import type { Point, Wall, Door, Window as Win, FurnitureItem, Stair, Column, Floor, Measurement, Annotation, TextAnnotation, EntourageItem } from '$lib/models/types';
 import type { Room } from '$lib/models/types';
-import { getCatalogItem } from '$lib/utils/furnitureCatalog';
+import { getCatalogItem, getFurnitureSize } from '$lib/utils/furnitureCatalog';
 import { getRoomPolygon } from '$lib/utils/roomDetection';
 import { wallPointAt } from '$lib/utils/canvasRenderer';
 import type { HandleType } from '$lib/utils/canvasInteraction';
@@ -78,8 +78,9 @@ export function findHandleAt(
   const angle = -(fi.rotation * Math.PI) / 180;
   const rx = dx * Math.cos(angle) - dy * Math.sin(angle);
   const ry = dx * Math.sin(angle) + dy * Math.cos(angle);
-  const hw = cat.width * Math.abs(fi.scale?.x ?? 1) / 2;
-  const hd = cat.depth * Math.abs(fi.scale?.y ?? 1) / 2;
+  const size = getFurnitureSize(fi);
+  const hw = size.width / 2;
+  const hd = size.depth / 2;
   const ht = 8 / zoom;
 
   const rotHandleDist = 18 / zoom;
@@ -108,8 +109,9 @@ export function findFurnitureAt(p: Point, furniture: FurnitureItem[]): Furniture
     const angle = -(fi.rotation * Math.PI) / 180;
     const rx = dx * Math.cos(angle) - dy * Math.sin(angle);
     const ry = dx * Math.sin(angle) + dy * Math.cos(angle);
-    const hw = cat.width * Math.abs(fi.scale?.x ?? 1) / 2;
-    const hd = cat.depth * Math.abs(fi.scale?.y ?? 1) / 2;
+    const size = getFurnitureSize(fi);
+    const hw = size.width / 2;
+    const hd = size.depth / 2;
     if (Math.abs(rx) < hw && Math.abs(ry) < hd) return fi;
   }
   return null;

--- a/test-furniture-resize.ts
+++ b/test-furniture-resize.ts
@@ -1,0 +1,68 @@
+/**
+ * Focused geometry tests for furniture resize handles.
+ * Run with: npx tsx test-furniture-resize.ts
+ */
+import assert from 'node:assert/strict';
+import { resizeFurnitureFromHandle, WALL_SNAP_DIST } from './src/lib/utils/canvasInteraction.ts';
+
+const close = (actual: number, expected: number, message: string) => {
+  assert.ok(Math.abs(actual - expected) < 1e-9, `${message}: expected ${expected}, got ${actual}`);
+};
+
+const resize = (handle: Parameters<typeof resizeFurnitureFromHandle>[0]['handle'], pointer: { x: number; y: number }, options: Partial<Parameters<typeof resizeFurnitureFromHandle>[0]> = {}) =>
+  resizeFurnitureFromHandle({
+    position: { x: 0, y: 0 },
+    rotation: 0,
+    width: 100,
+    depth: 60,
+    scale: { x: 1, y: 1 },
+    handle,
+    pointer,
+    preserveAspectRatio: false,
+    ...options,
+  });
+
+// The reduced attraction distance is intentionally much smaller than the old 30 cm.
+assert.equal(WALL_SNAP_DIST, 12);
+
+// Horizontal side handles keep the opposite vertical edge fixed.
+{
+  const right = resize('resize-r', { x: 150, y: 0 });
+  close(right.position.x, 50, 'right resize center');
+  close(right.scale.x, 2, 'right resize width scale');
+
+  const left = resize('resize-l', { x: -150, y: 0 });
+  close(left.position.x, -50, 'left resize center');
+  close(left.scale.x, 2, 'left resize width scale');
+}
+
+// Vertical side handles resize only depth and keep the opposite horizontal edge fixed.
+{
+  const top = resize('resize-t', { x: 0, y: -70 });
+  close(top.position.y, -20, 'top resize center');
+  close(top.scale.y, 100 / 60, 'top resize depth scale');
+  close(top.scale.x, 1, 'top resize leaves width unchanged');
+
+  const bottom = resize('resize-b', { x: 0, y: 70 });
+  close(bottom.position.y, 20, 'bottom resize center');
+  close(bottom.scale.y, 100 / 60, 'bottom resize depth scale');
+}
+
+// The same opposite-edge rule is evaluated in local coordinates for rotated items.
+{
+  const rotated = resize('resize-r', { x: 0, y: 100 }, { rotation: 90 });
+  close(rotated.position.x, 0, 'rotated resize center x');
+  close(rotated.position.y, 25, 'rotated resize center y');
+  close(rotated.scale.x, 1.5, 'rotated resize width scale');
+}
+
+// Corner resizing with Shift preserves aspect ratio while keeping the opposite corner fixed.
+{
+  const corner = resize('resize-br', { x: 80, y: 60 }, { preserveAspectRatio: true });
+  close(corner.position.x, 25, 'corner resize center x');
+  close(corner.position.y, 15, 'corner resize center y');
+  close(corner.scale.x, 1.5, 'corner resize width scale');
+  close(corner.scale.y, 1.5, 'corner resize depth scale');
+}
+
+console.log('Furniture resize geometry: PASS');


### PR DESCRIPTION
## Why

Furniture interaction still needed two follow-up fixes on top of #17: wall snapping could not be disabled independently, and side resize handles moved both edges instead of keeping the opposite edge fixed.

## Changes

- Add an independent Wall snapping setting, enabled by default.
- Reduce the wall-snap attraction distance from 30 cm to 12 cm.
- Resize from the dragged edge or corner while keeping the opposite edge or corner fixed, including rotated furniture.
- Add focused geometry coverage for side, rotated, and aspect-ratio resizing.

## Verification

- `npx tsx test-furniture-resize.ts`
- `npm run build`
- Manual checks for the wall-snapping toggle and furniture resize interactions.

This is stacked on #17; the first commit is the existing #17 baseline and the second commit contains only these follow-up fixes. The separate L-shaped sofa feature is not included.

The UI change is intentionally limited to the existing Settings dialog.

I like this tool cause its free and its the one thats gotten me the furthest in sketching a floor plan and planning, so I hope these fixes help improve the UX experience a bit and my first contributions are acceptable for the repo. Thank you.