### PR TITLE
Keep numeric wall edits connected and validate dimensions

### DIFF
--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -323,3 +323,11 @@ cancellation, and bounded error handling. Its unrestricted hosted proxy is remov
 no AI image storage or proxy bandwidth is added to Firebase. See
 [direct AI provider review](2026-09-06-direct-ai-providers.md) for the transport
 contract, compatibility limitations, contributor credit and validation.
+
+## Tenth batch: connected wall dimensions
+
+Issue #45 repairs numeric wall resizing so joined corners and room metadata survive
+length changes. It adds fixed-endpoint selection, invalid/blank dimension recovery,
+fractional lengths, consistent undo/redo, and simultaneous access to layers and
+properties on desktop. See [the batch report](2026-09-06-connected-wall-dimensions.md).
+No Firebase Storage or iPhone schema changes are introduced.

--- a/docs/reviews/2026-09-06-connected-wall-dimensions.md
+++ b/docs/reviews/2026-09-06-connected-wall-dimensions.md
@@ -25,6 +25,7 @@ geometry with zero or one.
   enforce the wall's actual range rather than a 5%/95% clamp.
 - Length inputs keep fractional centimetres, accept Enter or blur to commit, and
   do not convert a rounded imperial display back into geometry merely on focus/blur.
+  The same precision protection applies to wall heights, thickness and openings.
 - The desktop properties panel participates in the layout instead of covering the
   layers list. The compact bottom sheet remains available on phone widths.
 

--- a/docs/reviews/2026-09-06-connected-wall-dimensions.md
+++ b/docs/reviews/2026-09-06-connected-wall-dimensions.md
@@ -1,0 +1,47 @@
+# Connected wall dimensions — September 6, 2026
+
+Issue #45 fixes a mismatch between dragging a joined corner and editing a wall's
+numeric length. The old numeric handler moved only the selected wall, leaving the
+adjacent endpoint behind and removing the detected room. Whole-centimetre rounding
+also obscured fractional wall lengths, and blank size fields could overwrite
+geometry with zero or one.
+
+## Changes
+
+- Wall length edits choose a fixed start (A) or end (B), scale the selected wall
+  about that endpoint, and move neighbouring endpoints that shared the opposite
+  corner. Pointer dragging and numeric resizing now use the same 2 cm connection
+  tolerance. Resizes are prepared and validated before one grouped store mutation.
+- Joined walls that would collapse below 1 cm, invalid coordinates and invalid
+  lengths are rejected without project/history changes. Unchanged length edits
+  preserve redo. Rapid edits to the same wall/anchor retain undo coalescing.
+- Curved walls scale their control point about the chosen anchor using the existing
+  sampled arc-length measurement. Wall heights, materials, opening dimensions and
+  normalized opening positions are preserved. Room metadata stays associated with
+  the same wall IDs. Other floors are untouched.
+- Numeric wall/door/window drafts reject blank/non-finite/invalid sizes without
+  mutating the model, restoring the stored value on blur. Zero window sills and
+  valid endpoint positions remain supported. Distance inputs retain fractions and
+  enforce the wall's actual range rather than a 5%/95% clamp.
+- Length inputs keep fractional centimetres, accept Enter or blur to commit, and
+  do not convert a rounded imperial display back into geometry merely on focus/blur.
+- The desktop properties panel participates in the layout instead of covering the
+  layers list. The compact bottom sheet remains available on phone widths.
+
+This is connected-corner editing, not a geometric constraint solver: neighbouring
+walls may change angle, interior T-junction constraints are not propagated, and
+curved-wall opening holes remain separate work. No project schema, cloud service,
+Firebase Storage traffic, or iOS client behavior changes.
+
+## Validation
+
+281 unit tests pass, including 25 new geometry/store regressions for joined and
+rotated corners, both anchor choices, curved scaling, tolerance, named-room
+preservation, other-floor isolation, metadata, undo/redo, invalid/collapsing edits,
+positive dimensions, zero sills, and invalid positions. Production browser
+workflows at 1440px and 390px exercise import, layer selection, connected edits,
+room retention, fractional dimensions, input recovery, imperial conversion,
+undo/redo, save/reload/export, and 3D, with zero external editing requests.
+
+Type checks, production build, CI and interactive/live browser results are recorded
+on the linked implementation PR before release.

--- a/src/lib/components/editor/FloorPlanCanvas.svelte
+++ b/src/lib/components/editor/FloorPlanCanvas.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { connectedWallEndpoints } from '$lib/utils/wallEditing';
   import { startAnimationLoop } from '$lib/utils/animationLoop';
   import { activeFloor, selectedTool, selectedElementId, selectedElementIds, selectedRoomId, addWall, addDoor, addWindow, updateWall, moveWallEndpoint, updateDoor, updateWindow, addFurniture, moveFurniture, transformFurnitureDuringDrag, commitFurnitureMove, rotateFurniture, setFurnitureRotation, scaleFurniture, removeElement, placingFurnitureId, placingRotation, placingDoorType, placingWindowType, detectedRoomsStore, duplicateDoor, duplicateWindow, duplicateFurniture, duplicateWall, moveWallParallel, splitWall, snapEnabled, placingStair, addStair, moveStair, updateStair, placingColumn, placingColumnShape, addColumn, moveColumn, updateColumn, calibrationMode, calibrationPoints, updateBackgroundImage, setBackgroundImage, canvasZoom, canvasCamX, canvasCamY, panMode, showFurnitureStore, addGuide, moveGuide, removeGuide, beginUndoGroup, endUndoGroup, layerVisibility, updateRoom, addMeasurement, removeMeasurement, addAnnotation, removeAnnotation, updateAnnotation, addTextAnnotation, removeTextAnnotation, updateTextAnnotation, moveTextAnnotation, toggleFurnitureLock, createGroup, ungroupElements, findGroupForElement, placingEntourageId, addEntourageItem, moveEntourage, resizeEntourage, currentProject, elevationWallId, elevationPickMode } from '$lib/stores/project';
   import type { Point, Wall, Door, Window as Win, FurnitureItem, Stair, Column, GuideLine, Measurement, Annotation, TextAnnotation, CustomEntourageDef } from '$lib/models/types';
@@ -286,19 +287,7 @@
 
   /** Find all other wall endpoints that share the same point (within tolerance) */
   function findConnectedEndpoints(pt: Point, excludeWallId: string): { wallId: string; endpoint: 'start' | 'end' }[] {
-    const tolerance = 2;
-    const results: { wallId: string; endpoint: 'start' | 'end' }[] = [];
-    if (!currentFloor) return results;
-    for (const w of currentFloor.walls) {
-      if (w.id === excludeWallId) continue;
-      if (Math.hypot(w.start.x - pt.x, w.start.y - pt.y) < tolerance) {
-        results.push({ wallId: w.id, endpoint: 'start' });
-      }
-      if (Math.hypot(w.end.x - pt.x, w.end.y - pt.y) < tolerance) {
-        results.push({ wallId: w.id, endpoint: 'end' });
-      }
-    }
-    return results;
+    return currentFloor ? connectedWallEndpoints(currentFloor.walls, pt, excludeWallId) : [];
   }
 
   function magneticSnap(p: Point, excludeWallIds?: Set<string>): Point & { snappedToEndpoint?: boolean; snappedToWall?: boolean; snappedWallId?: string } {

--- a/src/lib/components/sidebar/PropertiesPanel.svelte
+++ b/src/lib/components/sidebar/PropertiesPanel.svelte
@@ -2,7 +2,8 @@
   import { onDestroy } from 'svelte';
   import { catalogAssetUrl } from '$lib/utils/catalogAssetUrl';
 
-  import { activeFloor, selectedElementId, selectedRoomId, updateWall, reverseWall, updateDoor, updateWindow, updateRoom, updateFurniture, detectedRoomsStore, updateStair, updateColumn, updateBackgroundImage, setBackgroundImage, calibrationMode, calibrationPoints, updateTextAnnotation, toggleFurnitureLock, updateEntourageItem, removeElement, elevationWallId } from '$lib/stores/project';
+  import { activeFloor, selectedElementId, selectedRoomId, updateWall, resizeWallLength, reverseWall, updateDoor, updateWindow, updateRoom, updateFurniture, detectedRoomsStore, updateStair, updateColumn, updateBackgroundImage, setBackgroundImage, calibrationMode, calibrationPoints, updateTextAnnotation, toggleFurnitureLock, updateEntourageItem, removeElement, elevationWallId } from '$lib/stores/project';
+  import { wallLength as calcWallLength, MIN_WALL_LENGTH, type WallEndpoint } from '$lib/utils/wallEditing';
   import { openingOnWall } from '$lib/utils/wallProfiles';
   import { getEntourageDef } from '$lib/utils/entourageCatalog';
   import { floorMaterials, wallColors } from '$lib/utils/materials';
@@ -25,7 +26,7 @@
   onDestroy(projectSettings.subscribe((s) => { settings = s; }));
 
   function displayValue(cm: number): number {
-    return settings.units === 'imperial' ? Math.round(cm / 2.54 * 10) / 10 : cm;
+    return settings.units === 'imperial' ? Math.round(cm / 2.54 * 10) / 10 : Math.round(cm * 1000) / 1000;
   }
   function inputToCm(value: number): number {
     return settings.units === 'imperial' ? value * 2.54 : value;
@@ -51,59 +52,41 @@
   let selectedDoorWall = $derived((selectedDoor && floor?.walls?.find(w => w.id === selectedDoor.wallId)) ?? null);
   let selectedWindowWall = $derived((selectedWindow && floor?.walls?.find(w => w.id === selectedWindow.wallId)) ?? null);
 
-  // Helper function to calculate wall length
-  function calcWallLength(wall: Wall): number {
-    if (wall.curvePoint) {
-      let len = 0; const N = 20;
-      let px = wall.start.x, py = wall.start.y;
-      for (let i = 1; i <= N; i++) {
-        const t = i / N, mt = 1 - t;
-        const nx = mt*mt*wall.start.x + 2*mt*t*wall.curvePoint.x + t*t*wall.end.x;
-        const ny = mt*mt*wall.start.y + 2*mt*t*wall.curvePoint.y + t*t*wall.end.y;
-        len += Math.hypot(nx - px, ny - py); px = nx; py = ny;
-      }
-      return len;
-    }
-    return Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
-  }
-
-  let wallLength = $derived(selectedWall ? Math.round(calcWallLength(selectedWall)) : 0);
+  let wallLength = $derived(selectedWall ? Math.round(calcWallLength(selectedWall) * 1000) / 1000 : 0);
+  let fixedEndpoint = $state<WallEndpoint>('start');
+  let wallLengthError = $state<string | null>(null);
+  $effect(() => { void selId; fixedEndpoint = 'start'; wallLengthError = null; });
 
   // Calculate door distances
-  let doorDistFromA = $derived(selectedDoor && selectedDoorWall ? Math.round(calcWallLength(selectedDoorWall) * selectedDoor.position) : 0);
-  let doorDistFromB = $derived(selectedDoor && selectedDoorWall ? Math.round(calcWallLength(selectedDoorWall) * (1 - selectedDoor.position)) : 0);
+  let doorDistFromA = $derived(selectedDoor && selectedDoorWall ? calcWallLength(selectedDoorWall) * selectedDoor.position : 0);
+  let doorDistFromB = $derived(selectedDoor && selectedDoorWall ? calcWallLength(selectedDoorWall) * (1 - selectedDoor.position) : 0);
 
   // Calculate window distances  
-  let windowDistFromA = $derived(selectedWindow && selectedWindowWall ? Math.round(calcWallLength(selectedWindowWall) * selectedWindow.position) : 0);
-  let windowDistFromB = $derived(selectedWindow && selectedWindowWall ? Math.round(calcWallLength(selectedWindowWall) * (1 - selectedWindow.position)) : 0);
+  let windowDistFromA = $derived(selectedWindow && selectedWindowWall ? calcWallLength(selectedWindowWall) * selectedWindow.position : 0);
+  let windowDistFromB = $derived(selectedWindow && selectedWindowWall ? calcWallLength(selectedWindowWall) * (1 - selectedWindow.position) : 0);
 
   function onWallLength(e: Event) {
     if (!selectedWall) return;
-    const target = e.target as HTMLInputElement;
-    const newLen = inputToCm(Number(target.value));
-    if (!isFinite(newLen) || newLen <= 0) return;
-    const currentLen = calcWallLength(selectedWall);
-    if (currentLen < 0.01) return;
-    const scale = newLen / currentLen;
-    const sx = selectedWall.start.x;
-    const sy = selectedWall.start.y;
-    const updates: Partial<Wall> = {
-      end: {
-        x: sx + (selectedWall.end.x - sx) * scale,
-        y: sy + (selectedWall.end.y - sy) * scale,
-      },
-    };
-    if (selectedWall.curvePoint) {
-      updates.curvePoint = {
-        x: sx + (selectedWall.curvePoint.x - sx) * scale,
-        y: sy + (selectedWall.curvePoint.y - sy) * scale,
-      };
-    }
-    updateWall(selectedWall.id, updates);
+    const input = e.target as HTMLInputElement;
+    const current = calcWallLength(selectedWall);
+    if (!input.value.trim() || !input.validity.valid || !Number.isFinite(input.valueAsNumber)) {
+      wallLengthError = 'Enter a wall length of at least 1 cm.';
+    } else if (input.valueAsNumber !== displayValue(current)) {
+      wallLengthError = resizeWallLength(selectedWall.id, inputToCm(input.valueAsNumber), fixedEndpoint);
+    } else { wallLengthError = null; }
+    input.value = String(displayValue(calcWallLength(selectedWall)));
+  }
+
+  /** Blank/invalid drafts leave geometry untouched; restore the saved value on blur. */
+  function dimensionInput(e: Event, current: number, save: (cm: number) => void, zeroAllowed = false, max = Infinity) {
+    const input = e.target as HTMLInputElement;
+    const value = inputToCm(input.valueAsNumber);
+    const valid = input.value.trim() && input.validity.valid && Number.isFinite(value) && (zeroAllowed ? value >= 0 : value > 0) && value <= max;
+    if (valid && input.valueAsNumber !== displayValue(current)) save(value);
+    else if (!valid && e.type === 'blur') input.value = String(displayValue(current));
   }
   function onWallThickness(e: Event) {
-    if (!selectedWall) return;
-    updateWall(selectedWall.id, { thickness: inputToCm(Number((e.target as HTMLInputElement).value)) });
+    if (selectedWall) dimensionInput(e, selectedWall.thickness, value => updateWall(selectedWall!.id, { thickness: value }));
   }
   let clippedOpenings = $derived.by(() => {
     if (!selectedWall || !floor) return false;
@@ -139,12 +122,10 @@
     updateWall(selectedWall.id, { color: (e.target as HTMLInputElement).value });
   }
   function onDoorWidth(e: Event) {
-    if (!selectedDoor) return;
-    updateDoor(selectedDoor.id, { width: Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1) });
+    if (selectedDoor) dimensionInput(e, selectedDoor.width, value => updateDoor(selectedDoor!.id, { width: value }));
   }
   function onDoorHeight(e: Event) {
-    if (!selectedDoor) return;
-    updateDoor(selectedDoor.id, { height: inputToCm(Number((e.target as HTMLInputElement).value)) });
+    if (selectedDoor) dimensionInput(e, selectedDoor.height ?? 210, value => updateDoor(selectedDoor!.id, { height: value }));
   }
   function onDoorType(e: Event) {
     if (!selectedDoor) return;
@@ -167,16 +148,13 @@
     updateWindow(selectedWindow.id, { type: (e.target as HTMLSelectElement).value as Win['type'] });
   }
   function onWindowWidth(e: Event) {
-    if (!selectedWindow) return;
-    updateWindow(selectedWindow.id, { width: Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1) });
+    if (selectedWindow) dimensionInput(e, selectedWindow.width, value => updateWindow(selectedWindow!.id, { width: value }));
   }
   function onWindowHeight(e: Event) {
-    if (!selectedWindow) return;
-    updateWindow(selectedWindow.id, { height: inputToCm(Number((e.target as HTMLInputElement).value)) });
+    if (selectedWindow) dimensionInput(e, selectedWindow.height, value => updateWindow(selectedWindow!.id, { height: value }));
   }
   function onWindowSill(e: Event) {
-    if (!selectedWindow) return;
-    updateWindow(selectedWindow.id, { sillHeight: inputToCm(Number((e.target as HTMLInputElement).value)) });
+    if (selectedWindow) dimensionInput(e, selectedWindow.sillHeight ?? 90, value => updateWindow(selectedWindow!.id, { sillHeight: value }), true);
   }
 
   // Furniture handlers
@@ -215,35 +193,31 @@
   // Door distance handlers
   function onDoorDistFromA(e: Event) {
     if (!selectedDoor || !selectedDoorWall) return;
-    const newDistFromA = inputToCm(Number((e.target as HTMLInputElement).value));
-    const wallLen = calcWallLength(selectedDoorWall);
-    const newPosition = Math.max(0.05, Math.min(0.95, newDistFromA / wallLen));
-    updateDoor(selectedDoor.id, { position: newPosition });
+    const length = calcWallLength(selectedDoorWall);
+    if (!Number.isFinite(length) || length <= 0) return;
+    dimensionInput(e, length * selectedDoor.position, value => updateDoor(selectedDoor!.id, { position: value / length }), true, length);
   }
   
   function onDoorDistFromB(e: Event) {
     if (!selectedDoor || !selectedDoorWall) return;
-    const newDistFromB = inputToCm(Number((e.target as HTMLInputElement).value));
-    const wallLen = calcWallLength(selectedDoorWall);
-    const newPosition = Math.max(0.05, Math.min(0.95, 1 - (newDistFromB / wallLen)));
-    updateDoor(selectedDoor.id, { position: newPosition });
+    const length = calcWallLength(selectedDoorWall);
+    if (!Number.isFinite(length) || length <= 0) return;
+    dimensionInput(e, length * (1 - selectedDoor.position), value => updateDoor(selectedDoor!.id, { position: 1 - value / length }), true, length);
   }
 
   // Window distance handlers
   function onWindowDistFromA(e: Event) {
     if (!selectedWindow || !selectedWindowWall) return;
-    const newDistFromA = inputToCm(Number((e.target as HTMLInputElement).value));
-    const wallLen = calcWallLength(selectedWindowWall);
-    const newPosition = Math.max(0.05, Math.min(0.95, newDistFromA / wallLen));
-    updateWindow(selectedWindow.id, { position: newPosition });
+    const length = calcWallLength(selectedWindowWall);
+    if (!Number.isFinite(length) || length <= 0) return;
+    dimensionInput(e, length * selectedWindow.position, value => updateWindow(selectedWindow!.id, { position: value / length }), true, length);
   }
   
   function onWindowDistFromB(e: Event) {
     if (!selectedWindow || !selectedWindowWall) return;
-    const newDistFromB = inputToCm(Number((e.target as HTMLInputElement).value));
-    const wallLen = calcWallLength(selectedWindowWall);
-    const newPosition = Math.max(0.05, Math.min(0.95, 1 - (newDistFromB / wallLen)));
-    updateWindow(selectedWindow.id, { position: newPosition });
+    const length = calcWallLength(selectedWindowWall);
+    if (!Number.isFinite(length) || length <= 0) return;
+    dimensionInput(e, length * (1 - selectedWindow.position), value => updateWindow(selectedWindow!.id, { position: 1 - value / length }), true, length);
   }
   // Preset colors for rooms and columns
   const roomColorPresets = [
@@ -350,7 +324,7 @@
 </script>
 
 <!-- Right sidebar on md+; slides up as a bottom sheet on phones -->
-<div class="{is3D ? 'w-80' : 'w-64'} shrink-0 bg-white border-l border-gray-200 flex flex-col overflow-y-auto p-3 fixed right-0 top-12 bottom-9 z-40 shadow-lg max-md:top-auto max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-h-[45vh] max-md:border-l-0 max-md:border-t max-md:rounded-t-xl max-md:shadow-2xl" class:hidden={!hasSelection}>
+<div class="{is3D ? 'w-80' : 'w-64'} shrink-0 bg-white border-l border-gray-200 flex flex-col overflow-y-auto p-3 fixed md:static right-0 top-12 bottom-9 z-40 shadow-lg max-md:top-auto max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-h-[45vh] max-md:border-l-0 max-md:border-t max-md:rounded-t-xl max-md:shadow-2xl" class:hidden={!hasSelection}>
   {#if selectedWall}
     <h3 class="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
       <span class="w-6 h-6 bg-gray-200 rounded flex items-center justify-center text-xs">▭</span>
@@ -359,11 +333,20 @@
     <div class="space-y-3">
       <label class="block">
         <span class="text-xs text-gray-500">Length ({unitLabel()})</span>
-        <input type="number" value={displayValue(wallLength)} onchange={onWallLength} min="1" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(wallLength)} onblur={onWallLength} onkeydown={(event) => { if (event.key === 'Enter') event.currentTarget.blur(); }} min={settings.units === 'imperial' ? MIN_WALL_LENGTH / 2.54 : MIN_WALL_LENGTH} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
+        <span class="text-xs text-gray-500">Keep fixed</span>
+        <select bind:value={fixedEndpoint} class="w-full px-2 py-1 border border-gray-200 rounded text-sm">
+          <option value="start">Start (A)</option>
+          <option value="end">End (B)</option>
+        </select>
+      </label>
+      <p class="text-xs text-gray-500">Joined corners follow the moving endpoint. Openings keep their relative positions.</p>
+      {#if wallLengthError}<p role="alert" class="text-xs text-red-700">{wallLengthError}</p>{/if}
+      <label class="block">
         <span class="text-xs text-gray-500">Thickness ({unitLabel()})</span>
-        <input type="number" value={displayValue(selectedWall.thickness)} oninput={onWallThickness} class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(selectedWall.thickness)} oninput={onWallThickness} onblur={onWallThickness} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <div class="grid grid-cols-2 gap-2">
         <label class="block">
@@ -520,19 +503,19 @@
     <div class="space-y-3">
       <label class="block">
         <span class="text-xs text-gray-500">Width ({unitLabel()})</span>
-        <input type="number" value={displayValue(selectedDoor.width)} oninput={onDoorWidth} min="1" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(selectedDoor.width)} oninput={onDoorWidth} onblur={onDoorWidth} step="any" min="0" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Distance from A ({unitLabel()})</span>
-        <input type="number" value={displayValue(doorDistFromA)} oninput={onDoorDistFromA} class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(doorDistFromA)} oninput={onDoorDistFromA} onblur={onDoorDistFromA} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Distance from B ({unitLabel()})</span>
-        <input type="number" value={displayValue(doorDistFromB)} oninput={onDoorDistFromB} class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(doorDistFromB)} oninput={onDoorDistFromB} onblur={onDoorDistFromB} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Height ({unitLabel()})</span>
-        <input type="number" value={displayValue(selectedDoor.height ?? 210)} oninput={onDoorHeight} class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(selectedDoor.height ?? 210)} oninput={onDoorHeight} onblur={onDoorHeight} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Type</span>
@@ -583,23 +566,23 @@
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Width ({unitLabel()})</span>
-        <input type="number" value={displayValue(selectedWindow.width)} oninput={onWindowWidth} min="1" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(selectedWindow.width)} oninput={onWindowWidth} onblur={onWindowWidth} step="any" min="0" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Distance from A ({unitLabel()})</span>
-        <input type="number" value={displayValue(windowDistFromA)} oninput={onWindowDistFromA} class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(windowDistFromA)} oninput={onWindowDistFromA} onblur={onWindowDistFromA} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Distance from B ({unitLabel()})</span>
-        <input type="number" value={displayValue(windowDistFromB)} oninput={onWindowDistFromB} class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(windowDistFromB)} oninput={onWindowDistFromB} onblur={onWindowDistFromB} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Height ({unitLabel()})</span>
-        <input type="number" value={displayValue(selectedWindow.height)} oninput={onWindowHeight} class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(selectedWindow.height)} oninput={onWindowHeight} onblur={onWindowHeight} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Sill Height ({unitLabel()})</span>
-        <input type="number" value={displayValue(selectedWindow.sillHeight)} oninput={onWindowSill} class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(selectedWindow.sillHeight)} oninput={onWindowSill} onblur={onWindowSill} step="any" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
     </div>
 
@@ -839,7 +822,7 @@
       </div>
       <label class="block">
         <span class="text-xs text-gray-500">Width ({unitLabel()})</span>
-        <input type="number" value={displayValue(Math.round(selectedEntourage.width))} oninput={(e) => { if (selectedEntourage) updateEntourageItem(selectedEntourage.id, { width: Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1) }); }} min="1" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(Math.round(selectedEntourage.width))} oninput={(e) => { if (selectedEntourage) updateEntourageItem(selectedEntourage.id, { width: Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1) }); }} min="0" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Rotation (°)</span>

--- a/src/lib/components/sidebar/PropertiesPanel.svelte
+++ b/src/lib/components/sidebar/PropertiesPanel.svelte
@@ -99,18 +99,10 @@
     });
   });
   function onWallStartHeight(e: Event) {
-    if (!selectedWall) return;
-    const input = e.target as HTMLInputElement;
-    if (!input.value.trim() || !input.validity.valid) { if (e.type === 'blur') input.value = String(displayValue(getWallStartHeight(selectedWall))); return; }
-    const height = inputToCm(input.valueAsNumber);
-    if (height !== getWallStartHeight(selectedWall)) updateWall(selectedWall.id, { startHeight: height });
+    if (selectedWall) dimensionInput(e, getWallStartHeight(selectedWall), value => updateWall(selectedWall!.id, { startHeight: value }), true);
   }
   function onWallEndHeight(e: Event) {
-    if (!selectedWall) return;
-    const input = e.target as HTMLInputElement;
-    if (!input.value.trim() || !input.validity.valid) { if (e.type === 'blur') input.value = String(displayValue(getWallEndHeight(selectedWall))); return; }
-    const height = inputToCm(input.valueAsNumber);
-    if (height !== getWallEndHeight(selectedWall)) updateWall(selectedWall.id, { endHeight: height });
+    if (selectedWall) dimensionInput(e, getWallEndHeight(selectedWall), value => updateWall(selectedWall!.id, { endHeight: value }), true);
   }
   function equalizeWallHeights() {
     if (!selectedWall) return;
@@ -822,7 +814,7 @@
       </div>
       <label class="block">
         <span class="text-xs text-gray-500">Width ({unitLabel()})</span>
-        <input type="number" value={displayValue(Math.round(selectedEntourage.width))} oninput={(e) => { if (selectedEntourage) updateEntourageItem(selectedEntourage.id, { width: Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1) }); }} min="0" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
+        <input type="number" value={displayValue(Math.round(selectedEntourage.width))} oninput={(e) => { if (selectedEntourage) updateEntourageItem(selectedEntourage.id, { width: Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1) }); }} min="1" class="w-full px-2 py-1 border border-gray-200 rounded text-sm" />
       </label>
       <label class="block">
         <span class="text-xs text-gray-500">Rotation (°)</span>

--- a/src/lib/stores/project.ts
+++ b/src/lib/stores/project.ts
@@ -1,5 +1,6 @@
 import { writable, derived, get } from 'svelte/store';
 import type { Project, Floor, Wall, Door, Window as Win, FurnitureItem, Point, Stair, Column, BackgroundImage, GuideLine, ElementGroup, EntourageItem } from '$lib/models/types';
+import { planWallResize, finitePoint, validPositiveDimension, validOpeningPosition, type WallEndpoint } from '$lib/utils/wallEditing';
 import { getOuterWalls } from '$lib/utils/outerWalls';
 import { nextFloorLevel, floorElevations, validFloorElevation, DEFAULT_FLOOR_SPACING } from '$lib/utils/floors';
 import { getWallStartHeight, getWallEndHeight, getWallHeightAt, validWallHeight } from '$lib/models/types';
@@ -562,7 +563,33 @@ export function moveWallEndpoint(id: string, endpoint: 'start' | 'end', position
   }
 }
 
+/** Resize joined corners atomically. Openings keep their normalized wall positions. */
+export function resizeWallLength(id: string, length: number, fixed: WallEndpoint = 'start'): string | null {
+  const floor = get(activeFloor);
+  if (!floor) return 'Select a floor first.';
+  let changes: Map<string, Partial<Wall>>;
+  try { changes = planWallResize(floor.walls, id, length, fixed); }
+  catch (error) { return error instanceof Error ? error.message : 'The wall could not be resized.'; }
+  if (!changes.size) return null;
+  mutate(f => {
+    for (const wall of f.walls) {
+      const updates = changes.get(wall.id);
+      if (updates) Object.assign(wall, updates);
+    }
+  }, 'Resized connected wall', `wall-length:${id}:${fixed}`);
+  return null;
+}
+
+function unchangedFields(current: object, updates: object): boolean {
+  return Object.entries(updates).every(([key, value]) => Object.is((current as Record<string, unknown>)[key], value));
+}
+
 export function updateWall(id: string, updates: Partial<Wall>) {
+  const wall = get(activeFloor)?.walls.find(w => w.id === id);
+  if (!wall || unchangedFields(wall, updates)) return;
+  if ('thickness' in updates && !validPositiveDimension(updates.thickness)) return;
+  if (['start', 'end'].some(key => key in updates && !finitePoint(updates[key as 'start' | 'end']))) return;
+  if (updates.curvePoint !== undefined && !finitePoint(updates.curvePoint)) return;
   if (['height', 'startHeight', 'endHeight'].some(key => key in updates && !validWallHeight(updates[key as keyof Wall]))) return;
   mutate((f) => {
     const w = f.walls.find((w) => w.id === id);
@@ -614,6 +641,10 @@ export function reverseWall(id: string) {
 }
 
 export function updateDoor(id: string, updates: Partial<Door>) {
+  const door = get(activeFloor)?.doors.find(d => d.id === id);
+  if (!door || unchangedFields(door, updates)) return;
+  if (['width', 'height'].some(key => key in updates && !validPositiveDimension(updates[key as 'width' | 'height']))) return;
+  if ('position' in updates && !validOpeningPosition(updates.position)) return;
   mutate((f) => {
     const d = f.doors.find((d) => d.id === id);
     if (d) Object.assign(d, updates);
@@ -621,6 +652,11 @@ export function updateDoor(id: string, updates: Partial<Door>) {
 }
 
 export function updateWindow(id: string, updates: Partial<Win>) {
+  const window = get(activeFloor)?.windows.find(w => w.id === id);
+  if (!window || unchangedFields(window, updates)) return;
+  if (['width', 'height'].some(key => key in updates && !validPositiveDimension(updates[key as 'width' | 'height']))) return;
+  if ('sillHeight' in updates && !validWallHeight(updates.sillHeight)) return;
+  if ('position' in updates && !validOpeningPosition(updates.position)) return;
   mutate((f) => {
     const w = f.windows.find((w) => w.id === id);
     if (w) Object.assign(w, updates);

--- a/src/lib/utils/wallEditing.ts
+++ b/src/lib/utils/wallEditing.ts
@@ -1,0 +1,72 @@
+import type { Point, Wall } from '$lib/models/types';
+
+export type WallEndpoint = 'start' | 'end';
+export const WALL_JOIN_TOLERANCE = 2; // cm; same joined-corner rule as pointer dragging
+export const MIN_WALL_LENGTH = 1; // cm
+
+export function wallLength(wall: Wall): number {
+  if (!wall.curvePoint) return Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
+  let length = 0, previous = wall.start;
+  for (let i = 1; i <= 20; i++) {
+    const t = i / 20, u = 1 - t;
+    const point = { x: u * u * wall.start.x + 2 * u * t * wall.curvePoint.x + t * t * wall.end.x,
+      y: u * u * wall.start.y + 2 * u * t * wall.curvePoint.y + t * t * wall.end.y };
+    length += Math.hypot(point.x - previous.x, point.y - previous.y);
+    previous = point;
+  }
+  return length;
+}
+
+export function connectedWallEndpoints(walls: Wall[], point: Point, excludeWallId: string): { wallId: string; endpoint: WallEndpoint }[] {
+  const results: { wallId: string; endpoint: WallEndpoint }[] = [];
+  for (const wall of walls) {
+    if (wall.id === excludeWallId) continue;
+    for (const endpoint of ['start', 'end'] as const) {
+      if (Math.hypot(wall[endpoint].x - point.x, wall[endpoint].y - point.y) < WALL_JOIN_TOLERANCE) {
+        results.push({ wallId: wall.id, endpoint });
+      }
+    }
+  }
+  return results;
+}
+
+export function finitePoint(point: unknown): point is Point {
+  return !!point && typeof point === 'object' && 'x' in point && 'y' in point && Number.isFinite(point.x) && Number.isFinite(point.y);
+}
+
+/** Plan all corner updates first, so a rejected resize cannot partly modify the floor. */
+export function planWallResize(walls: Wall[], id: string, length: number, fixed: WallEndpoint = 'start'): Map<string, Partial<Wall>> {
+  if (!Number.isFinite(length) || length < MIN_WALL_LENGTH) throw new Error('Wall length must be at least 1 cm.');
+  if (fixed !== 'start' && fixed !== 'end') throw new Error('Choose a fixed wall endpoint.');
+  const wall = walls.find(w => w.id === id);
+  if (!wall) throw new Error('Select a wall to resize.');
+  const currentLength = wallLength(wall);
+  if (!Number.isFinite(currentLength) || currentLength < MIN_WALL_LENGTH) throw new Error('This wall is too short to resize. Move its endpoint first.');
+  const changes = new Map<string, Partial<Wall>>();
+  if (Math.abs(length - currentLength) < 1e-6) return changes;
+  const moving: WallEndpoint = fixed === 'start' ? 'end' : 'start';
+  const origin = wall[fixed], scale = length / currentLength;
+  const transform = (p: Point): Point => ({ x: origin.x + (p.x - origin.x) * scale, y: origin.y + (p.y - origin.y) * scale });
+  const target = transform(wall[moving]);
+  changes.set(id, { [moving]: target, ...(wall.curvePoint ? { curvePoint: transform(wall.curvePoint) } : {}) });
+  for (const connection of connectedWallEndpoints(walls, wall[moving], id)) {
+    changes.set(connection.wallId, { ...changes.get(connection.wallId), [connection.endpoint]: { ...target } });
+  }
+  for (const [wallId, updates] of changes) {
+    const changed = { ...walls.find(w => w.id === wallId)!, ...updates };
+    if (!finitePoint(changed.start) || !finitePoint(changed.end) || (changed.curvePoint && !finitePoint(changed.curvePoint)) || !Number.isFinite(wallLength(changed))) {
+      throw new Error('This length would create invalid wall coordinates.');
+    }
+    if (Math.hypot(changed.end.x - changed.start.x, changed.end.y - changed.start.y) < MIN_WALL_LENGTH) {
+      throw new Error('This length would collapse a joined wall. Choose another length or fixed endpoint.');
+    }
+  }
+  return changes;
+}
+
+export function validPositiveDimension(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+export function validOpeningPosition(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1;
+}

--- a/tests/browser/wall-dimensions.spec.ts
+++ b/tests/browser/wall-dimensions.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type Page } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+async function exportPlan(page: Page) {
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const pending = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download JSON', exact: true }).click();
+  return JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
+}
+async function edit(page: Page, name: string, value: string) {
+  const input = page.getByRole('spinbutton', { name, exact: true });
+  await input.fill(value); await input.press('Tab');
+}
+
+for (const width of [1440, 390]) {
+  test(`numeric wall dimensions preserve joined rooms and valid opening values at ${width}px`, async ({ page }, testInfo) => {
+    test.setTimeout(90_000);
+    await page.setViewportSize({ width, height: 900 });
+    const errors: string[] = [], external: string[] = [];
+    page.on('pageerror', error => errors.push(error.message));
+    page.on('request', request => {
+      if (/^https?:/.test(request.url()) && new URL(request.url()).origin !== 'http://127.0.0.1:4188') external.push(request.url());
+    });
+    await page.goto('/editor');
+    await page.getByRole('button', { name: 'Export', exact: true }).click();
+    const chooser = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+    await (await chooser).setFiles(resolve('tests/fixtures/connected-dimensions.openplan.json'));
+    await expect(page.getByRole('application')).toContainText('1 room');
+    // L is the existing layers shortcut, available on desktop and compact layouts.
+    await page.getByRole('button', { name: 'Save', exact: true }).press('l');
+    await page.getByRole('button', { name: '─ Wall 1', exact: true }).click();
+    const length = page.getByRole('spinbutton', { name: 'Length (cm)', exact: true });
+    await expect(length).toHaveValue('600.5');
+    await edit(page, 'Length (cm)', '650.25');
+    await expect(length).toHaveValue('650.25');
+    await expect(page.getByRole('application')).toContainText('1 room');
+    await expect(page.getByRole('application')).toContainText('25.0 m²');
+    let exported = await exportPlan(page);
+    let walls = exported.floors[0].walls;
+    expect(walls[0].end.x).toBeCloseTo(650.25);
+    expect(walls[1].start).toEqual(walls[0].end);
+    expect(exported.floors[0].rooms[0].name).toBe('Kitchen & Dining');
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    await expect(length).toHaveValue('600.5');
+    await expect(page.getByRole('application')).toContainText('1 room');
+    await page.getByRole('button', { name: 'Redo', exact: true }).click();
+    await expect(length).toHaveValue('650.25');
+    await page.getByRole('combobox', { name: 'Keep fixed', exact: true }).selectOption('end');
+    await edit(page, 'Length (cm)', '700.75');
+    await expect(length).toHaveValue('700.75');
+    for (const value of ['', '0', '-10']) {
+      await edit(page, 'Length (cm)', value);
+      await expect(length).toHaveValue('700.75');
+      await expect(page.getByRole('alert')).toContainText('at least 1 cm');
+    }
+    await edit(page, 'Thickness (cm)', '');
+    await expect(page.getByRole('spinbutton', { name: 'Thickness (cm)', exact: true })).toHaveValue('20');
+    await edit(page, 'Thickness (cm)', '-5');
+    await expect(page.getByRole('spinbutton', { name: 'Thickness (cm)', exact: true })).toHaveValue('20');
+    await edit(page, 'Thickness (cm)', '32.75');
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    await expect(page.getByRole('spinbutton', { name: 'Thickness (cm)', exact: true })).toHaveValue('20');
+    await page.getByRole('button', { name: 'Undo', exact: true }).click(); // invalid drafts did not consume history
+    await expect(length).toHaveValue('650.25');
+    await page.getByRole('button', { name: 'Redo', exact: true }).click();
+    await page.getByRole('button', { name: 'Redo', exact: true }).click();
+    exported = await exportPlan(page); walls = exported.floors[0].walls;
+    expect(walls[0].start.x).toBeCloseTo(-50.5);
+    expect(walls[0].end.x).toBeCloseTo(650.25);
+    expect(walls[3].end).toEqual(walls[0].start);
+    expect(walls[1].start).toEqual(walls[0].end);
+    await testInfo.attach(`connected-resize-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+
+    await page.getByRole('button', { name: '🚪 opening door 1', exact: true }).click();
+    const doorWidth = page.getByRole('spinbutton', { name: 'Width (cm)', exact: true });
+    await expect(doorWidth).toHaveValue('90.5');
+    for (const value of ['', '0', '-1']) {
+      await edit(page, 'Width (cm)', value); await expect(doorWidth).toHaveValue('90.5');
+    }
+    await edit(page, 'Width (cm)', '95.125');
+    await edit(page, 'Height (cm)', '');
+    await expect(page.getByRole('spinbutton', { name: 'Height (cm)', exact: true })).toHaveValue('205.25');
+    await edit(page, 'Height (cm)', '207.75');
+    await edit(page, 'Distance from A (cm)', '250.125');
+    await expect(page.getByRole('spinbutton', { name: 'Distance from B (cm)', exact: true })).toHaveValue('450.625');
+    await edit(page, 'Distance from A (cm)', '');
+    await expect(page.getByRole('spinbutton', { name: 'Distance from A (cm)', exact: true })).toHaveValue('250.125');
+    await page.getByRole('button', { name: '🪟 standard window 1', exact: true }).click();
+    await edit(page, 'Height (cm)', '-10');
+    await expect(page.getByRole('spinbutton', { name: 'Height (cm)', exact: true })).toHaveValue('120.5');
+    await edit(page, 'Sill Height (cm)', '0');
+    await expect(page.getByRole('spinbutton', { name: 'Sill Height (cm)', exact: true })).toHaveValue('0');
+    await edit(page, 'Distance from A (cm)', '9999');
+
+    await page.getByRole('button', { name: '─ Wall 1', exact: true }).click();
+    if (width < 768) await page.getByRole('button', { name: 'More actions', exact: true }).click();
+    await page.getByRole('button', { name: 'Settings', exact: true }).click();
+    await page.getByRole('button', { name: 'Dimensions', exact: true }).click();
+    await page.getByRole('button', { name: 'ft, inch', exact: true }).click();
+    await page.getByRole('button', { name: 'Close settings', exact: true }).click();
+    const beforeFocus = (await exportPlan(page)).floors;
+    const inches = page.getByRole('spinbutton', { name: 'Length (in)', exact: true });
+    await expect(inches).toHaveValue('275.9');
+    await inches.click(); await inches.press('Tab');
+    expect((await exportPlan(page)).floors).toEqual(beforeFocus);
+    await edit(page, 'Length (in)', '300.25');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    const saved = await exportPlan(page); walls = saved.floors[0].walls;
+    expect(Math.hypot(walls[0].end.x - walls[0].start.x, walls[0].end.y - walls[0].start.y)).toBeCloseTo(300.25 * 2.54);
+    expect(walls[1].start).toEqual(walls[0].end);
+    expect(saved.floors[0].doors[0]).toMatchObject({ width: 95.125, height: 207.75 });
+    expect(saved.floors[0].windows[0]).toMatchObject({ height: 120.5, sillHeight: 0 });
+    await page.reload();
+    await expect(page.getByRole('application')).toContainText('1 room');
+    expect((await exportPlan(page)).floors).toEqual(saved.floors);
+    await page.getByRole('button', { name: '3D', exact: true }).click();
+    await expect(page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
+    await testInfo.attach(`resized-3d-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+    expect(errors).toEqual([]); expect(external).toEqual([]);
+  });
+}

--- a/tests/browser/wall-dimensions.spec.ts
+++ b/tests/browser/wall-dimensions.spec.ts
@@ -103,7 +103,10 @@ for (const width of [1440, 390]) {
     const beforeFocus = (await exportPlan(page)).floors;
     const inches = page.getByRole('spinbutton', { name: 'Length (in)', exact: true });
     await expect(inches).toHaveValue('275.9');
-    await inches.click(); await inches.press('Tab');
+    for (const name of ['Length (in)', 'Thickness (in)', 'Start Height (in)', 'End Height (in)']) {
+      const input = page.getByRole('spinbutton', { name, exact: true });
+      await input.click(); await input.press('Tab');
+    }
     expect((await exportPlan(page)).floors).toEqual(beforeFocus);
     await edit(page, 'Length (in)', '300.25');
     await page.getByRole('button', { name: 'Save', exact: true }).click();

--- a/tests/fixtures/connected-dimensions.openplan.json
+++ b/tests/fixtures/connected-dimensions.openplan.json
@@ -1,0 +1,123 @@
+{
+  "id": "qa-connected-dimensions",
+  "name": "QA Connected Dimensions",
+  "floors": [
+    {
+      "id": "dimensions-floor",
+      "name": "Ground Floor",
+      "level": 0,
+      "walls": [
+        {
+          "id": "qa-wall-0",
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "end": {
+            "x": 600.5,
+            "y": 0
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-1",
+          "start": {
+            "x": 600.5,
+            "y": 0
+          },
+          "end": {
+            "x": 600,
+            "y": 400
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-2",
+          "start": {
+            "x": 600,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 400
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-3",
+          "start": {
+            "x": 0,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        }
+      ],
+      "rooms": [
+        {
+          "id": "qa-named-room",
+          "name": "Kitchen & Dining",
+          "walls": [
+            "qa-wall-0",
+            "qa-wall-1",
+            "qa-wall-2",
+            "qa-wall-3"
+          ],
+          "area": 24.01,
+          "floorTexture": "light-oak",
+          "color": "#ddf2ff",
+          "roomType": "kitchen",
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "doors": [
+        {
+          "id": "qa-door",
+          "wallId": "qa-wall-0",
+          "position": 0.5,
+          "width": 90.5,
+          "height": 205.25,
+          "type": "opening",
+          "swingDirection": "left",
+          "opensInward": true
+        }
+      ],
+      "windows": [
+        {
+          "id": "qa-window",
+          "wallId": "qa-wall-1",
+          "position": 0.5,
+          "width": 110.25,
+          "height": 120.5,
+          "sillHeight": 90,
+          "type": "standard"
+        }
+      ],
+      "furniture": [],
+      "stairs": [],
+      "columns": [],
+      "guides": [],
+      "measurements": [],
+      "annotations": [],
+      "textAnnotations": [],
+      "groups": []
+    }
+  ],
+  "activeFloorId": "dimensions-floor",
+  "createdAt": "2026-09-05T00:00:00.000Z",
+  "updatedAt": "2026-09-05T00:00:00.000Z"
+}

--- a/tests/wall-editing.test.ts
+++ b/tests/wall-editing.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { loadProject, currentProject, activeFloor, resizeWallLength, updateWall, updateDoor, updateWindow, undo, redo, undoHistoryStore } from '$lib/stores/project';
+import { planWallResize, wallLength, connectedWallEndpoints } from '$lib/utils/wallEditing';
+import { resolveRooms } from '$lib/utils/roomDetection';
+import { roomProject } from './fixtures/project';
+import type { Wall } from '$lib/models/types';
+
+beforeEach(() => {
+  const project = roomProject(), floor = project.floors[0];
+  floor.rooms = resolveRooms(floor).map(room => ({ ...room, id: 'named-room', name: 'Kitchen & Dining', color: '#abcdef', floorTexture: 'tile', labelOffset: { x: 12, y: 4 } }));
+  floor.walls[0] = { ...floor.walls[0], startHeight: 210, endHeight: 350, height: 350, interiorTexture: 'brick' };
+  floor.doors = [{ id: 'door', wallId: floor.walls[0].id, position: 0.35, width: 90.5, height: 205.25, type: 'double', swingDirection: 'right', flipSide: true }];
+  floor.windows = [{ id: 'window', wallId: floor.walls[1].id, position: 0.65, width: 100.25, height: 120.5, sillHeight: 85.25, type: 'casement' }];
+  project.floors.push({ ...structuredClone(floor), id: 'other-floor', name: 'Other floor', level: 1 });
+  loadProject(project);
+});
+
+const floor = () => get(activeFloor)!;
+const serialized = () => JSON.stringify(get(currentProject));
+
+describe('connected wall dimensions', () => {
+  it('keeps joined corners and named rooms during fractional resizing, in one undo entry', () => {
+    const before = serialized(), oldWall = structuredClone(floor().walls[0]), other = structuredClone(get(currentProject)!.floors[1]);
+    const doors = structuredClone(floor().doors), windows = structuredClone(floor().windows);
+    expect(resizeWallLength('a-0', 500.25)).toBeNull();
+    expect(floor().walls[0].start).toEqual({ x: 0, y: 0 });
+    expect(floor().walls[0].end.x).toBeCloseTo(500.25);
+    expect(floor().walls[0].end.y).toBe(0);
+    expect(floor().walls[1].start).toEqual(floor().walls[0].end);
+    expect(floor().walls[1].end).toEqual({ x: 400, y: 300 });
+    expect(resolveRooms(floor())).toHaveLength(1);
+    expect(resolveRooms(floor())[0]).toMatchObject({ id: 'named-room', name: 'Kitchen & Dining', color: '#abcdef', floorTexture: 'tile', labelOffset: { x: 12, y: 4 } });
+    expect(resolveRooms(floor())[0].area).toBeCloseTo((400 + 500.25) / 2 * 300 / 10000);
+    expect(floor().walls[0]).toMatchObject({ ...oldWall, end: floor().walls[0].end });
+    expect(floor().doors).toEqual(doors); expect(floor().windows).toEqual(windows);
+    expect(get(currentProject)!.floors[1]).toEqual(other);
+    expect(get(undoHistoryStore).entries).toHaveLength(1);
+    const after = serialized(); undo(); expect(serialized()).toBe(before); redo(); expect(serialized()).toBe(after);
+  });
+  it('supports a fixed end and coalesces consecutive edits without moving the wrong neighbour', () => {
+    expect(resizeWallLength('a-0', 475, 'end')).toBeNull();
+    expect(resizeWallLength('a-0', 525.5, 'end')).toBeNull();
+    expect(floor().walls[0].end).toEqual({ x: 400, y: 0 });
+    expect(floor().walls[0].start).toEqual({ x: -125.5, y: 0 });
+    expect(floor().walls[3].end).toEqual(floor().walls[0].start);
+    expect(floor().walls[1].start).toEqual({ x: 400, y: 0 });
+    expect(get(undoHistoryStore).entries).toHaveLength(1);
+    undo(); expect(wallLength(floor().walls[0])).toBe(400);
+  });
+  it('handles rotated corners and both endpoint orientations', () => {
+    const p = roomProject();
+    for (const w of p.floors[0].walls) {
+      const rotate = ({ x, y }: { x: number; y: number }) => ({ x: 10 + x * 0.6 - y * 0.8, y: -20 + x * 0.8 + y * 0.6 });
+      w.start = rotate(w.start); w.end = rotate(w.end);
+    }
+    const second = p.floors[0].walls[1]; [second.start, second.end] = [second.end, second.start];
+    loadProject(p);
+    resizeWallLength('a-0', 700.5);
+    expect(wallLength(floor().walls[0])).toBeCloseTo(700.5);
+    expect(floor().walls[1].end).toEqual(floor().walls[0].end);
+    expect(resolveRooms(floor())).toHaveLength(1);
+  });
+  it('uses the pointer-drag tolerance for all joined endpoints, but excludes separated walls', () => {
+    const wall = floor().walls[0];
+    const extra = (id: string, x: number): Wall => ({ ...wall, id, start: { x, y: 0 }, end: { x, y: -200 } });
+    floor().walls.push(extra('near', 401), extra('apart', 403));
+    expect(connectedWallEndpoints(floor().walls, wall.end, wall.id).map(c => c.wallId)).toEqual(['a-1', 'near']);
+    resizeWallLength('a-0', 550);
+    expect(floor().walls.find(w => w.id === 'near')!.start).toEqual({ x: 550, y: 0 });
+    expect(floor().walls.find(w => w.id === 'apart')!.start).toEqual({ x: 403, y: 0 });
+  });
+  it.each(['start', 'end'] as const)('scales curved length and control point about the fixed %s', fixed => {
+    const wall = floor().walls[0]; wall.curvePoint = { x: 150, y: -120 };
+    const anchor = { ...wall[fixed] }, oldControl = { ...wall.curvePoint }, before = wallLength(wall);
+    expect(resizeWallLength(wall.id, before * 1.5, fixed)).toBeNull();
+    expect(wallLength(wall)).toBeCloseTo(before * 1.5);
+    expect(wall[fixed]).toEqual(anchor);
+    expect(wall.curvePoint).toEqual({ x: anchor.x + (oldControl.x - anchor.x) * 1.5, y: anchor.y + (oldControl.y - anchor.y) * 1.5 });
+  });
+  it('rejects a resize that would collapse a connected neighbour without partially changing the room', () => {
+    floor().walls.push({ ...floor().walls[0], id: 'extension', start: { x: 400, y: 0 }, end: { x: 600, y: 0 } });
+    const before = serialized();
+    expect(resizeWallLength('a-0', 600)).toContain('collapse');
+    expect(serialized()).toBe(before); expect(get(undoHistoryStore).entries).toHaveLength(0);
+  });
+  it.each([NaN, Infinity, -Infinity, 0, -25, 0.5])('rejects invalid length %s without touching history or project', length => {
+    const before = serialized();
+    expect(resizeWallLength('a-0', length)).toBeTruthy();
+    expect(serialized()).toBe(before); expect(get(undoHistoryStore).entries).toHaveLength(0);
+  });
+  it('does not create history for a missing wall or an unchanged length, and keeps redo intact', () => {
+    resizeWallLength('a-0', 500); undo();
+    const before = serialized();
+    expect(resizeWallLength('missing', 500)).toBeTruthy();
+    expect(resizeWallLength('a-0', 400)).toBeNull();
+    expect(serialized()).toBe(before); expect(get(undoHistoryStore).entries).toHaveLength(0);
+    redo(); expect(wallLength(floor().walls[0])).toBe(500);
+  });
+  it('rejects invalid coordinates and zero-length source walls', () => {
+    const wall = floor().walls[0];
+    expect(() => planWallResize([{ ...wall, end: { ...wall.start } }], wall.id, 500)).toThrow('too short');
+    expect(() => planWallResize([{ ...wall, end: { x: Infinity, y: 0 } }], wall.id, 500)).toThrow();
+  });
+});
+
+describe('dimension mutation safety', () => {
+  it.each([0, -1, NaN, Infinity])('rejects invalid positive dimension %s atomically', value => {
+    const before = serialized();
+    updateWall('a-0', { thickness: value, color: '#000000' });
+    updateDoor('door', { width: value, height: value, type: 'single' });
+    updateWindow('window', { width: value, height: value, type: 'fixed' });
+    expect(serialized()).toBe(before); expect(get(undoHistoryStore).entries).toHaveLength(0);
+  });
+  it.each([-0.01, 1.01, NaN, Infinity])('rejects invalid opening position %s without poisoning saves', position => {
+    const before = serialized();
+    updateDoor('door', { position }); updateWindow('window', { position });
+    expect(serialized()).toBe(before); expect(get(undoHistoryStore).entries).toHaveLength(0);
+  });
+  it('accepts fractional dimensions and zero sill/endpoint positions and undoes them', () => {
+    updateDoor('door', { width: 95.125, height: 207.75, position: 0 });
+    updateWindow('window', { width: 125.875, height: 130.25, sillHeight: 0, position: 1 });
+    expect(floor().doors[0]).toMatchObject({ width: 95.125, height: 207.75, position: 0 });
+    expect(floor().windows[0]).toMatchObject({ width: 125.875, height: 130.25, sillHeight: 0, position: 1 });
+    undo(); expect(floor().windows[0].sillHeight).toBe(85.25);
+    undo(); expect(floor().doors[0].width).toBe(90.5);
+  });
+  it('rejects non-finite points and invalid sills, and ignores missing/unchanged edits', () => {
+    const before = serialized();
+    updateWall('a-0', { start: { x: NaN, y: 0 } });
+    updateWall('a-0', { curvePoint: { x: 0, y: Infinity } });
+    updateWindow('window', { sillHeight: -1 });
+    updateDoor('door', { width: 90.5 }); updateWindow('window', { height: 120.5 }); updateWall('a-0', { thickness: 15 });
+    updateWall('missing', { thickness: 20 }); updateDoor('missing', { width: 90 }); updateWindow('missing', { width: 90 });
+    expect(serialized()).toBe(before); expect(get(undoHistoryStore).entries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Changes
Editing a wall length previously moved only that wall, separating joined corners and losing detected rooms. Numeric resizing now keeps either endpoint fixed, moves joined wall endpoints together, and rejects changes that would collapse a neighbor. Openings keep their relative positions and room metadata is preserved.

Wall and opening dimension fields preserve fractional values, ignore invalid drafts, and avoid changing geometry when rounded imperial values merely receive focus. Desktop properties now occupy sidebar space so the layer list stays clickable.

Closes #45.

## Validation
- 281 unit tests pass, including 25 connected resizing and dimension validation cases.
- Svelte check: zero errors; production build passes.
- All 10 browser workflows pass on the final commit, including new 1440px and 390px coverage of connected rooms, undo/redo, invalid input, imperial length/height/thickness precision, export/reload, and 3D rendering.
- Final CI: https://github.com/laanlabs/openPlan3D/actions/runs/34052681722 (281 unit tests, 10 browser workflows, zero audit vulnerabilities; 24 existing Svelte warnings).
- Interactive production-build browser checks passed on desktop and phone layouts, including pointer layer selection, both fixed endpoints, invalid drafts, exact metric heights after visiting imperial fields, and mobile 3D. No browser errors.
- No Firebase Storage, backend schema, or iPhone compatibility changes.

See docs/reviews/2026-09-06-connected-wall-dimensions.md for scope and remaining limitations.
