### PR TITLE
Add configurable floor elevations and fix stacked camera placement

### DIFF
--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -305,3 +305,12 @@ split/exterior-copy heights, per-room ceiling decisions and consistent curved
 walls in stacked views. The suite has 207 unit tests and a fourth browser
 workflow. This work adds no Firebase Storage traffic. See the
 [implementation and validation report](2026-09-05-variable-height-walls.md).
+
+### Eighth batch — configurable floor elevations
+
+Issue #42 adds independent floor elevations with legacy 300 cm defaults, local
+persistence and undo/redo. Stacked geometry, placement and cameras follow the
+same elevations, including basements. Settings supports compact screens. The
+suite has 216 unit tests and adds desktop/390 px browser workflows without new
+Firebase Storage operations. See the
+[floor elevation report](2026-09-05-floor-elevations.md).

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -311,6 +311,6 @@ workflow. This work adds no Firebase Storage traffic. See the
 Issue #42 adds independent floor elevations with legacy 300 cm defaults, local
 persistence and undo/redo. Stacked geometry, placement and cameras follow the
 same elevations, including basements. Settings supports compact screens. The
-suite has 216 unit tests and adds desktop/390 px browser workflows without new
+suite has 220 unit tests and adds desktop/390 px browser workflows without new
 Firebase Storage operations. See the
 [floor elevation report](2026-09-05-floor-elevations.md).

--- a/docs/reviews/2026-09-05-floor-elevations.md
+++ b/docs/reviews/2026-09-05-floor-elevations.md
@@ -1,0 +1,40 @@
+# Floor elevations and stacked cameras
+
+Issue #42 is addressed through **Settings → Project → Floor elevations**. Each
+floor has an optional `elevation` in centimetres above ground; negative values
+represent basements. Values are independent, so raising an upper floor does not
+resize walls or move its neighbours. The existing floor level remains the order
+for the selector and lower-floor reference. Elevations may intentionally overlap
+for split-level layouts; no automatic collision or roof/slab design is added.
+
+Legacy files without the field retain `level × 300 cm`, including skipped levels,
+basements and the array-order fallback for files without levels. Invalid imported
+elevations fall back without modifying the imported source. The editor rejects
+non-finite values and restores blank/invalid inputs on blur. Reset restores the
+level-based default. Edits participate in per-floor undo/redo, local save/reload,
+JSON import/export and project duplication. New top floors continue 300 cm above
+the previous top floor's adjusted elevation (with the legacy spacing for gaps).
+
+Stacked geometry, floor labels, placement planes, walkthrough eye height and
+interior camera poses use the active floor's elevation. Camera markers and
+previews follow elevation edits and stacking toggles. Floor switches clear the
+old interior camera and exit walkthrough. The presentation ground moves beneath
+the lowest basement, and top-down framing includes elevated geometry. The
+isolated active-floor view retains its existing local zero-height ground.
+
+Settings now fits compact screens, scrolls its tabs, and closes with Escape from
+inside the dialog. The camera preview canvas is reactive so its first mounted
+preview can render; replaced marker geometry is disposed.
+
+Validation at implementation: 216 unit tests pass; type checking has zero errors
+and 24 remaining warnings; the production build passes. Tests raycast through
+actual Three.js wall meshes from floor-relative cameras on four mixed-height
+storeys, including a basement, and cover invalid data, legacy defaults, additions,
+removal, persistence and undo/redo. Browser coverage adds desktop and 390 px
+workflows for editing, reset, undo/redo, import/export, save/reload and stacked
+views, plus a desktop walkthrough. Final CI, interactive and rollout results are
+recorded on the release PR.
+
+No Firebase Storage calls, services, dependencies, IAM permissions or retention
+settings are added. Storage migration and billing work remains in issue #30.
+The companion app is unchanged; this is not an iPhone distribution release.

--- a/docs/reviews/2026-09-05-floor-elevations.md
+++ b/docs/reviews/2026-09-05-floor-elevations.md
@@ -23,8 +23,12 @@ the lowest basement, and top-down framing includes elevated geometry. The
 isolated active-floor view retains its existing local zero-height ground.
 
 Settings now fits compact screens, scrolls its tabs, and closes with Escape from
-inside the dialog. The camera preview canvas is reactive so its first mounted
+inside the dialog. Browser testing caught 3D controls blocking the compact floor
+menu; isolating the viewer's stacking context keeps project menus on top.
+The camera preview canvas is reactive so its first mounted
 preview can render; replaced marker geometry is disposed.
+Walkthrough handles rejected mouse capture with a visible keyboard fallback,
+clears placement modes on entry, and releases its controls on unmount.
 
 Validation at implementation: 216 unit tests pass; type checking has zero errors
 and 24 remaining warnings; the production build passes. Tests raycast through
@@ -32,7 +36,7 @@ actual Three.js wall meshes from floor-relative cameras on four mixed-height
 storeys, including a basement, and cover invalid data, legacy defaults, additions,
 removal, persistence and undo/redo. Browser coverage adds desktop and 390 px
 workflows for editing, reset, undo/redo, import/export, save/reload and stacked
-views, plus a desktop walkthrough. Final CI, interactive and rollout results are
+views, plus desktop walkthrough and rejected-mouse-capture coverage. Final CI, interactive and rollout results are
 recorded on the release PR.
 
 No Firebase Storage calls, services, dependencies, IAM permissions or retention

--- a/docs/reviews/2026-09-05-floor-elevations.md
+++ b/docs/reviews/2026-09-05-floor-elevations.md
@@ -21,6 +21,8 @@ previews follow elevation edits and stacking toggles. Floor switches clear the
 old interior camera and exit walkthrough. The presentation ground moves beneath
 the lowest basement, and top-down framing includes elevated geometry. The
 isolated active-floor view retains its existing local zero-height ground.
+Initial perspective framing fits the complete scene using both fields of view,
+so portrait screens do not clip the building. Empty floors have a useful default.
 
 Settings now fits compact screens, scrolls its tabs, and closes with Escape from
 inside the dialog. Browser testing caught 3D controls blocking the compact floor
@@ -30,10 +32,11 @@ preview can render; replaced marker geometry is disposed.
 Walkthrough handles rejected mouse capture with a visible keyboard fallback,
 clears placement modes on entry, and releases its controls on unmount.
 
-Validation at implementation: 216 unit tests pass; type checking has zero errors
+Validation at implementation: 220 unit tests pass; type checking has zero errors
 and 24 remaining warnings; the production build passes. Tests raycast through
 actual Three.js wall meshes from floor-relative cameras on four mixed-height
-storeys, including a basement, and cover invalid data, legacy defaults, additions,
+storeys, including a basement, project all eight bounds corners into portrait and
+landscape camera views, and cover invalid data, legacy defaults, additions,
 removal, persistence and undo/redo. Browser coverage adds desktop and 390 px
 workflows for editing, reset, undo/redo, import/export, save/reload and stacked
 views, plus desktop walkthrough and rejected-mouse-capture coverage. Final CI, interactive and rollout results are

--- a/src/lib/components/toolbar/FloorElevations.svelte
+++ b/src/lib/components/toolbar/FloorElevations.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { currentProject, updateFloorElevation } from '$lib/stores/project';
+  import { floorElevations, DEFAULT_FLOOR_SPACING } from '$lib/utils/floors';
+
+  const entries = $derived(floorElevations($currentProject?.floors ?? []));
+
+  function editElevation(event: Event, floorId: string) {
+    const input = event.currentTarget as HTMLInputElement;
+    if (input.value.trim() !== '' && Number.isFinite(input.valueAsNumber)) {
+      updateFloorElevation(floorId, input.valueAsNumber);
+    } else if (event.type === 'blur') {
+      input.value = String(entries.find(entry => entry.floor.id === floorId)?.elevation ?? 0);
+    }
+  }
+</script>
+
+<section aria-label="Floor elevations" class="space-y-3 border-t border-gray-200 dark:border-gray-700 pt-4">
+  <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-100">Floor elevations</h3>
+  <p id="floor-elevation-help" class="text-xs text-gray-500 dark:text-gray-400">
+    Set each floor's height above ground for stacked 3D. Use negative values for basements.
+    Wall heights and other floors stay unchanged. Defaults are 300 cm apart.
+  </p>
+  {#each entries as { floor, level, elevation } (floor.id)}
+    <div class="space-y-1">
+      <label class="block text-sm text-gray-700 dark:text-gray-300">
+        {floor.name} elevation (cm)
+        <input type="number" step="any" value={elevation} aria-describedby="floor-elevation-help"
+          oninput={(event) => editElevation(event, floor.id)} onblur={(event) => editElevation(event, floor.id)}
+          class="mt-1 w-full rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:text-gray-100" />
+      </label>
+      <button type="button" disabled={floor.elevation === undefined}
+        aria-label={`Use default elevation for ${floor.name}`}
+        onclick={() => updateFloorElevation(floor.id)}
+        class="text-xs text-blue-700 dark:text-blue-300 underline disabled:text-gray-400 disabled:no-underline">
+        Use default ({level * DEFAULT_FLOOR_SPACING} cm)
+      </button>
+    </div>
+  {/each}
+</section>

--- a/src/lib/components/toolbar/SettingsDialog.svelte
+++ b/src/lib/components/toolbar/SettingsDialog.svelte
@@ -4,6 +4,7 @@
   import { currentProject, updateProjectName } from '$lib/stores/project';
   import type { Project } from '$lib/models/types';
   import { themePreference, type ThemePreference } from '$lib/stores/theme';
+  import FloorElevations from './FloorElevations.svelte';
 
   let { open = $bindable(false) }: { open: boolean } = $props();
   let projectName = $state('');
@@ -115,7 +116,7 @@
 {#if open}
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center" onclick={close} onkeydown={(e) => { if (e.key === 'Escape') close(); }} role="dialog" tabindex="-1" aria-label="Settings">
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-[420px] max-h-[80vh] flex flex-col" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()} role="document">
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-[420px] max-w-[calc(100vw-1rem)] max-h-[80vh] flex flex-col" onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') close(); e.stopPropagation(); }} role="document">
       <!-- Header -->
       <div class="flex items-center justify-between px-5 pt-4 pb-2">
         <h2 class="text-lg font-bold text-gray-800 dark:text-gray-100">Settings</h2>
@@ -123,7 +124,7 @@
       </div>
 
       <!-- Tabs -->
-      <div class="flex border-b border-gray-200 dark:border-gray-700 px-5">
+      <div class="flex shrink-0 overflow-x-auto border-b border-gray-200 dark:border-gray-700 px-5">
         <button
           class="px-4 py-2 text-sm font-medium transition-colors relative {activeTab === 'project' ? 'text-slate-800 dark:text-slate-200' : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
           onclick={() => activeTab = 'project'}
@@ -178,6 +179,7 @@
                 placeholder="Add a description for this project..."
               ></textarea>
             </label>
+            <FloorElevations />
           </div>
 
         {:else if activeTab === 'dimensions'}

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -59,6 +59,7 @@
 
   // Walkthrough mode
   let walkthroughMode = $state(false);
+  let walkthroughMouseUnavailable = $state(false);
   let moveForward = false;
   let moveBackward = false;
   let moveLeft = false;
@@ -1919,7 +1920,12 @@
   }
 
   function enterWalkthroughMode() {
+    cameraPlacementMode = false;
+    cameraPreviewOpen = false;
+    furniturePlacementMode = false;
+    removeGhostPreview();
     walkthroughMode = true;
+    walkthroughMouseUnavailable = false;
     controls.enabled = false;
 
     // Position camera at eye height in center of floor plan or largest room
@@ -1960,7 +1966,15 @@
         { ...startPos, z: startPos.z - 100 });
     }
 
-    pointerControls.lock();
+    // Three's lock() discards the browser's promise. Handle rejection here so
+    // embedded/unsupported browsers can still use keyboard movement and look.
+    try {
+      Promise.resolve(renderer.domElement.requestPointerLock()).catch(() => {
+        if (walkthroughMode) walkthroughMouseUnavailable = true;
+      });
+    } catch {
+      walkthroughMouseUnavailable = true;
+    }
   }
 
 
@@ -2096,6 +2110,8 @@
       cancelAnimationFrame(animId);
       document.removeEventListener('keydown', onKeyDown, false);
       document.removeEventListener('keyup', onKeyUp, false);
+      pointerControls.dispose();
+      controls.dispose();
       renderer.dispose();
     };
   });
@@ -2426,6 +2442,9 @@
     <!-- Controls Panel -->
     <div class="absolute top-4 left-4 z-10 bg-black/70 text-white text-xs rounded-lg backdrop-blur-sm p-3 space-y-2 min-w-[180px]">
       <div class="font-semibold text-white/90 mb-1">Walkthrough Controls</div>
+      {#if walkthroughMouseUnavailable}
+        <p role="status" class="max-w-56 text-amber-200">Mouse look is unavailable in this browser. Use WASD to look and arrow keys to move.</p>
+      {/if}
       <label class="flex items-center justify-between gap-2">
         <span class="text-white/70">Eye Height</span>
         <div class="flex items-center gap-1">

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -10,6 +10,7 @@
   import { createSlopedBoxGeometry } from '$lib/utils/slopedWallGeometry';
   import { buildWallSegments, openingOnWall, roomCeilingHeight, wallPathSpans, doorPanelPose } from '$lib/utils/wallProfiles';
   import { assembleFloorStack } from '$lib/utils/floorStack';
+  import { setFloorCameraPose } from '$lib/utils/floorCamera';
   import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
   import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
   import MaterialPicker from './MaterialPicker.svelte';
@@ -33,7 +34,7 @@
   function markSceneDirty() { sceneDirty = true; }
   let pointerControls: PointerLockControls;
   let animId: number;
-  let currentFloor: Floor | null = null;
+  let currentFloor = $state.raw<Floor | null>(null);
   let wallGroup: THREE.Group;
 
   // Raycasting for wall selection in 3D
@@ -52,6 +53,8 @@
   let wallsTransparent = $state(false);
   // Multi-floor stacking
   let showAllFloors = $state(false);
+  let activeFloorElevation = $state(0);
+  let sceneGround: THREE.Mesh;
   // Stacked geometry uses the same floor levels as the 2D reference layer.
 
   // Walkthrough mode
@@ -98,7 +101,7 @@
   let cameraFOV = $state(90);
   let cameraHeight = $state(160);
   let cameraPreviewOpen = $state(false);
-  let cameraPreviewCanvas: HTMLCanvasElement | null = null;
+  let cameraPreviewCanvas = $state<HTMLCanvasElement | null>(null);
   let cameraPreviewRenderer: THREE.WebGLRenderer | null = null;
   let cameraPlaced = $state(false);
   let cameraDragMode = $state<'position' | 'lookat' | null>(null);
@@ -327,7 +330,10 @@
   }
 
   function createCameraMarker(pos: THREE.Vector3, lookAt: THREE.Vector3) {
-    if (cameraHelper) wallGroup.remove(cameraHelper);
+    if (cameraHelper) {
+      clearGroup(cameraHelper);
+      wallGroup.remove(cameraHelper);
+    }
     cameraHelper = new THREE.Group();
     cameraHelper.name = 'interior_camera';
 
@@ -382,6 +388,7 @@
     target.position.set(lookAt.x, cameraHeight * 0.75, lookAt.z);
     cameraHelper.add(target);
 
+    cameraHelper.position.y = activeFloorElevation;
     wallGroup.add(cameraHelper);
     markSceneDirty();
   }
@@ -391,7 +398,6 @@
       interiorCamera = new THREE.PerspectiveCamera(cameraFOV, 16 / 9, 1, 5000);
     }
     interiorCamera.fov = cameraFOV;
-    interiorCamera.position.set(cameraPosition.x, cameraHeight, cameraPosition.z);
 
     // Apply yaw (horizontal) and pitch (vertical) rotation to base direction
     const yawRad = cameraYaw * Math.PI / 180;
@@ -403,11 +409,9 @@
     const lookDist = 500;
     const lookY = cameraHeight + Math.tan(pitchRad) * lookDist;
 
-    interiorCamera.lookAt(
-      cameraPosition.x + dirX * lookDist,
-      lookY,
-      cameraPosition.z + dirZ * lookDist
-    );
+    setFloorCameraPose(interiorCamera, activeFloorElevation,
+      { x: cameraPosition.x, y: cameraHeight, z: cameraPosition.z },
+      { x: cameraPosition.x + dirX * lookDist, y: lookY, z: cameraPosition.z + dirZ * lookDist });
     interiorCamera.updateProjectionMatrix();
   }
 
@@ -757,6 +761,7 @@
     groundMat.polygonOffsetFactor = 2;
     groundMat.polygonOffsetUnits = 2;
     const ground = new THREE.Mesh(groundGeo, groundMat);
+    sceneGround = ground;
     ground.rotation.x = -Math.PI / 2;
     ground.position.y = -1;
     ground.receiveShadow = true;
@@ -1728,7 +1733,10 @@
     for (const { floor, yOffset } of entries) {
       addFloorLabel(floor.name, yOffset, labelX, center.z);
     }
-    floorPlane.constant = -(entries.find(entry => entry.floor.id === activeF.id)?.yOffset ?? 0);
+    activeFloorElevation = entries.find(entry => entry.floor.id === activeF.id)?.yOffset ?? 0;
+    floorPlane.constant = -activeFloorElevation;
+    // Keep the presentation ground below basements as well as above-ground floors.
+    sceneGround.position.y = Math.min(0, ...entries.map(entry => entry.yOffset)) - 1;
     autoCenterCameraAllFloors();
   }
 
@@ -1854,11 +1862,25 @@
   }
 
   function rebuildScene() {
+    const walkingPosition = walkthroughMode ? camera.position.clone() : null;
+    const walkingRotation = walkthroughMode ? camera.quaternion.clone() : null;
     if (showAllFloors) {
       buildAllFloorsStacked();
     } else if (currentFloor) {
+      activeFloorElevation = 0;
       floorPlane.constant = 0;
+      sceneGround.position.y = -1;
       buildWalls(currentFloor);
+    }
+    if (walkingPosition && walkingRotation) {
+      camera.position.copy(walkingPosition);
+      camera.position.y = activeFloorElevation + eyeHeight;
+      camera.quaternion.copy(walkingRotation);
+    }
+    if (cameraPlaced) {
+      updateInteriorCamera();
+      updateCameraMarkerFromState();
+      cameraPreviewDirty = true;
     }
     markSceneDirty();
   }
@@ -1883,8 +1905,8 @@
     const maxDim = Math.max(size.x, size.z, 500);
 
     // Animate camera to top-down position
-    camera.position.set(center.x, maxDim * 1.5, center.z);
-    controls.target.set(center.x, 0, center.z);
+    camera.position.set(center.x, (box.isEmpty() ? 0 : box.max.y) + maxDim * 1.5, center.z);
+    controls.target.copy(center);
     controls.update();
   }
 
@@ -1934,8 +1956,8 @@
         startPos = { x: (minX + maxX) / 2, y: eyeHeight, z: (minZ + maxZ) / 2 };
       }
 
-      camera.position.set(startPos.x, startPos.y, startPos.z);
-      camera.lookAt(startPos.x, startPos.y, startPos.z - 100); // Look forward initially
+      setFloorCameraPose(camera, activeFloorElevation, startPos,
+        { ...startPos, z: startPos.z - 100 });
     }
 
     pointerControls.lock();
@@ -1962,7 +1984,7 @@
 
       pointerControls.moveRight(-velocity.x * delta);
       pointerControls.moveForward(-velocity.z * delta);
-      camera.position.y = eyeHeight;
+      camera.position.y = activeFloorElevation + eyeHeight;
 
       if (lookLeft || lookRight) {
         const yaw = ((lookLeft ? 1 : 0) - (lookRight ? 1 : 0)) * LOOK_SPEED * delta;
@@ -2017,6 +2039,12 @@
     resizeObs.observe(container);
 
     const unsub = activeFloor.subscribe((f) => {
+      if (currentFloor?.id !== f?.id) {
+        if (walkthroughMode) exitWalkthroughMode();
+        cameraPlaced = false;
+        cameraPreviewOpen = false;
+        cameraPlacementMode = false;
+      }
       currentFloor = f;
       if (f) rebuildScene();
     });
@@ -2074,6 +2102,11 @@
 </script>
 
 <div bind:this={container} class="w-full h-full relative" role="region" aria-label="3D floor plan viewer">
+  {#if showAllFloors && currentFloor}
+    <div class="absolute bottom-4 right-4 z-10 rounded bg-black/70 px-3 py-2 text-xs text-white pointer-events-none">
+      {currentFloor.name} · {activeFloorElevation} cm elevation
+    </div>
+  {/if}
   <!-- 3D Toolbar Row -->
   <div class="absolute top-4 right-4 z-50 flex gap-1.5">
     <!-- Multi-Floor Stacking Toggle -->

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -11,6 +11,7 @@
   import { buildWallSegments, openingOnWall, roomCeilingHeight, wallPathSpans, doorPanelPose } from '$lib/utils/wallProfiles';
   import { assembleFloorStack } from '$lib/utils/floorStack';
   import { setFloorCameraPose } from '$lib/utils/floorCamera';
+  import { frameScene } from '$lib/utils/frameScene';
   import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
   import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
   import MaterialPicker from './MaterialPicker.svelte';
@@ -1033,20 +1034,8 @@
     }
   }
 
-  function autoCenterCamera(floor: Floor) {
-    if (floor.walls.length === 0) return;
-    let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
-    for (const w of floor.walls) {
-      for (const p of [w.start, w.end]) {
-        minX = Math.min(minX, p.x); maxX = Math.max(maxX, p.x);
-        minZ = Math.min(minZ, p.y); maxZ = Math.max(maxZ, p.y);
-      }
-    }
-    const cx = (minX + maxX) / 2;
-    const cz = (minZ + maxZ) / 2;
-    const size = Math.max(maxX - minX, maxZ - minZ, 200);
-    controls.target.set(cx, 100, cz);
-    camera.position.set(cx + size * 1.8, size * 1.4, cz + size * 1.8);
+  function autoCenterCamera() {
+    frameScene(camera, new THREE.Box3().setFromObject(wallGroup), controls.target);
     controls.update();
   }
 
@@ -1714,7 +1703,7 @@
     // Columns
     buildColumns(floor);
 
-    autoCenterCamera(floor);
+    autoCenterCamera();
   }
 
   /** Build all floors stacked vertically in 3D */
@@ -1738,7 +1727,7 @@
     floorPlane.constant = -activeFloorElevation;
     // Keep the presentation ground below basements as well as above-ground floors.
     sceneGround.position.y = Math.min(0, ...entries.map(entry => entry.yOffset)) - 1;
-    autoCenterCameraAllFloors();
+    autoCenterCamera();
   }
 
   function addFloorLabel(name: string, yOffset: number, labelX: number, labelZ: number) {
@@ -1850,16 +1839,6 @@
         group.add(mesh);
       }
     }
-  }
-
-  function autoCenterCameraAllFloors() {
-    const box = new THREE.Box3().setFromObject(wallGroup);
-    const center = box.getCenter(new THREE.Vector3());
-    const size = box.getSize(new THREE.Vector3());
-    const maxDim = Math.max(size.x, size.y, size.z, 400);
-    controls.target.copy(center);
-    camera.position.set(center.x + maxDim * 1.2, center.y + maxDim * 0.8, center.z + maxDim * 1.2);
-    controls.update();
   }
 
   function rebuildScene() {

--- a/src/lib/models/types.ts
+++ b/src/lib/models/types.ts
@@ -185,6 +185,8 @@ export interface Floor {
   id: string;
   name: string;
   level: number;
+  /** Floor surface above ground in cm; omitted in legacy projects (level × 300). */
+  elevation?: number;
   walls: Wall[];
   rooms: Room[];
   doors: Door[];

--- a/src/lib/stores/project.ts
+++ b/src/lib/stores/project.ts
@@ -1,7 +1,7 @@
 import { writable, derived, get } from 'svelte/store';
 import type { Project, Floor, Wall, Door, Window as Win, FurnitureItem, Point, Stair, Column, BackgroundImage, GuideLine, ElementGroup, EntourageItem } from '$lib/models/types';
 import { getOuterWalls } from '$lib/utils/outerWalls';
-import { nextFloorLevel } from '$lib/utils/floors';
+import { nextFloorLevel, floorElevations, validFloorElevation, DEFAULT_FLOOR_SPACING } from '$lib/utils/floors';
 import { getWallStartHeight, getWallEndHeight, getWallHeightAt, validWallHeight } from '$lib/models/types';
 
 
@@ -668,6 +668,12 @@ export function addFloor(name?: string, seed: FloorSeed = 'outer') {
   // otherwise hand the next storey a level that is already taken.
   const level = nextFloorLevel(p.floors);
   const floor = createDefaultFloor(level);
+  // Continue the top floor's adjusted elevation, retaining any skipped levels.
+  const top = floorElevations(p.floors).at(-1);
+  if (top) {
+    const elevation = top.elevation + (level - top.level) * DEFAULT_FLOOR_SPACING;
+    if (elevation !== level * DEFAULT_FLOOR_SPACING && validFloorElevation(elevation)) floor.elevation = elevation;
+  }
   if (name !== undefined) floor.name = name;
   if (seed !== 'empty') {
     const cur = p.floors.find(f => f.id === p.activeFloorId);
@@ -708,6 +714,19 @@ export function setActiveFloor(floorId: string) {
     p.activeFloorId = floorId;
     currentProject.set({ ...p });
   }
+}
+
+/** An omitted elevation restores the legacy level-based default. */
+export function updateFloorElevation(floorId: string, elevation?: number) {
+  const p = get(currentProject);
+  if (!p || (elevation !== undefined && !validFloorElevation(elevation))) return;
+  const entry = floorElevations(p.floors).find(entry => entry.floor.id === floorId);
+  if (!entry || (elevation === undefined ? entry.floor.elevation === undefined : entry.elevation === elevation)) return;
+  snapshot('Changed floor elevation', `floor-elevation:${floorId}`);
+  if (elevation === undefined) delete entry.floor.elevation;
+  else entry.floor.elevation = elevation;
+  p.updatedAt = new Date();
+  currentProject.set({ ...p });
 }
 
 export function updateProjectName(name: string) {

--- a/src/lib/utils/floorCamera.ts
+++ b/src/lib/utils/floorCamera.ts
@@ -1,0 +1,7 @@
+import type { Camera, Vector3Like } from 'three';
+
+/** Camera coordinates are local to a floor, just like its walls and furniture. */
+export function setFloorCameraPose(camera: Camera, elevation: number, position: Vector3Like, target: Vector3Like) {
+  camera.position.set(position.x, position.y + elevation, position.z);
+  camera.lookAt(target.x, target.y + elevation, target.z);
+}

--- a/src/lib/utils/floorStack.ts
+++ b/src/lib/utils/floorStack.ts
@@ -1,15 +1,13 @@
 import { Group } from 'three';
 import type { Floor } from '$lib/models/types';
-import { orderedFloors } from './floors';
-
-export const FLOOR_HEIGHT = 300;
+import { floorElevations } from './floors';
 
 /** The active floor is already built at zero; move it before adding any other floors. */
 export function assembleFloorStack(
   root: Group, floors: Floor[], activeFloorId: string,
   buildOther: (floor: Floor, group: Group, yOffset: number) => void,
 ): { floor: Floor; yOffset: number }[] {
-  const entries = orderedFloors(floors).map(({ floor, level }) => ({ floor, yOffset: level * FLOOR_HEIGHT }));
+  const entries = floorElevations(floors).map(({ floor, elevation }) => ({ floor, yOffset: elevation }));
   const active = entries.find(entry => entry.floor.id === activeFloorId);
   if (!active) return [];
   for (const child of root.children) child.position.y += active.yOffset;

--- a/src/lib/utils/floors.ts
+++ b/src/lib/utils/floors.ts
@@ -1,9 +1,23 @@
 import type { Floor, Project } from '$lib/models/types';
 
+export const DEFAULT_FLOOR_SPACING = 300;
+
+export function validFloorElevation(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
 /** Older project files without a level retain their original array order. */
 export function orderedFloors(floors: Floor[]): { floor: Floor; level: number }[] {
   return floors.map((floor, index) => ({ floor, level: Number.isFinite(floor.level) ? floor.level : index }))
     .sort((a, b) => a.level - b.level);
+}
+
+/** Elevations are independent of wall heights and retain level/legacy ordering. */
+export function floorElevations(floors: Floor[]): { floor: Floor; level: number; elevation: number }[] {
+  return orderedFloors(floors).map(({ floor, level }) => ({
+    floor, level,
+    elevation: validFloorElevation(floor.elevation) ? floor.elevation : level * DEFAULT_FLOOR_SPACING,
+  }));
 }
 
 export function nextFloorLevel(floors: Floor[]): number {

--- a/src/lib/utils/frameScene.ts
+++ b/src/lib/utils/frameScene.ts
@@ -1,0 +1,28 @@
+import { Box3, PerspectiveCamera, Vector3 } from 'three';
+
+/** Fit every corner using the camera's horizontal and vertical field of view. */
+export function frameScene(camera: PerspectiveCamera, bounds: Box3, target: Vector3) {
+  const box = bounds.isEmpty()
+    ? new Box3(new Vector3(-200, 0, -200), new Vector3(200, 280, 200))
+    : bounds;
+  box.getCenter(target);
+  const outward = new Vector3(1.2, 0.8, 1.2).normalize();
+  const right = new Vector3().crossVectors(camera.up, outward).normalize();
+  const up = new Vector3().crossVectors(outward, right).normalize();
+  const tanY = Math.tan(camera.getEffectiveFOV() * Math.PI / 360);
+  const tanX = tanY * camera.aspect;
+  let distance = 400;
+  for (const x of [box.min.x, box.max.x]) {
+    for (const y of [box.min.y, box.max.y]) {
+      for (const z of [box.min.z, box.max.z]) {
+        const corner = new Vector3(x, y, z).sub(target);
+        const depth = corner.dot(outward);
+        distance = Math.max(distance, depth + Math.abs(corner.dot(right)) / tanX,
+          depth + Math.abs(corner.dot(up)) / tanY, depth + camera.near);
+      }
+    }
+  }
+  camera.position.copy(target).addScaledVector(outward, distance * 1.15);
+  camera.lookAt(target);
+  camera.updateMatrixWorld(true);
+}

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -196,7 +196,8 @@
 {#if ready}
   <div class="h-screen flex flex-col overflow-hidden">
     <TopBar />
-    <div class="flex flex-1 overflow-hidden">
+    <!-- Keep canvas/viewer controls beneath toolbar menus and project dialogs. -->
+    <div class="flex flex-1 overflow-hidden isolate">
       {#if mode === '2d'}
         <!-- Build panel: inline sidebar on md+, off-canvas drawer on phones -->
         {#if buildPanelOpen}

--- a/tests/browser/editor.spec.ts
+++ b/tests/browser/editor.spec.ts
@@ -222,3 +222,82 @@ test('sloped walls preserve heights and openings through edits, reversal, elevat
   expect(errors).toEqual([]);
   expect(externalRequests).toEqual([]);
 });
+
+for (const width of [1440, 390]) {
+  test(`floor elevations survive edits and reload at ${width}px with stacked views`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    const errors: string[] = [];
+    const externalRequests: string[] = [];
+    page.on('pageerror', error => errors.push(error.message));
+    page.on('request', request => {
+      if (/^https?:/.test(request.url()) && new URL(request.url()).origin !== 'http://127.0.0.1:4188') externalRequests.push(request.url());
+    });
+    const settings = async () => {
+      if (width < 768) await page.getByRole('button', { name: 'More actions', exact: true }).click();
+      await page.getByRole('button', { name: 'Settings', exact: true }).click();
+      await expect(page.getByRole('dialog', { name: 'Settings', exact: true })).toBeVisible();
+    };
+    const selectFloor = async (name: string) => {
+      if (width < 768) {
+        await page.getByRole('button', { name: 'More actions', exact: true }).click();
+        await page.getByRole('button', { name, exact: true }).click();
+      } else await page.getByRole('combobox', { name: 'Current floor' }).selectOption({ label: name });
+    };
+    await page.goto('/editor');
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+    await importJSON(page, resolve('tests/fixtures/sloped-walls.openplan.json'));
+    const original = await exportJSON(page);
+    await settings();
+    const upper = page.getByRole('spinbutton', { name: 'Curved Upper elevation (cm)', exact: true });
+    const ground = page.getByRole('spinbutton', { name: 'Sloped Ground elevation (cm)', exact: true });
+    await expect(upper).toHaveValue('300');
+    await expect(ground).toHaveValue('0');
+    await ground.fill('-50.5'); await ground.press('Tab');
+    await upper.fill('425.5'); await upper.press('Tab');
+    await upper.fill(''); await upper.press('Tab');
+    await expect(upper).toHaveValue('425.5');
+    await testInfo.attach(`floor-settings-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+    await page.getByRole('button', { name: 'Close settings', exact: true }).click();
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    await settings();
+    await expect(upper).toHaveValue('300');
+    await expect(ground).toHaveValue('-50.5');
+    await page.getByRole('button', { name: 'Close settings', exact: true }).click();
+    await page.getByRole('button', { name: 'Redo', exact: true }).click();
+    await settings();
+    await expect(upper).toHaveValue('425.5');
+    await page.getByRole('button', { name: 'Use default elevation for Curved Upper', exact: true }).click();
+    await expect(upper).toHaveValue('300');
+    await upper.fill('425.5'); await upper.press('Tab');
+    await page.getByRole('button', { name: 'Close settings', exact: true }).click();
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    const saved = await exportJSON(page);
+    expect(saved.floors.map((floor: { elevation: number }) => floor.elevation)).toEqual([-50.5, 425.5]);
+    expect(saved.floors.map(({ elevation: _, ...floor }: { elevation: number }) => floor)).toEqual(original.floors);
+    await page.reload();
+    expect((await exportJSON(page)).floors).toEqual(saved.floors);
+    // JSON import must preserve the setting as well as local storage does.
+    await importJSON(page, { name: 'elevations.json', mimeType: 'application/json', buffer: Buffer.from(JSON.stringify(saved)) });
+    await selectFloor('Curved Upper');
+    await page.getByRole('button', { name: '3D', exact: true }).click();
+    await expect(page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
+    await page.getByRole('button', { name: 'Show All Floors Stacked', exact: true }).click();
+    await expect(page.getByText('Curved Upper · 425.5 cm elevation', { exact: true })).toBeVisible();
+    await page.waitForLoadState('networkidle');
+    await testInfo.attach(`adjusted-stack-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+    if (width >= 768) {
+      await page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true }).click();
+      await expect(page.getByText('Walkthrough Controls', { exact: true })).toBeVisible();
+      await testInfo.attach('upper-floor-walkthrough', { body: await page.screenshot(), contentType: 'image/png' });
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true })).toBeVisible();
+    }
+    await selectFloor('Sloped Ground');
+    await expect(page.getByText('Sloped Ground · -50.5 cm elevation', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Active Floor Only', exact: true }).click();
+    await expect(page.getByText('Sloped Ground · -50.5 cm elevation', { exact: true })).not.toBeVisible();
+    await page.getByRole('button', { name: '2D', exact: true }).click();
+    expect(errors).toEqual([]);
+    expect(externalRequests).toEqual([]);
+  });
+}

--- a/tests/browser/editor.spec.ts
+++ b/tests/browser/editor.spec.ts
@@ -291,6 +291,17 @@ for (const width of [1440, 390]) {
       await testInfo.attach('upper-floor-walkthrough', { body: await page.screenshot(), contentType: 'image/png' });
       await page.keyboard.press('Escape');
       await expect(page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true })).toBeVisible();
+      // Browser mouse capture can be denied independently of the editor. A
+      // rejected browser API must leave keyboard walkthrough usable, without
+      // an unhandled rejection. This does not alter project or scene state.
+      await page.evaluate(() => {
+        HTMLCanvasElement.prototype.requestPointerLock = () => Promise.reject(new DOMException('Mouse capture denied', 'NotAllowedError'));
+      });
+      await page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true }).click();
+      await expect(page.getByRole('status')).toContainText('Mouse look is unavailable');
+      await page.keyboard.press('ArrowUp');
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true })).toBeVisible();
     }
     await selectFloor('Sloped Ground');
     await expect(page.getByText('Sloped Ground · -50.5 cm elevation', { exact: true })).toBeVisible();

--- a/tests/datastore.test.ts
+++ b/tests/datastore.test.ts
@@ -20,6 +20,7 @@ describe('local project persistence', () => {
   it('round trips a project and its dates without changing other projects', async () => {
     const first = createDefaultProject('First');
     const second = createDefaultProject('Second');
+    second.floors[0].elevation = -325.5;
     await localStore.save(first);
     await localStore.save(second);
     second.name = 'Renamed';

--- a/tests/floor-stack.test.ts
+++ b/tests/floor-stack.test.ts
@@ -1,7 +1,8 @@
 import { expect, it } from 'vitest';
-import { Group, Mesh, BoxGeometry, MeshBasicMaterial, Vector3 } from 'three';
+import { Group, Mesh, BoxGeometry, MeshBasicMaterial, Vector3, PerspectiveCamera, Plane, Raycaster } from 'three';
 import { assembleFloorStack } from '$lib/utils/floorStack';
-import { getFloorBelow, orderedFloors } from '$lib/utils/floors';
+import { getFloorBelow, orderedFloors, floorElevations } from '$lib/utils/floors';
+import { setFloorCameraPose } from '$lib/utils/floorCamera';
 import { createDefaultFloor, createDefaultProject } from '$lib/stores/project';
 
 it.each([0, 1, 2])('keeps all floors at their own elevation with floor %s active', active => {
@@ -37,4 +38,54 @@ it('keeps legacy floors without level metadata in array order without mutating t
   for (const floor of floors) delete (floor as Partial<typeof floor>).level;
   expect(orderedFloors(floors).map(entry => entry.level)).toEqual([0, 1]);
   expect(floors[0]).not.toHaveProperty('level');
+  expect(floorElevations(floors).map(entry => entry.elevation)).toEqual([0, 300]);
+});
+
+it.each([0, 1, 2, 3])('aligns mixed-height geometry, placement and floor cameras with floor %s active', active => {
+  const floors = [-1, 0, 1, 3].map(createDefaultFloor);
+  const elevations = [-350, 0, 425.5, 1125.5];
+  floors.forEach((floor, i) => { floor.elevation = elevations[i]; });
+  const root = new Group();
+  const meshes = new Map<string, Mesh>();
+  const add = (floorId: string, target: Group, y: number) => {
+    const mesh = new Mesh(new BoxGeometry(400, 280, 20), new MeshBasicMaterial());
+    mesh.position.set(0, y + 140, -200);
+    meshes.set(floorId, mesh);
+    target.add(mesh);
+  };
+  add(floors[active].id, root, 0);
+  const entries = assembleFloorStack(root, [...floors].reverse(), floors[active].id,
+    (floor, group, y) => add(floor.id, group, y));
+  root.updateMatrixWorld(true);
+  expect(entries.map(entry => entry.yOffset)).toEqual(elevations);
+  expect(floors.map(floor => meshes.get(floor.id)!.getWorldPosition(new Vector3()).y))
+    .toEqual(elevations.map(elevation => elevation + 140));
+
+  const elevation = entries.find(entry => entry.floor.id === floors[active].id)!.yOffset;
+  const camera = new PerspectiveCamera();
+  setFloorCameraPose(camera, elevation, { x: 0, y: 160, z: 0 }, { x: 0, y: 160, z: -100 });
+  expect(camera.position.y).toBe(elevation + 160);
+  const ray = new Raycaster(camera.position, camera.getWorldDirection(new Vector3()));
+  // Eye-level view intersects the selected floor's wall, even on a basement/upper storey.
+  expect(ray.intersectObjects(root.children)[0]?.object).toBe(meshes.get(floors[active].id));
+  const down = new Raycaster(camera.position, new Vector3(0, -1, 0));
+  expect(down.ray.intersectPlane(new Plane(new Vector3(0, 1, 0), -elevation), new Vector3())?.y).toBe(elevation);
+});
+
+it('keeps an interior camera pitch and direction unchanged when the floor moves', () => {
+  const camera = new PerspectiveCamera();
+  const position = { x: 80, y: 180, z: 120 };
+  const target = { x: 280, y: 130, z: -200 };
+  setFloorCameraPose(camera, 0, position, target);
+  const direction = camera.getWorldDirection(new Vector3());
+  setFloorCameraPose(camera, 750, position, target);
+  expect(camera.position.toArray()).toEqual([80, 930, 120]);
+  expect(camera.getWorldDirection(new Vector3()).distanceTo(direction)).toBeLessThan(1e-12);
+});
+
+it('falls back for malformed imported elevations without changing the source document', () => {
+  const floors = [0, 1, 3, -1].map(createDefaultFloor);
+  [NaN, Infinity, '450', null].forEach((value, i) => { floors[i].elevation = value as number; });
+  expect(floorElevations(floors).map(entry => entry.elevation)).toEqual([-300, 0, 300, 900]);
+  expect(floors[2].elevation).toBe('450');
 });

--- a/tests/floors.test.ts
+++ b/tests/floors.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, expect, it } from 'vitest';
 import { get } from 'svelte/store';
 import { addFloor, createDefaultFloor, currentProject, loadProject, removeFloor, setActiveFloor, undo, redo, selectedElementId, selectedElementIds, elevationWallId, selectedTool } from '$lib/stores/project';
 import { roomProject } from './fixtures/project';
+import { updateFloorElevation } from '$lib/stores/project';
+import { floorElevations } from '$lib/utils/floors';
 
 beforeEach(() => loadProject(roomProject()));
 
@@ -85,4 +87,48 @@ it('clears selections, unfinished tools and elevation when switching or adding f
   elevationWallId.set(get(currentProject)!.floors[1].walls[0].id);
   setActiveFloor(ground);
   expect(get(elevationWallId)).toBeNull();
+});
+
+it('changes floor elevations independently of geometry and groups undo by floor', () => {
+  addFloor();
+  const original = structuredClone(get(currentProject)!.floors);
+  const [ground, upper] = original;
+  updateFloorElevation(ground.id, -50.5);
+  updateFloorElevation(upper.id, 400);
+  updateFloorElevation(upper.id, 425.5);
+  expect(floorElevations(get(currentProject)!.floors).map(entry => entry.elevation)).toEqual([-50.5, 425.5]);
+  expect(get(currentProject)!.floors.map(f => f.walls)).toEqual(original.map(f => f.walls));
+  undo();
+  expect(floorElevations(get(currentProject)!.floors).map(entry => entry.elevation)).toEqual([-50.5, 300]);
+  redo();
+  expect(get(currentProject)!.floors[1].elevation).toBe(425.5);
+  updateFloorElevation(upper.id);
+  expect(get(currentProject)!.floors[1]).not.toHaveProperty('elevation');
+  undo();
+  expect(get(currentProject)!.floors[1].elevation).toBe(425.5);
+});
+
+it('ignores invalid, unchanged and missing-floor edits without consuming undo history', () => {
+  const id = get(currentProject)!.activeFloorId;
+  updateFloorElevation(id, 40);
+  updateFloorElevation(id, 40);
+  for (const value of [NaN, Infinity, -Infinity, '400', null]) updateFloorElevation(id, value as number);
+  updateFloorElevation('missing', 400);
+  undo();
+  expect(get(currentProject)!.floors[0]).not.toHaveProperty('elevation');
+  redo();
+  expect(get(currentProject)!.floors[0].elevation).toBe(40);
+});
+
+it('adds a new top floor above adjusted floors and preserves elevations through remove/undo', () => {
+  addFloor();
+  const upperId = get(currentProject)!.activeFloorId;
+  updateFloorElevation(upperId, 425.5);
+  addFloor(undefined, 'copy');
+  const p = get(currentProject)!;
+  expect(p.floors[2]).toMatchObject({ level: 2, elevation: 725.5 });
+  removeFloor(upperId);
+  expect(floorElevations(get(currentProject)!.floors).map(entry => entry.elevation)).toEqual([0, 725.5]);
+  undo();
+  expect(floorElevations(get(currentProject)!.floors).map(entry => entry.elevation)).toEqual([0, 425.5, 725.5]);
 });

--- a/tests/frame-scene.test.ts
+++ b/tests/frame-scene.test.ts
@@ -1,0 +1,31 @@
+import { expect, it } from 'vitest';
+import { Box3, PerspectiveCamera, Vector3 } from 'three';
+import { frameScene } from '$lib/utils/frameScene';
+
+it.each([390 / 852, 640 / 630, 1440 / 852])('fits a tall mixed-floor scene at aspect %s', aspect => {
+  const camera = new PerspectiveCamera(60, aspect, 1, 100000);
+  const bounds = new Box3(new Vector3(-250, -350, -150), new Vector3(800, 1425, 700));
+  const target = new Vector3();
+  frameScene(camera, bounds, target);
+  expect(target.toArray()).toEqual([275, 537.5, 275]);
+  for (const x of [bounds.min.x, bounds.max.x]) {
+    for (const y of [bounds.min.y, bounds.max.y]) {
+      for (const z of [bounds.min.z, bounds.max.z]) {
+        const projected = new Vector3(x, y, z).project(camera);
+        expect(Math.abs(projected.x)).toBeLessThan(1);
+        expect(Math.abs(projected.y)).toBeLessThan(1);
+        expect(projected.z).toBeGreaterThan(-1);
+        expect(projected.z).toBeLessThan(1);
+      }
+    }
+  }
+});
+
+it('provides a finite useful camera for empty floors', () => {
+  const camera = new PerspectiveCamera(60, 390 / 852, 1, 100000);
+  const target = new Vector3();
+  frameScene(camera, new Box3(), target);
+  expect(camera.position.toArray().every(Number.isFinite)).toBe(true);
+  expect(target.toArray()).toEqual([0, 140, 0]);
+  expect(camera.position.distanceTo(target)).toBeGreaterThan(400);
+});


### PR DESCRIPTION
Floors now have editable elevations in Settings → Project, so tall/sloped walls can fit beneath upper storeys. Legacy projects keep their existing 300 cm spacing, negative elevations support basements, and changes preserve wall geometry and neighbouring floor positions. New top floors continue above adjusted floors.

Stacked geometry, placement planes, walkthrough and interior cameras use the same active-floor elevation. Camera previews and markers update after elevation/stacking changes; basement ground and top-down framing are corrected. Initial perspective framing fits complete buildings on portrait screens. Settings fits compact screens and supports Escape. The compact floor menu stays above 3D controls, and browsers that refuse mouse capture get a keyboard walkthrough fallback.

Validation: 220 unit tests and all six Chromium browser workflows pass without retries on both [the final PR revision](https://github.com/laanlabs/openPlan3D/actions/runs/34008050623) and [merged main](https://github.com/laanlabs/openPlan3D/actions/runs/34008195839). Type checking has zero errors (24 remaining warnings); the production build and dependency audit pass. Unit checks project actual bounding-box corners through portrait/landscape cameras and raycast from floor-relative cameras through actual wall meshes. Browser workflows cover desktop and 390 px settings, undo/redo, reset, save/reload, JSON exchange, stacked 3D and rejected mouse capture. Interactive local checks also cover interior camera previews, basement walkthrough and the browser's mouse-capture fallback. See the [report](https://github.com/laanlabs/openPlan3D/blob/main/docs/reviews/2026-09-05-floor-elevations.md).

Release verified: main commit `39c53f7f39f43cf36b7df853b8e3224fe865917f` is deployed as `openplan3d-build-2026-09-06-002` and serves 100% of traffic. Live checks passed for legacy defaults, independent elevation edits/undo/redo, local persistence after reopening, stacked rendering, 390 px pointer-driven floor selection and complete portrait framing. Saved elevations were -50.5 cm and 425.5 cm. One reload received `ERR_CONNECTION_CLOSED`; reopening the same saved project succeeded, and the fresh live tab logged zero warnings/errors through the completed checks. The embedded local browser refuses pointer lock; its keyboard fallback works, although Three.js still logs its mouse-capture diagnostic. Physical iPhone, Safari and Firefox checks were not part of this web release.

Issue #42 is closed. The integration branch is deleted locally/remotely and local main is clean and synchronized.

Cost impact: all changes remain local to the editor, with no Firebase Storage operations, new services, dependencies or cloud-policy changes. iPhone distribution and #30's remaining migration/budget work are unchanged.

Closes #42.
