### PR TITLE
Fix quota updates and align handoff format validation

### DIFF
--- a/docs/handoff-quotas.md
+++ b/docs/handoff-quotas.md
@@ -80,6 +80,10 @@ access for `inbox/` and the ledger. App Hosting already supplies its service
 identity; do not add service-account key files to the repository or browser.
 The OpenPlan3D backend's existing identity already has these permissions; this
 release does not expand IAM access. Browser CI explicitly disables cloud sharing.
+The token requests `devstorage.full_control`: the Storage JSON API's
+`objects.patch` method requires that scope even for custom metadata updates;
+`devstorage.read_write` allows inserts but fails subsequent quota updates.
+See the method scopes in the [official API definition](https://storage.googleapis.com/$discovery/rest?version=v1).
 
 After the new client is distributed and the compatibility decision is confirmed:
 

--- a/docs/reviews/2026-09-05-cost-controls-and-browser-ci.md
+++ b/docs/reviews/2026-09-05-cost-controls-and-browser-ci.md
@@ -14,8 +14,8 @@ content-hashed asset pipeline. Per-file measurements are in
 
 The converted oak and detailed porcelain images were visually inspected. The
 local production browser also rendered the imported furnished plan in 3D without
-console warnings/errors. Production cache/header verification follows rollout
-and is recorded on the release PR.
+console warnings/errors. The live hashed oak GET matched all 99,336 bytes and returned a CDN hit with
+one-year immutable caching after rollout.
 
 ## Browser CI
 
@@ -99,7 +99,7 @@ necessary. Budget alerts do not enforce a spending cap.
 
 ## Validation
 
-- 180 web unit tests pass, including 18 new admission/transport tests.
+- 182 web unit tests pass, including 20 admission/transport cases.
 - Three production-browser CI checks pass; zero type errors and 25 existing
   Svelte warnings; production build succeeds; dependency audit finds zero
   vulnerabilities.

--- a/src/lib/server/handoffStorage.ts
+++ b/src/lib/server/handoffStorage.ts
@@ -1,7 +1,10 @@
 import { GoogleAuth } from 'google-auth-library';
 import { parseQuotaState, type QuotaSnapshot, type QuotaState, type QuotaStore } from './handoffQuota';
 
-const auth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/devstorage.read_write'] });
+// objects.patch requires full_control even for custom metadata only. The
+// read_write scope permits the first insert, but rejects subsequent ledger CAS.
+// IAM still limits this token to the existing runtime identity's permissions.
+const auth = new GoogleAuth({ scopes: ['https://www.googleapis.com/auth/devstorage.full_control'] });
 const ledgerName = '_system/handoff-admission-v1';
 
 export class HandoffStorageFailure extends Error {

--- a/src/lib/server/handoffUpload.ts
+++ b/src/lib/server/handoffUpload.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { validateRoomPlan } from '$lib/utils/roomplanValidation';
+import { isRoomPlanJson, validateRoomPlan } from '$lib/utils/roomplanValidation';
 import { HANDOFF_LIMITS, HandoffError, reserveHandoff, type QuotaStore } from './handoffQuota';
 
 export interface HandoffSink extends QuotaStore {
@@ -32,7 +32,11 @@ export async function readCapture(request: Request): Promise<Uint8Array> {
       chunks.push(chunk.value);
     }
     const bytes = Buffer.concat(chunks);
-    try { validateRoomPlan(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes))); }
+    try {
+      const capture = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+      if (!isRoomPlanJson(capture)) throw new Error('Unrecognized RoomPlan export');
+      validateRoomPlan(capture);
+    }
     catch { throw new HandoffError(422, 'This capture cannot be shared. Check it using Export Editable Plan (JSON).'); }
     return bytes;
   } finally {

--- a/src/lib/utils/roomplanImport.ts
+++ b/src/lib/utils/roomplanImport.ts
@@ -10,7 +10,7 @@ import type { Floor, Wall, Door, Window, FurnitureItem, Room, Point, Project } f
 import { createDefaultProject, createDefaultFloor } from '$lib/stores/project';
 import { detectRooms, getRoomPolygon } from '$lib/utils/roomDetection';
 import { validateRoomPlan } from './roomplanValidation';
-export { validateRoomPlan } from './roomplanValidation';
+export { validateRoomPlan, isRoomPlanJson } from './roomplanValidation';
 
 function uid(): string {
   return Math.random().toString(36).slice(2, 10);
@@ -811,12 +811,6 @@ export async function extractRoomJsonFromZip(zipFile: File): Promise<any> {
     throw new Error('The ZIP must contain exactly one room.json capture.');
   }
   return JSON.parse(await captures[0].async('string'));
-}
-
-/** Quick structural check that data looks like an Apple RoomPlan JSON export */
-export function isRoomPlanJson(data: any): boolean {
-  return !!data && (data.openplanPrepared === true || data.openplanHandoffVersion !== undefined ||
-    (Array.isArray(data.walls) && data.walls.some((wall: any) => wall?.dimensions !== undefined)));
 }
 
 /** Default import options — same defaults the import options dialog starts with */

--- a/src/lib/utils/roomplanValidation.ts
+++ b/src/lib/utils/roomplanValidation.ts
@@ -1,3 +1,9 @@
+/** Shared format recognition for file imports and link admission. */
+export function isRoomPlanJson(data: any): boolean {
+  return !!data && (data.openplanPrepared === true || data.openplanHandoffVersion !== undefined ||
+    (Array.isArray(data.walls) && data.walls.some((wall: any) => wall?.dimensions !== undefined)));
+}
+
 /** Validate a complete capture before constructing or replacing a project. */
 export function validateRoomPlan(data: any): void {
   function fail(path: string, reason: string): never {

--- a/tests/handoff-quota.test.ts
+++ b/tests/handoff-quota.test.ts
@@ -66,14 +66,14 @@ it('fails closed for unavailable, damaged or persistently contended ledgers', as
 
 it('validates body bytes before touching the ledger, including a dishonest length', async () => {
   const store = new MemorySink();
-  const body = '{"walls":[]}' + ' '.repeat(HANDOFF_LIMITS.maxBytes);
+  const body = '{"openplanHandoffVersion":1,"walls":[]}' + ' '.repeat(HANDOFF_LIMITS.maxBytes);
   await expect(uploadHandoff(request(body, { 'Content-Length': '1' }), store, now)).rejects.toMatchObject({ status: 413 });
   expect(store.read).not.toHaveBeenCalled();
   expect(store.create).not.toHaveBeenCalled();
 });
 
 it('accepts exactly the byte limit and preserves a valid empty edited plan', async () => {
-  const json = '{"walls":[]}';
+  const json = '{"openplanHandoffVersion":1,"walls":[]}';
   const body = json + ' '.repeat(HANDOFF_LIMITS.maxBytes - Buffer.byteLength(json));
   expect((await readCapture(request(body))).byteLength).toBe(HANDOFF_LIMITS.maxBytes);
 });
@@ -82,8 +82,9 @@ it.each([
   ['broken JSON', '{"walls":[', {}, 422],
   ['invalid elements', '{"walls":[{}]}', {}, 422],
   ['no walls', '{}', {}, 422],
-  ['wrong media type', '{"walls":[]}', { 'Content-Type': 'text/plain' }, 415],
-  ['compressed payload', '{"walls":[]}', { 'Content-Encoding': 'gzip' }, 415],
+  ['unrecognized empty document', '{"walls":[]}', {}, 422],
+  ['wrong media type', '{"openplanHandoffVersion":1,"walls":[]}', { 'Content-Type': 'text/plain' }, 415],
+  ['compressed payload', '{"openplanHandoffVersion":1,"walls":[]}', { 'Content-Encoding': 'gzip' }, 415],
 ] as const)('rejects %s before admission', async (_, body, headers, status) => {
   const store = new MemorySink();
   await expect(uploadHandoff(request(body, headers), store, now)).rejects.toMatchObject({ status });
@@ -107,21 +108,21 @@ it('uploads only after reservation, retains failed reservations, and bounds coll
     expect(store.snapshot!.state.uploads).toBe(1);
     throw new Error('Uncertain upload');
   });
-  await expect(uploadHandoff(request('{"walls":[]}'), store, now)).rejects.toThrow('Uncertain upload');
+  await expect(uploadHandoff(request('{"openplanHandoffVersion":1,"walls":[]}'), store, now)).rejects.toThrow('Uncertain upload');
   expect(store.snapshot!.state.uploads).toBe(1);
   store.create.mockResolvedValue(false);
-  await expect(uploadHandoff(request('{"walls":[]}'), store, now)).rejects.toMatchObject({ status: 503 });
+  await expect(uploadHandoff(request('{"openplanHandoffVersion":1,"walls":[]}'), store, now)).rejects.toMatchObject({ status: 503 });
   expect(store.create).toHaveBeenCalledTimes(4);
   expect(store.snapshot!.state.uploads).toBe(2);
 });
 
 it('returns a random code and expiry while storing the original validated bytes', async () => {
   const store = new MemorySink();
-  const result = await uploadHandoff(request('{"walls":[]}'), store, now);
+  const result = await uploadHandoff(request('{"openplanHandoffVersion":1,"walls":[]}'), store, now);
   expect(result.code).toMatch(/^[A-HJ-NP-Z2-9]{8}$/);
   expect(result.reuseUntil).toBe('2026-09-06T12:00:30.000Z');
   expect(store.captures[0].name).toBe(`inbox/${result.code}.json`);
-  expect(Buffer.from(store.captures[0].bytes).toString()).toBe('{"walls":[]}');
+  expect(Buffer.from(store.captures[0].bytes).toString()).toBe('{"openplanHandoffVersion":1,"walls":[]}');
 });
 
 it('uses generation AND metageneration preconditions for quota metadata updates', async () => {


### PR DESCRIPTION
The first hosted upload succeeded, but subsequent uploads returned 503 because the quota metadata PATCH used the `devstorage.read_write` OAuth scope. The Storage API permits inserts with that scope but requires `devstorage.full_control` for PATCH. Request the required scope using the existing service identity; no IAM grants or keys change. Live safe diagnostics isolated this to ledger-write HTTP 403; the [official API definition](https://storage.googleapis.com/$discovery/rest?version=v1) confirms the scope requirement.

Also share format recognition between the web importer and upload validation, so ambiguous empty JSON cannot consume quota and create a link the editor rejects. Prepared/versioned empty iPhone exports remain valid, including exactly 1 MiB requests.

Validation: 182 unit tests and type checking pass (25 existing Svelte warnings). Production build, dependency audit and three browser regressions run in CI. Repeat/concurrent live uploads and native share/reuse will be verified after rollout before the companion PR merges. Relates to #30 and follows #38/#39.
