### PR TITLE
Expose safe diagnostics for handoff storage failures

### DIFF
--- a/src/lib/server/handoffStorage.ts
+++ b/src/lib/server/handoffStorage.ts
@@ -4,6 +4,12 @@ import { parseQuotaState, type QuotaSnapshot, type QuotaState, type QuotaStore }
 const auth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/devstorage.read_write'] });
 const ledgerName = '_system/handoff-admission-v1';
 
+export class HandoffStorageFailure extends Error {
+  constructor(public operation: 'credentials' | 'network' | 'ledger-read' | 'ledger-format' | 'ledger-write' | 'object-create', public status?: number) {
+    super(`Handoff storage failure: ${operation}`);
+  }
+}
+
 /** Existing bucket + a zero-byte metadata ledger; no database, function or keys.
  * Metadata updates advance metageneration, without creating new data generations.
  */
@@ -15,20 +21,25 @@ export class HandoffStorage implements QuotaStore {
   }
 
   private async send(url: string, init: RequestInit = {}) {
-    const token = await this.accessToken();
-    if (!token) throw new Error('Handoff service credentials unavailable');
+    let token;
+    try { token = await this.accessToken(); }
+    catch { throw new HandoffStorageFailure('credentials'); }
+    if (!token) throw new HandoffStorageFailure('credentials');
     const headers = new Headers(init.headers);
     headers.set('Authorization', `Bearer ${token}`);
-    return this.request(url, { ...init, headers, signal: AbortSignal.timeout(5000) });
+    try { return await this.request(url, { ...init, headers, signal: AbortSignal.timeout(5000) }); }
+    catch { throw new HandoffStorageFailure('network'); }
   }
 
   async read(): Promise<QuotaSnapshot | null> {
     const response = await this.send(`${this.bucketUrl}/${encodeURIComponent(ledgerName)}?fields=generation,metageneration,metadata`);
     if (response.status === 404) { await response.body?.cancel(); return null; }
-    if (!response.ok) { await response.body?.cancel(); throw new Error('Could not read handoff quota'); }
-    const data = await response.json();
-    if (!/^\d+$/.test(data.generation) || !/^\d+$/.test(data.metageneration)) throw new Error('Invalid quota preconditions');
-    return { state: parseQuotaState(JSON.parse(data.metadata?.quota)), generation: data.generation, metageneration: data.metageneration };
+    if (!response.ok) { await response.body?.cancel(); throw new HandoffStorageFailure('ledger-read', response.status); }
+    try {
+      const data = await response.json();
+      if (!/^\d+$/.test(data.generation) || !/^\d+$/.test(data.metageneration)) throw new Error('Invalid quota preconditions');
+      return { state: parseQuotaState(JSON.parse(data.metadata?.quota)), generation: data.generation, metageneration: data.metageneration };
+    } catch { throw new HandoffStorageFailure('ledger-format'); }
   }
 
   async write(previous: QuotaSnapshot | null, state: QuotaState): Promise<boolean> {
@@ -40,7 +51,7 @@ export class HandoffStorage implements QuotaStore {
     });
     await response.body?.cancel();
     if (response.status === 412) return false;
-    if (!response.ok) throw new Error('Could not reserve handoff quota');
+    if (!response.ok) throw new HandoffStorageFailure('ledger-write', response.status);
     return true;
   }
 
@@ -55,7 +66,7 @@ export class HandoffStorage implements QuotaStore {
     const response = await this.send(url, { method: 'POST', headers: { 'Content-Type': `multipart/related; boundary=${boundary}` }, body });
     await response.body?.cancel();
     if (response.status === 409 || response.status === 412) return false;
-    if (!response.ok) throw new Error('Could not store handoff');
+    if (!response.ok) throw new HandoffStorageFailure('object-create', response.status);
     return true;
   }
 }

--- a/src/routes/api/handoffs/+server.ts
+++ b/src/routes/api/handoffs/+server.ts
@@ -1,7 +1,7 @@
 import { env } from '$env/dynamic/private';
 import { json } from '@sveltejs/kit';
 import { HandoffError } from '$lib/server/handoffQuota';
-import { HandoffStorage } from '$lib/server/handoffStorage';
+import { HandoffStorage, HandoffStorageFailure } from '$lib/server/handoffStorage';
 import { uploadHandoff } from '$lib/server/handoffUpload';
 
 let storage: HandoffStorage | undefined;
@@ -22,6 +22,7 @@ export async function POST({ request }: { request: Request }) {
     return json(await uploadHandoff(request, storage), { status: 201, headers });
   } catch (error) {
     const known = error instanceof HandoffError;
+    if (!known) console.error(JSON.stringify({ event: 'handoff_unavailable', operation: error instanceof HandoffStorageFailure ? error.operation : 'quota-or-runtime', status: error instanceof HandoffStorageFailure ? error.status : undefined }));
     if (known && error.retryAfter) headers['Retry-After'] = String(error.retryAfter);
     // Never log capture bodies, tokens or sharing codes; storage failures fail closed.
     return json({ error: known ? error.message : 'Link sharing is temporarily unavailable. Use Export Editable Plan (JSON) instead.' }, { status: known ? error.status : 503, headers });

--- a/tests/handoff-quota.test.ts
+++ b/tests/handoff-quota.test.ts
@@ -154,7 +154,14 @@ it('distinguishes a missing ledger from denied access and invalid metadata', asy
   const store = new HandoffStorage('example.test', async () => 'test-token', transport);
   expect(await store.read()).toBeNull();
   transport.mockResolvedValue(new Response(null, { status: 403 }));
-  await expect(store.read()).rejects.toThrow('Could not read');
+  await expect(store.read()).rejects.toMatchObject({ operation: 'ledger-read', status: 403 });
   transport.mockResolvedValue(Response.json({ generation: '1', metageneration: '1', metadata: { quota: '{}' } }));
-  await expect(store.read()).rejects.toThrow('Invalid handoff quota ledger');
+  await expect(store.read()).rejects.toMatchObject({ operation: 'ledger-format' });
+});
+
+it('round-trips the live ledger wire format without losing its version or counters', async () => {
+  const state = { ...emptyState(), uploads: 1, bytes: 12, minuteUploads: 1 };
+  const transport = vi.fn<typeof fetch>().mockResolvedValue(Response.json({ generation: '1788645246013944', metageneration: '1', metadata: { quota: JSON.stringify(state) } }));
+  const store = new HandoffStorage('example.test', async () => 'test-token', transport);
+  expect(await store.read()).toEqual({ generation: '1788645246013944', metageneration: '1', state });
 });


### PR DESCRIPTION
The live handoff smoke check accepted the first synthetic upload but returned 503 for later attempts. The service currently hides every infrastructure failure behind the same response, so the failed operation cannot be identified from runtime logs.

Add structured diagnostics containing only a fixed operation label and an upstream HTTP status. Capture bodies, authorization data, URLs and sharing codes are never logged. Add a regression test for the actual persisted quota metadata wire format. The public fallback response and fail-closed admission behavior remain unchanged.

Validation: 181 unit tests pass, including the live ledger format; type checks report zero errors and 25 existing warnings. The quota migration remains staged, and old iPhone uploads continue to work. Related to #30 and the live verification of #38.
