### PR TITLE
Protect native project imports and version recovery

### DIFF
--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -331,3 +331,11 @@ length changes. It adds fixed-endpoint selection, invalid/blank dimension recove
 fractional lengths, consistent undo/redo, and simultaneous access to layers and
 properties on desktop. See [the batch report](2026-09-06-connected-wall-dimensions.md).
 No Firebase Storage or iPhone schema changes are introduced.
+
+## Eleventh batch: native project validation and recovery
+
+Issue #47 validates native JSON before replacing the active plan, supports older
+files with missing arrays, and protects reopening/duplicate/version-restoration
+paths from malformed geometry. Damaged files and history retain raw-backup paths.
+See [the batch report](2026-09-06-native-project-validation.md). All processing
+remains local with no added Firebase Storage usage.

--- a/docs/reviews/2026-09-06-native-project-validation.md
+++ b/docs/reviews/2026-09-06-native-project-validation.md
@@ -41,8 +41,8 @@ nested validation.
 house templates, generated iPhone handoffs, legacy defaults, rejected fields,
 local-load failures and snapshot recovery. Added desktop and phone-width browser
 workflows cover atomic native import rejection, unchanged saved bytes, undo/redo,
-legacy welcome import, save/reload/3D, raw-library backup and failed snapshot
-restoration. The linked PR records final CI and live browser results.
+native/RoomPlan welcome imports, save/reload/3D, raw-library backup and failed snapshot
+restoration, including unreadable history containers. The linked PR records final CI and live browser results.
 
 All work remains in the browser. No schema version, hosted service, Firebase
 Storage operation or iPhone export changes are introduced. This does not migrate

--- a/docs/reviews/2026-09-06-native-project-validation.md
+++ b/docs/reviews/2026-09-06-native-project-validation.md
@@ -1,0 +1,50 @@
+# Native project validation — September 6, 2026
+
+Issue #47 closes an import/recovery gap: native JSON imports checked floor IDs and
+wall arrays, but could replace the current plan with a wall whose start point was
+null. The renderer then encountered malformed geometry, and autosave could persist
+it. Welcome imports, saved-project reopening and version restoration did not share
+nested validation.
+
+## Changes
+
+- A shared native-project reader checks known geometry, arrays, identifiers,
+  opening references, dimensions, dates and attachment metadata before editor
+  state changes. Errors identify the failing field. Failed imports preserve the
+  current floor, selection, geometry, undo/redo and saved library.
+- The reader clones its input and fills missing legacy arrays and defaults. It
+  preserves fractional dimensions, mirrored furniture, zero wall heights/sills,
+  named rooms, floor elevations, embedded images and unknown extension metadata.
+  Missing dates use the Unix epoch; an absent/stale active floor uses the first
+  floor. Explicitly malformed values are rejected rather than treated as absent.
+- Floor-local IDs remain supported. Obsolete room/group memberships are retained
+  because deleting geometry can leave historical metadata. Unknown catalog IDs
+  remain available for future catalog support. Unsupported door/window/stair
+  types fail explicitly. This is structural validation, not a constraint solver
+  or a guarantee that a drawn plan represents a physically buildable building.
+- Toolbar and welcome imports use the same reader. Welcome also accepts the
+  RoomPlan JSON advertised by its existing interface, using the existing lazy
+  import adapter. Invalid imports use a dismissible error instead of a browser
+  alert, and the file input resets so selecting the same file can retry.
+- Saved-project reopening validates before loading and verifies the library entry
+  ID. No read migrates or rewrites stored bytes. Damaged projects remain available
+  through the existing raw-library backup; other entries are unchanged.
+- Snapshot restoration validates before replacing the current plan, verifies the
+  project ID and leaves the history panel open on failure. Raw version history
+  can be downloaded for recovery. Unreadable history containers are not replaced
+  by autosnapshot attempts. The existing ten-version bound is unchanged for
+  readable history.
+
+## Validation and cost
+
+345 unit tests pass, including 64 new cases covering the reader, all shipped
+house templates, generated iPhone handoffs, legacy defaults, rejected fields,
+local-load failures and snapshot recovery. Added desktop and phone-width browser
+workflows cover atomic native import rejection, unchanged saved bytes, undo/redo,
+legacy welcome import, save/reload/3D, raw-library backup and failed snapshot
+restoration. The linked PR records final CI and live browser results.
+
+All work remains in the browser. No schema version, hosted service, Firebase
+Storage operation or iPhone export changes are introduced. This does not migrate
+localStorage to IndexedDB or resolve the client-distribution and budget work in
+issue #30.

--- a/docs/reviews/2026-09-06-native-project-validation.md
+++ b/docs/reviews/2026-09-06-native-project-validation.md
@@ -28,7 +28,9 @@ nested validation.
   alert, and the file input resets so selecting the same file can retry.
 - Saved-project reopening validates before loading and verifies the library entry
   ID. No read migrates or rewrites stored bytes. Damaged projects remain available
-  through the existing raw-library backup; other entries are unchanged.
+  through the existing raw-library backup; other entries are unchanged. Library
+  maps treat reserved object-property names as project IDs, and project links
+  encode IDs so imported punctuation cannot cause a false save or broken link.
 - Snapshot restoration validates before replacing the current plan, verifies the
   project ID and leaves the history panel open on failure. Raw version history
   can be downloaded for recovery. Unreadable history containers are not replaced
@@ -37,7 +39,7 @@ nested validation.
 
 ## Validation and cost
 
-345 unit tests pass, including 64 new cases covering the reader, all shipped
+350 unit tests pass, including 69 new cases covering the reader, all shipped
 house templates, generated iPhone handoffs, legacy defaults, rejected fields,
 local-load failures and snapshot recovery. Added desktop and phone-width browser
 workflows cover atomic native import rejection, unchanged saved bytes, undo/redo,

--- a/src/lib/components/WelcomeScreen.svelte
+++ b/src/lib/components/WelcomeScreen.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { isRoomPlanJson } from '$lib/utils/roomplanValidation';
+  import { readProject } from '$lib/utils/projectValidation';
+  import ImportError from '$lib/components/ImportError.svelte';
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { autoSave } from '$lib/stores/saveStatus';
@@ -7,6 +10,7 @@
 
   let { onDismiss }: { onDismiss: () => void } = $props();
 
+  let importError = $state<string | null>(null);
   let showTour = $state(false);
   let tourStep = $state(0);
 
@@ -52,21 +56,22 @@
     const input = e.target as HTMLInputElement;
     const file = input.files?.[0];
     if (!file) return;
+    importError = null;
     try {
-      const text = await file.text();
-      const data = JSON.parse(text);
-      // If it looks like a project, load it
-      if (data.id && data.floors) {
-        data.updatedAt = new Date();
-        loadProject(data);
-        await autoSave();
-        markSeen();
-        goto(`${base}/editor?id=${data.id}`);
-      } else {
-        alert('Unrecognized file format');
-      }
-    } catch {
-      alert('Failed to parse file');
+      const data = JSON.parse(await file.text());
+      const project = isRoomPlanJson(data)
+        ? (await import('$lib/utils/roomplanImport')).createProjectFromRoomPlan(data, file.name.replace(/\.json$/i, ''))
+        : readProject(data);
+      project.updatedAt = new Date();
+      loadProject(project);
+      await autoSave();
+      markSeen();
+      goto(`${base}/editor?id=${encodeURIComponent(project.id)}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Could not read this file.';
+      importError = message.includes('No project was imported.') ? message : `${message} No project was imported.`;
+    } finally {
+      input.value = '';
     }
   }
 
@@ -86,6 +91,8 @@
 </script>
 
 <input type="file" accept=".json" class="hidden" bind:this={fileInput} onchange={onFileSelected} />
+
+{#if importError}<ImportError message={importError} onDismiss={() => importError = null} />{/if}
 
 <!-- Backdrop -->
 <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">

--- a/src/lib/components/toolbar/TopBar.svelte
+++ b/src/lib/components/toolbar/TopBar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { readProject } from '$lib/utils/projectValidation';
   import ImportError from '$lib/components/ImportError.svelte';
   import { onMount, onDestroy } from 'svelte';
   import { base } from '$app/paths';
@@ -6,7 +7,7 @@
   import type { FloorSeed } from '$lib/stores/project';
   import { currentProject, viewMode, undo, redo, addFloor, removeFloor, setActiveFloor, updateProjectName, loadProject, createDefaultProject, snapEnabled, canvasZoom, panMode, showFurnitureStore, layerVisibility, activeFloor, selectedElementId, elevationWallId, elevationPickMode } from '$lib/stores/project';
   import { get } from 'svelte/store';
-  import type { Floor, Project } from '$lib/models/types';
+  import type { Floor } from '$lib/models/types';
   import { exportAsPNG, exportAsJSON, exportAsSVG, exportPDF } from '$lib/utils/export';
   import { exportDXF, exportDWG } from '$lib/utils/cadExport';
   import { createProjectFromRoomPlan, extractRoomJsonFromZip, isRoomPlanJson } from '$lib/utils/roomplanImport';
@@ -256,30 +257,12 @@
           : JSON.parse(await file.text());
         if (isRoomPlanJson(data)) {
           loadProject(createProjectFromRoomPlan(data, file.name.replace(/\.(json|zip)$/i, '')));
-        } else if (data.floors && data.id) {
-          // Validate project structure
-          if (!Array.isArray(data.floors) || data.floors.length === 0) {
-            importError = 'Invalid project file: "floors" must be a non-empty array.';
-            return;
-          }
-          for (const fl of data.floors) {
-            if (!fl.id || !Array.isArray(fl.walls)) {
-              importError = 'Invalid project file: each floor must have an "id" and "walls" array.';
-              return;
-            }
-          }
-          if (!data.activeFloorId || !data.floors.some((f: any) => f.id === data.activeFloorId)) {
-            data.activeFloorId = data.floors[0].id;
-          }
-          // Revive dates
-          if (data.createdAt) data.createdAt = new Date(data.createdAt);
-          if (data.updatedAt) data.updatedAt = new Date(data.updatedAt);
-          loadProject(data as Project);
         } else {
-          importError = 'Unrecognized file format. Expected a project file or Apple RoomPlan JSON.';
+          loadProject(readProject(data));
         }
       } catch (e: any) {
-        importError = e.message;
+        const message = e?.message ?? 'Could not read this file.';
+        importError = message.includes('No project was imported.') ? message : `${message} No project was imported.`;
       }
     };
     input.click();

--- a/src/lib/components/toolbar/VersionHistoryPanel.svelte
+++ b/src/lib/components/toolbar/VersionHistoryPanel.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-  import { snapshotsStore, refreshSnapshots, restoreSnapshot, deleteAllSnapshots, type Snapshot } from '$lib/stores/versionHistory';
+  import { onDestroy } from 'svelte';
+  import { snapshotError, downloadSnapshotBackup, snapshotsStore, refreshSnapshots, restoreSnapshot, deleteAllSnapshots, type Snapshot } from '$lib/stores/versionHistory';
   import { currentProject } from '$lib/stores/project';
   import { get } from 'svelte/store';
 
   let { open = $bindable(false) } = $props();
 
   let snapshots: Snapshot[] = $state([]);
-  snapshotsStore.subscribe(v => { snapshots = v; });
+  onDestroy(snapshotsStore.subscribe(v => { snapshots = v; }));
 
   $effect(() => {
     if (open) refreshSnapshots();
@@ -26,15 +27,21 @@
     const p = get(currentProject);
     if (!p) return;
     if (!confirm('Restore this version? Current unsaved changes will be lost.')) return;
-    restoreSnapshot(p.id, index);
-    open = false;
+    if (restoreSnapshot(p.id, index)) open = false;
   }
 
   function onClearAll() {
     const p = get(currentProject);
     if (!p) return;
     if (!confirm('Delete all version history for this project?')) return;
-    deleteAllSnapshots(p.id);
+    try { deleteAllSnapshots(p.id); }
+    catch { snapshotError.set('Could not clear version history. Allow site storage and try again.'); }
+  }
+  function backupHistory() {
+    const project = get(currentProject);
+    if (!project) return;
+    try { downloadSnapshotBackup(project.id); }
+    catch (error) { snapshotError.set(error instanceof Error ? error.message : 'Could not download version history.'); }
   }
 </script>
 
@@ -42,7 +49,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center" onclick={() => open = false} onkeydown={(e) => { if (e.key === 'Escape') open = false; }}>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="bg-white rounded-xl shadow-2xl w-96 max-h-[70vh] flex flex-col" onclick={(e) => e.stopPropagation()} onkeydown={() => {}}>
+  <div role="dialog" aria-label="Version History" aria-modal="true" tabindex="-1" class="bg-white rounded-xl shadow-2xl w-96 max-w-[calc(100vw-2rem)] max-h-[70vh] flex flex-col" onclick={(e) => e.stopPropagation()} onkeydown={() => {}}>
     <div class="flex items-center justify-between px-4 py-3 border-b border-gray-100">
       <h2 class="text-sm font-semibold text-gray-800 flex items-center gap-2">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
@@ -53,21 +60,27 @@
       </button>
     </div>
 
+    {#if $snapshotError}
+      <div role="alert" class="mx-4 my-2 rounded-lg bg-red-50 p-3 text-sm text-red-800">
+        <p>{$snapshotError}</p>
+        <button class="mt-2 underline font-semibold" onclick={backupHistory}>Download version backup</button>
+      </div>
+    {/if}
     <div class="flex-1 overflow-y-auto px-4 py-2">
-      {#if snapshots.length === 0}
+      {#if snapshots.length === 0 && !$snapshotError}
         <p class="text-sm text-gray-400 text-center py-8">No snapshots yet.<br>Versions are saved automatically every 5 minutes.</p>
       {:else}
         <div class="space-y-1">
           {#each [...snapshots].reverse() as snap, i}
             {@const realIndex = snapshots.length - 1 - i}
-            <div class="flex items-center justify-between py-2 px-2 rounded-lg hover:bg-gray-50 group transition-colors">
+            <div role="group" aria-label={snap.description} class="flex items-center justify-between py-2 px-2 rounded-lg hover:bg-gray-50 group transition-colors">
               <div class="flex-1 min-w-0">
                 <div class="text-sm font-medium text-gray-700 truncate">{snap.description}</div>
                 <div class="text-xs text-gray-400">{formatTime(snap.timestamp)}</div>
               </div>
               <button
                 onclick={() => onRestore(realIndex)}
-                class="text-xs px-2.5 py-1 bg-blue-50 text-blue-600 rounded-md hover:bg-blue-100 transition-colors opacity-0 group-hover:opacity-100 font-medium shrink-0 ml-2"
+                class="text-xs px-2.5 py-1 bg-blue-50 text-blue-600 rounded-md hover:bg-blue-100 transition-colors opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 font-medium shrink-0 ml-2"
               >
                 Restore
               </button>
@@ -77,7 +90,7 @@
       {/if}
     </div>
 
-    {#if snapshots.length > 0}
+    {#if snapshots.length > 0 || $snapshotError}
       <div class="px-4 py-2 border-t border-gray-100">
         <button onclick={onClearAll} class="text-xs text-red-400 hover:text-red-600 transition-colors">
           Clear all versions

--- a/src/lib/services/datastore.ts
+++ b/src/lib/services/datastore.ts
@@ -1,3 +1,4 @@
+import { readProject } from '$lib/utils/projectValidation';
 import type { Project } from '$lib/models/types';
 
 export interface DataStore {
@@ -61,19 +62,9 @@ export const localStore: DataStore = {
     const all = getAll();
     const raw = all[id];
     if (!raw) return null;
-    const p = JSON.parse(raw);
-    p.createdAt = new Date(p.createdAt);
-    p.updatedAt = new Date(p.updatedAt);
-    // Migrate floors: ensure all array fields exist
-    for (const floor of (p.floors ?? [])) {
-      if (!floor.rooms) floor.rooms = [];
-      if (!floor.doors) floor.doors = [];
-      if (!floor.windows) floor.windows = [];
-      if (!floor.furniture) floor.furniture = [];
-      if (!floor.stairs) floor.stairs = [];
-      if (!floor.columns) floor.columns = [];
-    }
-    return p as Project;
+    const project = readProject(JSON.parse(raw));
+    if (project.id !== id) throw new Error('The saved project ID does not match its library entry. Download a library backup before recovery.');
+    return project;
   },
 
   async list() {

--- a/src/lib/services/datastore.ts
+++ b/src/lib/services/datastore.ts
@@ -21,7 +21,8 @@ function getAll(): Record<string, string> {
         Object.values(all).some(value => typeof value !== 'string')) {
       throw new Error('Invalid project library');
     }
-    return all;
+    // Imported IDs are data, including names such as "__proto__" and "constructor".
+    return Object.assign(Object.create(null), all);
   } catch {
     throw new Error('The saved project library could not be read. Download a backup before attempting recovery.');
   }

--- a/src/lib/stores/versionHistory.ts
+++ b/src/lib/stores/versionHistory.ts
@@ -1,5 +1,6 @@
 import { writable, get } from 'svelte/store';
 import { currentProject, loadProject } from './project';
+import { readProject } from '$lib/utils/projectValidation';
 import type { Project } from '$lib/models/types';
 
 export interface Snapshot {
@@ -15,13 +16,30 @@ function storageKey(projectId: string): string {
   return `vh_${projectId}`;
 }
 
+export const snapshotError = writable<string | null>(null);
+
 export function getSnapshots(projectId: string): Snapshot[] {
+  const raw = localStorage.getItem(storageKey(projectId));
+  if (raw === null) return [];
   try {
-    const raw = localStorage.getItem(storageKey(projectId));
-    return raw ? JSON.parse(raw) : [];
+    const snapshots = JSON.parse(raw);
+    if (!Array.isArray(snapshots) || snapshots.some(item => !item ||
+        typeof item.timestamp !== 'number' || !Number.isFinite(item.timestamp) ||
+        typeof item.description !== 'string' || typeof item.data !== 'string')) throw new Error();
+    return snapshots;
   } catch {
-    return [];
+    throw new Error('Version history could not be read. Download a backup before clearing damaged versions.');
   }
+}
+
+/** Keep the raw history bytes available even if a snapshot cannot be opened. */
+export function downloadSnapshotBackup(projectId: string) {
+  const raw = localStorage.getItem(storageKey(projectId));
+  if (raw === null) throw new Error('No saved version history was found.');
+  const url = URL.createObjectURL(new Blob([raw], { type: 'application/json' }));
+  const link = document.createElement('a');
+  link.href = url; link.download = 'openplan3d-version-history-backup.json'; link.click();
+  URL.revokeObjectURL(url);
 }
 
 function persistSnapshots(projectId: string, snapshots: Snapshot[]) {
@@ -40,7 +58,12 @@ function persistSnapshots(projectId: string, snapshots: Snapshot[]) {
 }
 
 export function saveSnapshot(project: Project, description: string) {
-  const snapshots = getSnapshots(project.id);
+  let snapshots: Snapshot[];
+  try { snapshots = getSnapshots(project.id); }
+  catch (error) {
+    snapshotError.set(error instanceof Error ? error.message : 'Could not read version history.');
+    return; // Never replace an unreadable history with a new, empty one.
+  }
   snapshots.push({
     timestamp: Date.now(),
     description,
@@ -55,16 +78,16 @@ export function saveSnapshot(project: Project, description: string) {
 }
 
 export function restoreSnapshot(projectId: string, index: number): boolean {
-  const snapshots = getSnapshots(projectId);
-  if (index < 0 || index >= snapshots.length) return false;
   try {
-    const project = JSON.parse(snapshots[index].data) as Project;
-    if (project.createdAt) project.createdAt = new Date(project.createdAt as any);
-    if (project.updatedAt) project.updatedAt = new Date(project.updatedAt as any);
+    const snapshots = getSnapshots(projectId);
+    if (!Number.isInteger(index) || index < 0 || index >= snapshots.length) throw new Error('This version is no longer available.');
+    const project = readProject(JSON.parse(snapshots[index].data));
+    if (project.id !== projectId) throw new Error('This version belongs to a different project.');
     loadProject(project);
+    snapshotError.set(null);
     return true;
-  } catch (e) {
-    console.error('[VersionHistory] Failed to restore snapshot:', e);
+  } catch (error) {
+    snapshotError.set(`${error instanceof Error ? error.message : 'Could not read this version.'} Your current plan has not changed.`);
     return false;
   }
 }
@@ -72,6 +95,7 @@ export function restoreSnapshot(projectId: string, index: number): boolean {
 export function deleteAllSnapshots(projectId: string) {
   localStorage.removeItem(storageKey(projectId));
   snapshotsStore.set([]);
+  snapshotError.set(null);
 }
 
 // Reactive store for current project's snapshots
@@ -79,8 +103,13 @@ export const snapshotsStore = writable<Snapshot[]>([]);
 
 // Refresh snapshots store for current project
 export function refreshSnapshots() {
+  snapshotError.set(null);
   const p = get(currentProject);
-  if (p) snapshotsStore.set(getSnapshots(p.id));
+  try { snapshotsStore.set(p ? getSnapshots(p.id) : []); }
+  catch (error) {
+    snapshotsStore.set([]);
+    snapshotError.set(error instanceof Error ? error.message : 'Could not read version history.');
+  }
 }
 
 // Auto-snapshot timer

--- a/src/lib/utils/projectValidation.ts
+++ b/src/lib/utils/projectValidation.ts
@@ -1,0 +1,169 @@
+import type { Project } from '$lib/models/types';
+
+/** Read untrusted native files without mutating their input or the active editor. */
+export function readProject(value: unknown): Project {
+  const fail = (path: string, reason: string): never => { throw new Error(`Invalid project: ${path} ${reason}.`); };
+  const record = (value: any, path: string): Record<string, any> => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) fail(path, 'must be an object');
+    return value;
+  };
+  const text = (value: any, path: string, nonempty = false) => {
+    if (typeof value !== 'string' || (nonempty && !value.trim())) fail(path, nonempty ? 'must be nonempty text' : 'must be text');
+  };
+  const number = (value: any, path: string, min = -Infinity, max = Infinity) => {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < min || value > max) fail(path, 'must be a finite number in range');
+  };
+  const positive = (value: any, path: string) => {
+    number(value, path);
+    if (value <= 0) fail(path, 'must be greater than zero');
+  };
+  const point = (value: any, path: string) => {
+    record(value, path); number(value.x, `${path}.x`); number(value.y, `${path}.y`);
+  };
+  const list = (owner: Record<string, any>, key: string, path: string, optional = true): any[] => {
+    if (owner[key] === undefined && optional) owner[key] = [];
+    if (!Array.isArray(owner[key])) fail(`${path}.${key}`, 'must be an array');
+    return owner[key];
+  };
+  const defaults = (owner: Record<string, any>, values: Record<string, any>) => {
+    for (const [key, fallback] of Object.entries(values)) if (owner[key] === undefined) owner[key] = fallback;
+  };
+  const strings = (owner: Record<string, any>, keys: string[], path: string) => {
+    for (const key of keys) if (owner[key] !== undefined) text(owner[key], `${path}.${key}`);
+  };
+  const booleans = (owner: Record<string, any>, keys: string[], path: string) => {
+    for (const key of keys) if (owner[key] !== undefined && typeof owner[key] !== 'boolean') fail(`${path}.${key}`, 'must be a boolean');
+  };
+  const choice = (value: any, allowed: string[], path: string) => {
+    if (!allowed.includes(value)) fail(path, 'has an unsupported value');
+  };
+  const ids = (value: any, path: string) => {
+    if (!Array.isArray(value)) fail(path, 'must be an array');
+    for (const [i, id] of value.entries()) text(id, `${path}[${i}]`, true);
+  };
+  let project: Record<string, any>;
+  try { project = structuredClone(record(value, 'document')); }
+  catch (error) {
+    if (error instanceof Error && error.message.startsWith('Invalid project:')) throw error;
+    fail('document', 'could not be read');
+  }
+  text(project!.id, 'id', true);
+  defaults(project!, { name: 'Untitled Project' });
+  text(project!.name, 'name'); strings(project!, ['description'], 'document');
+  const floors = list(project!, 'floors', 'document', false);
+  if (floors.length === 0) fail('floors', 'must contain at least one floor');
+  const floorIds = new Set<string>();
+  for (const [index, floor] of floors.entries()) {
+    const path = `floors[${index}]`;
+    record(floor, path); text(floor.id, `${path}.id`, true);
+    if (floorIds.has(floor.id)) fail(`${path}.id`, 'duplicates another floor');
+    floorIds.add(floor.id);
+    defaults(floor, { name: index === 0 ? 'Ground Floor' : `Floor ${index}`, level: index });
+    text(floor.name, `${path}.name`);
+    if (!Number.isSafeInteger(floor.level)) fail(`${path}.level`, 'must be an integer');
+    if (floor.elevation !== undefined) number(floor.elevation, `${path}.elevation`);
+    const seen = new Set<string>();
+    const elements = (key: string, validate: (item: Record<string, any>, path: string) => void, optional = true) => {
+      for (const [i, item] of list(floor, key, path, optional).entries()) {
+        const itemPath = `${path}.${key}[${i}]`;
+        record(item, itemPath); text(item.id, `${itemPath}.id`, true);
+        if (seen.has(item.id)) fail(`${itemPath}.id`, 'duplicates another element on this floor');
+        seen.add(item.id); validate(item, itemPath);
+      }
+    };
+    const positioned = (item: Record<string, any>, path: string) => {
+      point(item.position, `${path}.position`); defaults(item, { rotation: 0 }); number(item.rotation, `${path}.rotation`);
+    };
+    elements('walls', (wall, path) => {
+      point(wall.start, `${path}.start`); point(wall.end, `${path}.end`);
+      positive(wall.thickness, `${path}.thickness`);
+      for (const key of ['startHeight', 'endHeight']) if (wall[key] !== undefined) number(wall[key], `${path}.${key}`, 0);
+      defaults(wall, { height: Math.max(wall.startHeight ?? 280, wall.endHeight ?? 280), color: '#444444' });
+      number(wall.height, `${path}.height`, 0);
+      if (wall.curvePoint !== undefined) point(wall.curvePoint, `${path}.curvePoint`);
+      strings(wall, ['color', 'texture', 'interiorColor', 'interiorTexture', 'exteriorColor', 'exteriorTexture'], path);
+    }, false);
+    const walls = new Set<string>(floor.walls.map((wall: any) => wall.id));
+    for (const kind of ['doors', 'windows']) elements(kind, (opening, path) => {
+      text(opening.wallId, `${path}.wallId`, true);
+      if (!walls.has(opening.wallId)) fail(`${path}.wallId`, 'must refer to a wall on the same floor');
+      number(opening.position, `${path}.position`, 0, 1); positive(opening.width, `${path}.width`);
+      defaults(opening, kind === 'doors' ? { height: 210, type: 'single', swingDirection: 'left', flipSide: false } : { height: 120, type: 'standard', sillHeight: 90 });
+      positive(opening.height, `${path}.height`);
+      if (kind === 'doors') {
+        choice(opening.type, ['single', 'double', 'sliding', 'french', 'pocket', 'bifold', 'opening', 'garage'], `${path}.type`);
+        choice(opening.swingDirection, ['left', 'right'], `${path}.swingDirection`);
+        booleans(opening, ['flipSide'], path);
+      } else {
+        choice(opening.type, ['standard', 'fixed', 'casement', 'sliding', 'bay'], `${path}.type`);
+        number(opening.sillHeight, `${path}.sillHeight`, 0);
+      }
+    });
+    elements('furniture', (item, path) => {
+      text(item.catalogId, `${path}.catalogId`, true); positioned(item, path);
+      defaults(item, { scale: { x: 1, y: 1, z: 1 } }); record(item.scale, `${path}.scale`);
+      // Mirroring uses negative scale. Do not normalize signs or round dimensions.
+      for (const key of ['x', 'y', 'z']) number(item.scale[key], `${path}.scale.${key}`);
+      for (const key of ['width', 'depth', 'height']) if (item[key] !== undefined) positive(item[key], `${path}.${key}`);
+      strings(item, ['color', 'material'], path); booleans(item, ['locked'], path);
+    });
+    elements('stairs', (item, path) => {
+      positioned(item, path); positive(item.width, `${path}.width`); positive(item.depth, `${path}.depth`);
+      if (!Number.isSafeInteger(item.riserCount) || item.riserCount < 1) fail(`${path}.riserCount`, 'must be a positive integer');
+      defaults(item, { stairType: 'straight', direction: 'up' });
+      choice(item.stairType, ['straight', 'l-shaped', 'u-shaped', 'spiral'], `${path}.stairType`); choice(item.direction, ['up', 'down'], `${path}.direction`);
+    });
+    elements('columns', (item, path) => {
+      positioned(item, path); positive(item.diameter, `${path}.diameter`); number(item.height, `${path}.height`, 0);
+      choice(item.shape, ['round', 'square'], `${path}.shape`); defaults(item, { color: '#cccccc' }); text(item.color, `${path}.color`);
+    });
+    elements('rooms', (item, path) => {
+      // Saved room/group memberships may outlive deleted walls/objects. Preserve metadata.
+      ids(item.walls, `${path}.walls`); defaults(item, { name: '', floorTexture: 'light-oak', area: 0 });
+      strings(item, ['name', 'floorTexture', 'color', 'roomType'], path); number(item.area, `${path}.area`, 0);
+      if (item.labelOffset !== undefined) point(item.labelOffset, `${path}.labelOffset`);
+    });
+    elements('guides', (item, path) => {
+      choice(item.orientation, ['horizontal', 'vertical'], `${path}.orientation`); number(item.position, `${path}.position`);
+    });
+    for (const key of ['measurements', 'annotations']) elements(key, (item, path) => {
+      for (const key of ['x1', 'y1', 'x2', 'y2']) number(item[key], `${path}.${key}`);
+      if (key === 'annotations') { defaults(item, { offset: 40 }); number(item.offset, `${path}.offset`); strings(item, ['label'], path); }
+    });
+    elements('textAnnotations', (item, path) => {
+      number(item.x, `${path}.x`); number(item.y, `${path}.y`); text(item.text, `${path}.text`);
+      defaults(item, { fontSize: 16, color: '#1e293b', rotation: 0 });
+      positive(item.fontSize, `${path}.fontSize`); number(item.rotation, `${path}.rotation`); text(item.color, `${path}.color`);
+    });
+    elements('groups', (item, path) => { ids(item.elementIds, `${path}.elementIds`); });
+    // Avoid adding optional attachment arrays to otherwise unchanged current files.
+    if (floor.entourage !== undefined) elements('entourage', (item, path) => {
+      text(item.defId, `${path}.defId`, true); positioned(item, path); positive(item.width, `${path}.width`);
+      if (item.opacity !== undefined) number(item.opacity, `${path}.opacity`, 0, 1);
+      booleans(item, ['locked'], path);
+    });
+    if (floor.backgroundImage !== undefined) {
+      const bg = record(floor.backgroundImage, `${path}.backgroundImage`), bgPath = `${path}.backgroundImage`;
+      text(bg.dataUrl, `${bgPath}.dataUrl`, true); positioned(bg, bgPath); positive(bg.scale, `${bgPath}.scale`);
+      defaults(bg, { opacity: 0.4, locked: false }); number(bg.opacity, `${bgPath}.opacity`, 0, 1); booleans(bg, ['locked'], bgPath);
+    }
+  }
+  if (project!.activeFloorId !== undefined) text(project!.activeFloorId, 'activeFloorId');
+  if (!floorIds.has(project!.activeFloorId)) project!.activeFloorId = floors[0].id;
+  if (project!.customEntourage !== undefined) {
+    const seen = new Set<string>();
+    for (const [i, item] of list(project!, 'customEntourage', 'document').entries()) {
+      const path = `customEntourage[${i}]`; record(item, path); text(item.id, `${path}.id`, true);
+      if (seen.has(item.id)) fail(`${path}.id`, 'duplicates another custom symbol');
+      seen.add(item.id); text(item.name, `${path}.name`); text(item.dataUrl, `${path}.dataUrl`, true); positive(item.aspect, `${path}.aspect`);
+    }
+  }
+  for (const key of ['createdAt', 'updatedAt']) {
+    const value = project![key];
+    if (value !== undefined && !(value instanceof Date) && typeof value !== 'string') fail(key, 'must be a date');
+    const date = value === undefined ? new Date(0) : new Date(value);
+    if (!Number.isFinite(date.getTime())) fail(key, 'must be a valid date');
+    project![key] = date;
+  }
+  return project! as Project;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -190,7 +190,7 @@
         {#each projects as project}
           <div class="group bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-lg hover:border-gray-300 transition-all duration-200 relative">
             <!-- Thumbnail -->
-            <a href={`${base}/editor?id=${project.id}`} class="block">
+            <a href={`${base}/editor?id=${encodeURIComponent(project.id)}`} class="block">
               <div class="aspect-[4/3] bg-gray-100 relative overflow-hidden">
                 {#if thumbnails[project.id]}
                   <img src={thumbnails[project.id]} alt="" class="w-full h-full object-contain" />
@@ -214,7 +214,7 @@
                   class="font-semibold text-gray-800 text-sm bg-blue-50 border border-blue-300 rounded px-2 py-1 w-full outline-none"
                 />
               {:else}
-                <a href={`${base}/editor?id=${project.id}`} class="block">
+                <a href={`${base}/editor?id=${encodeURIComponent(project.id)}`} class="block">
                   <h3 class="font-semibold text-gray-800 text-sm truncate">{project.name || 'Untitled Project'}</h3>
                 </a>
               {/if}
@@ -235,7 +235,7 @@
                 class="absolute top-12 right-3 bg-white rounded-lg shadow-xl border border-gray-200 py-1 w-40 z-50"
                 onclick={(e) => e.stopPropagation()}
               >
-                <button onclick={() => { goto(`${base}/editor?id=${project.id}`); }} class="w-full px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 text-left flex items-center gap-2">
+                <button onclick={() => { goto(`${base}/editor?id=${encodeURIComponent(project.id)}`); }} class="w-full px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 text-left flex items-center gap-2">
                   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
                   Open
                 </button>

--- a/tests/browser/project-validation.spec.ts
+++ b/tests/browser/project-validation.spec.ts
@@ -143,3 +143,36 @@ test('a damaged version stays available for backup and cannot replace the curren
   expect(await exportProject(page)).toEqual(before);
   check();
 });
+
+test('welcome import accepts the advertised iPhone RoomPlan JSON locally', async ({ page }) => {
+  const check = observe(page);
+  await page.goto('/');
+  const pending = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: /Import a Plan/ }).click();
+  await (await pending).setFiles(resolve('tests/fixtures/handoff-roomplan.json'));
+  await expect(page.getByRole('application')).toContainText('4 walls');
+  await expect(page.getByRole('combobox', { name: 'Current floor' }).locator('option')).toHaveText(['Entry', 'Loft', 'Future Floor']);
+  const saved = await exportProject(page);
+  expect(saved.floors[0].walls[0].thickness).toBe(27.5);
+  expect(saved.floors[0].doors[0].width).toBeCloseTo(91.5);
+  await page.reload(); expect((await exportProject(page)).floors).toEqual(saved.floors);
+  check();
+});
+
+test('unreadable history remains downloadable and is not replaced by the session snapshot', async ({ page }) => {
+  const check = observe(page), source = JSON.parse(await readFile(fixture, 'utf8'));
+  await page.addInitScript(source => {
+    localStorage.setItem('floorplan_projects', JSON.stringify({ [source.id]: JSON.stringify(source) }));
+    localStorage.setItem(`vh_${source.id}`, '{damaged history bytes');
+  }, source);
+  await page.goto(`/editor?id=${source.id}`);
+  await expect(page.getByRole('application')).toContainText('1 room');
+  await page.getByRole('button', { name: 'Version History', exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'Version History', exact: true });
+  await expect(dialog.getByRole('alert')).toContainText('Version history could not be read.');
+  const pending = page.waitForEvent('download');
+  await dialog.getByRole('button', { name: 'Download version backup', exact: true }).click();
+  expect(await readFile((await (await pending).path())!, 'utf8')).toBe('{damaged history bytes');
+  expect(await page.evaluate(id => localStorage.getItem(`vh_${id}`), source.id)).toBe('{damaged history bytes');
+  check();
+});

--- a/tests/browser/project-validation.spec.ts
+++ b/tests/browser/project-validation.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Page } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const fixture = resolve('tests/fixtures/native-import.openplan.json');
+const damagedFixture = resolve('tests/fixtures/damaged-native.openplan.json');
+async function exportProject(page: Page) {
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const pending = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download JSON', exact: true }).click();
+  return JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
+}
+async function importProject(page: Page, data: unknown) {
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const pending = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+  await (await pending).setFiles({ name: 'project.json', mimeType: 'application/json', buffer: Buffer.from(JSON.stringify(data)) });
+}
+function observe(page: Page) {
+  const errors: string[] = [], external: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  page.on('request', request => {
+    if (/^https?:/.test(request.url()) && new URL(request.url()).origin !== 'http://127.0.0.1:4188') external.push(request.url());
+  });
+  return () => { expect(errors).toEqual([]); expect(external).toEqual([]); };
+}
+
+for (const width of [1440, 390]) {
+  test(`native import rejects damaged projects atomically at ${width}px`, async ({ page }, testInfo) => {
+    test.setTimeout(90_000);
+    await page.setViewportSize({ width, height: 900 });
+    const check = observe(page);
+    await page.goto('/editor');
+    const source = JSON.parse(await readFile(fixture, 'utf8'));
+    await importProject(page, source);
+    await expect(page.getByRole('application')).toContainText('1 room');
+    await page.getByRole('button', { name: 'Save', exact: true }).press('l');
+    await page.getByRole('button', { name: '─ Wall 1', exact: true }).click();
+    const thickness = page.getByRole('spinbutton', { name: 'Thickness (cm)', exact: true });
+    await thickness.fill('32.5'); await thickness.press('Tab');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    const saved = await exportProject(page), url = page.url();
+    const library = await page.evaluate(() => localStorage.getItem('floorplan_projects'));
+    const changes: [string, (project: any) => void][] = [
+      ['walls[0].start', p => p.floors[0].walls[0].start = null],
+      ['doors[0].wallId', p => p.floors[0].doors[0].wallId = 'missing'],
+      ['floors[0].furniture', p => p.floors[0].furniture = {}],
+      ['floors[1].id', p => p.floors.push(structuredClone(p.floors[0]))],
+      ['windows[0].height', p => p.floors[0].windows[0].height = -1],
+    ];
+    for (const [path, change] of changes) {
+      const damaged = structuredClone(saved); change(damaged);
+      await importProject(page, damaged);
+      await expect(page.getByRole('alert')).toContainText(path);
+      await expect(page.getByRole('alert')).toContainText('No project was imported.');
+      expect(page.url()).toBe(url);
+      expect(await exportProject(page)).toEqual(saved);
+      expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBe(library);
+      await expect(thickness).toHaveValue('32.5');
+      await page.getByRole('button', { name: 'Dismiss import error', exact: true }).click();
+    }
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    await expect(thickness).toHaveValue('20');
+    await page.getByRole('button', { name: 'Redo', exact: true }).click();
+    await expect(thickness).toHaveValue('32.5');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.reload();
+    await expect(page.getByRole('application')).toContainText('1 room');
+    expect((await exportProject(page)).floors).toEqual(saved.floors);
+    expect((await exportProject(page)).extensions).toEqual(source.extensions);
+    await page.getByRole('button', { name: '3D', exact: true }).click();
+    await expect(page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
+    await testInfo.attach(`native-import-recovery-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+    check();
+  });
+}
+
+test('welcome import recovers from a damaged file and accepts missing legacy fields', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 900 });
+  const check = observe(page);
+  await page.goto('/');
+  const importButton = page.getByRole('button', { name: /Import a Plan/ });
+  const pending = page.waitForEvent('filechooser'); await importButton.click();
+  await (await pending).setFiles(damagedFixture);
+  await expect(page.getByRole('alert')).toContainText('walls[0].start');
+  await expect(page.getByRole('heading', { name: 'Welcome', exact: true })).toBeVisible();
+  expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBeNull();
+  await page.getByRole('button', { name: 'Dismiss import error', exact: true }).click();
+  const retry = page.waitForEvent('filechooser'); await importButton.click();
+  await (await retry).setFiles(resolve('tests/fixtures/legacy-native.openplan.json'));
+  await expect(page).toHaveURL(/id=qa-legacy-native-import/);
+  await expect(page.getByRole('application')).toContainText('1 room');
+  const saved = await exportProject(page);
+  expect(saved.floors[0]).toMatchObject({ name: 'Ground Floor', level: 0, rooms: [], doors: [], windows: [], furniture: [], stairs: [], columns: [], guides: [], groups: [] });
+  expect(saved.floors[0].walls[0]).toMatchObject({ end: { x: 600.5, y: 0 }, height: 280, color: '#444444' });
+  await page.reload(); expect((await exportProject(page)).floors).toEqual(saved.floors);
+  check();
+});
+
+test('damaged saved geometry offers an exact raw backup without hiding healthy projects', async ({ page }) => {
+  const check = observe(page);
+  const damaged = await readFile(damagedFixture, 'utf8');
+  const healthy = JSON.parse(await readFile(fixture, 'utf8')); healthy.id = 'qa-healthy-neighbor';
+  const raw = JSON.stringify({ 'qa-project-import-safety': damaged, [healthy.id]: JSON.stringify(healthy) });
+  await page.addInitScript(raw => {
+    if (localStorage.getItem('floorplan_projects') === null) localStorage.setItem('floorplan_projects', raw);
+  }, raw);
+  await page.goto('/editor?id=qa-project-import-safety');
+  await expect(page.getByRole('alert')).toContainText('walls[0].start');
+  const pending = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download library backup', exact: true }).click();
+  expect(await readFile((await (await pending).path())!, 'utf8')).toBe(raw);
+  expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBe(raw);
+  await page.goto('/editor?id=qa-healthy-neighbor');
+  await expect(page.getByRole('application')).toContainText('1 room');
+  expect((await exportProject(page)).id).toBe(healthy.id);
+  expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBe(raw);
+  check();
+});
+
+test('a damaged version stays available for backup and cannot replace the current plan', async ({ page }, testInfo) => {
+  const check = observe(page), source = JSON.parse(await readFile(fixture, 'utf8'));
+  const history = JSON.stringify([{ timestamp: Date.now(), description: 'Damaged snapshot', data: await readFile(damagedFixture, 'utf8') }]);
+  await page.addInitScript(({ source, history }) => {
+    localStorage.setItem('floorplan_projects', JSON.stringify({ [source.id]: JSON.stringify(source) }));
+    localStorage.setItem(`vh_${source.id}`, history);
+  }, { source, history });
+  await page.goto(`/editor?id=${source.id}`);
+  await expect(page.getByRole('application')).toContainText('1 room');
+  const before = await exportProject(page);
+  await page.getByRole('button', { name: 'Version History', exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'Version History', exact: true });
+  page.once('dialog', modal => modal.accept());
+  await dialog.getByRole('group', { name: 'Damaged snapshot', exact: true }).getByRole('button', { name: 'Restore', exact: true }).click();
+  await expect(dialog.getByRole('alert')).toContainText('walls[0].start');
+  await expect(dialog.getByRole('alert')).toContainText('Your current plan has not changed.');
+  const raw = await page.evaluate(id => localStorage.getItem(`vh_${id}`), source.id);
+  const pending = page.waitForEvent('download');
+  await dialog.getByRole('button', { name: 'Download version backup', exact: true }).click();
+  expect(await readFile((await (await pending).path())!, 'utf8')).toBe(raw);
+  await testInfo.attach('damaged-version-recovery', { body: await page.screenshot(), contentType: 'image/png' });
+  await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+  expect(await exportProject(page)).toEqual(before);
+  check();
+});

--- a/tests/browser/project-validation.spec.ts
+++ b/tests/browser/project-validation.spec.ts
@@ -176,3 +176,23 @@ test('unreadable history remains downloadable and is not replaced by the session
   expect(await page.evaluate(id => localStorage.getItem(`vh_${id}`), source.id)).toBe('{damaged history bytes');
   check();
 });
+
+test('imported reserved and punctuated IDs save and reopen through project-library links', async ({ page }) => {
+  const check = observe(page), source = JSON.parse(await readFile(fixture, 'utf8'));
+  await page.goto('/editor');
+  for (const [i, id] of ['__proto__', 'qa project?#& spaces'].entries()) {
+    const project = { ...source, id, name: `QA unusual ID ${i}` };
+    await importProject(page, project);
+    await expect(page.getByRole('application')).toContainText('1 room');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
+    await page.getByRole('link', { name: 'Projects', exact: true }).click();
+    await page.getByRole('link', { name: project.name, exact: true }).click();
+    await expect(page.getByRole('application')).toContainText('1 room');
+    expect(new URL(page.url()).searchParams.get('id')).toBe(id);
+    const loaded = await exportProject(page);
+    expect(loaded.id).toBe(id); expect(loaded.name).toBe(project.name);
+    expect(loaded.floors[0].walls).toEqual(project.floors[0].walls);
+  }
+  check();
+});

--- a/tests/datastore.test.ts
+++ b/tests/datastore.test.ts
@@ -70,3 +70,20 @@ describe('local project persistence', () => {
     expect(data.get(key)).toBe(before);
   });
 });
+
+it('rejects damaged nested geometry on load and duplicate without rewriting the library', async () => {
+  const project = createDefaultProject('Damaged');
+  const damaged: any = JSON.parse(JSON.stringify(project));
+  damaged.floors[0].walls = [{ id: 'wall', start: null, end: { x: 200, y: 0 }, thickness: 15 }];
+  const raw = JSON.stringify({ [project.id]: JSON.stringify(damaged) }); data.set(key, raw);
+  await expect(localStore.load(project.id)).rejects.toThrow('walls[0].start');
+  await expect(localStore.duplicate(project.id)).rejects.toThrow('walls[0].start');
+  expect(data.get(key)).toBe(raw); expect(setItem).not.toHaveBeenCalled();
+});
+
+it('does not load a project under another library entry ID', async () => {
+  const project = createDefaultProject();
+  data.set(key, JSON.stringify({ wrong: JSON.stringify(project) }));
+  await expect(localStore.load('wrong')).rejects.toThrow('does not match');
+  expect(setItem).not.toHaveBeenCalled();
+});

--- a/tests/datastore.test.ts
+++ b/tests/datastore.test.ts
@@ -87,3 +87,19 @@ it('does not load a project under another library entry ID', async () => {
   await expect(localStore.load('wrong')).rejects.toThrow('does not match');
   expect(setItem).not.toHaveBeenCalled();
 });
+
+it.each(['__proto__', 'constructor', 'toString', 'a project?with#punctuation&spaces'])('round trips an imported project ID as data: %s', async id => {
+  const neighbor = createDefaultProject('Keep me'); await localStore.save(neighbor);
+  const project = { ...createDefaultProject('Imported'), id };
+  await localStore.save(project);
+  expect(await localStore.load(id)).toEqual(project);
+  expect(await localStore.load(neighbor.id)).toEqual(neighbor);
+  expect(await localStore.list()).toHaveLength(2);
+  await localStore.delete(id); expect(await localStore.load(id)).toBeNull();
+  expect(await localStore.load(neighbor.id)).toEqual(neighbor);
+});
+
+it('does not mistake inherited object properties for saved projects', async () => {
+  await expect(localStore.load('constructor')).resolves.toBeNull();
+  await expect(localStore.load('__proto__')).resolves.toBeNull();
+});

--- a/tests/fixtures/damaged-native.openplan.json
+++ b/tests/fixtures/damaged-native.openplan.json
@@ -1,0 +1,124 @@
+{
+  "id": "qa-project-import-safety",
+  "name": "QA Project Import Safety",
+  "floors": [
+    {
+      "id": "dimensions-floor",
+      "name": "Ground Floor",
+      "level": 0,
+      "walls": [
+        {
+          "id": "qa-wall-0",
+          "start": null,
+          "end": {
+            "x": 600.5,
+            "y": 0
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-1",
+          "start": {
+            "x": 600.5,
+            "y": 0
+          },
+          "end": {
+            "x": 600,
+            "y": 400
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-2",
+          "start": {
+            "x": 600,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 400
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-3",
+          "start": {
+            "x": 0,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        }
+      ],
+      "rooms": [
+        {
+          "id": "qa-named-room",
+          "name": "Kitchen & Dining",
+          "walls": [
+            "qa-wall-0",
+            "qa-wall-1",
+            "qa-wall-2",
+            "qa-wall-3"
+          ],
+          "area": 24.01,
+          "floorTexture": "light-oak",
+          "color": "#ddf2ff",
+          "roomType": "kitchen",
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "doors": [
+        {
+          "id": "qa-door",
+          "wallId": "qa-wall-0",
+          "position": 0.5,
+          "width": 90.5,
+          "height": 205.25,
+          "type": "opening",
+          "swingDirection": "left",
+          "opensInward": true
+        }
+      ],
+      "windows": [
+        {
+          "id": "qa-window",
+          "wallId": "qa-wall-1",
+          "position": 0.5,
+          "width": 110.25,
+          "height": 120.5,
+          "sillHeight": 90,
+          "type": "standard"
+        }
+      ],
+      "furniture": [],
+      "stairs": [],
+      "columns": [],
+      "guides": [],
+      "measurements": [],
+      "annotations": [],
+      "textAnnotations": [],
+      "groups": []
+    }
+  ],
+  "activeFloorId": "dimensions-floor",
+  "createdAt": "2026-09-05T00:00:00.000Z",
+  "updatedAt": "2026-09-05T00:00:00.000Z",
+  "extensions": {
+    "source": "native validation regression",
+    "revision": 7
+  }
+}

--- a/tests/fixtures/legacy-native.openplan.json
+++ b/tests/fixtures/legacy-native.openplan.json
@@ -1,0 +1,59 @@
+{
+  "id": "qa-legacy-native-import",
+  "name": "QA Legacy Native Import",
+  "floors": [
+    {
+      "id": "legacy-ground",
+      "walls": [
+        {
+          "id": "qa-wall-0",
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "end": {
+            "x": 600.5,
+            "y": 0
+          },
+          "thickness": 20
+        },
+        {
+          "id": "qa-wall-1",
+          "start": {
+            "x": 600.5,
+            "y": 0
+          },
+          "end": {
+            "x": 600,
+            "y": 400
+          },
+          "thickness": 20
+        },
+        {
+          "id": "qa-wall-2",
+          "start": {
+            "x": 600,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 400
+          },
+          "thickness": 20
+        },
+        {
+          "id": "qa-wall-3",
+          "start": {
+            "x": 0,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "thickness": 20
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/native-import.openplan.json
+++ b/tests/fixtures/native-import.openplan.json
@@ -1,0 +1,127 @@
+{
+  "id": "qa-project-import-safety",
+  "name": "QA Project Import Safety",
+  "floors": [
+    {
+      "id": "dimensions-floor",
+      "name": "Ground Floor",
+      "level": 0,
+      "walls": [
+        {
+          "id": "qa-wall-0",
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "end": {
+            "x": 600.5,
+            "y": 0
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-1",
+          "start": {
+            "x": 600.5,
+            "y": 0
+          },
+          "end": {
+            "x": 600,
+            "y": 400
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-2",
+          "start": {
+            "x": 600,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 400
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-3",
+          "start": {
+            "x": 0,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        }
+      ],
+      "rooms": [
+        {
+          "id": "qa-named-room",
+          "name": "Kitchen & Dining",
+          "walls": [
+            "qa-wall-0",
+            "qa-wall-1",
+            "qa-wall-2",
+            "qa-wall-3"
+          ],
+          "area": 24.01,
+          "floorTexture": "light-oak",
+          "color": "#ddf2ff",
+          "roomType": "kitchen",
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "doors": [
+        {
+          "id": "qa-door",
+          "wallId": "qa-wall-0",
+          "position": 0.5,
+          "width": 90.5,
+          "height": 205.25,
+          "type": "opening",
+          "swingDirection": "left",
+          "opensInward": true
+        }
+      ],
+      "windows": [
+        {
+          "id": "qa-window",
+          "wallId": "qa-wall-1",
+          "position": 0.5,
+          "width": 110.25,
+          "height": 120.5,
+          "sillHeight": 90,
+          "type": "standard"
+        }
+      ],
+      "furniture": [],
+      "stairs": [],
+      "columns": [],
+      "guides": [],
+      "measurements": [],
+      "annotations": [],
+      "textAnnotations": [],
+      "groups": []
+    }
+  ],
+  "activeFloorId": "dimensions-floor",
+  "createdAt": "2026-09-05T00:00:00.000Z",
+  "updatedAt": "2026-09-05T00:00:00.000Z",
+  "extensions": {
+    "source": "native validation regression",
+    "revision": 7
+  }
+}

--- a/tests/project-validation.test.ts
+++ b/tests/project-validation.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { readProject } from '$lib/utils/projectValidation';
+import { houseTemplates } from '$lib/utils/houseTemplates';
+import { createProjectFromRoomPlan } from '$lib/utils/roomplanImport';
+import { roomProject } from './fixtures/project';
+
+function completeProject(): any {
+  const project: any = roomProject(), floor = project.floors[0];
+  project.description = 'Preserve notes'; project.extensions = { version: 7, note: 'future metadata' };
+  floor.elevation = -325.125;
+  floor.walls[0] = { ...floor.walls[0], thickness: 21.125, startHeight: 0, endHeight: 290.75, curvePoint: { x: 200.25, y: -45.125 }, extensions: { source: 'survey' } };
+  floor.doors = [{ id: 'door', wallId: floor.walls[0].id, position: 0, width: 95.125, height: 207.25, type: 'double', swingDirection: 'right', flipSide: true }];
+  floor.windows = [{ id: 'window', wallId: floor.walls[1].id, position: 1, width: 100.5, height: 120.25, sillHeight: 0, type: 'casement' }];
+  floor.furniture = [{ id: 'chair', catalogId: 'future-catalog-item', position: { x: 80.5, y: -20.25 }, rotation: -45.5, scale: { x: -1, y: 2.5, z: -1 }, width: 81.125, depth: 60.25, height: 85.75, locked: true, material: 'Wood' }];
+  floor.stairs = [{ id: 'stair', position: { x: 50, y: 75 }, rotation: 90, width: 95.5, depth: 302.5, riserCount: 14, direction: 'down', stairType: 'l-shaped' }];
+  floor.columns = [{ id: 'column', position: { x: 40, y: 30 }, rotation: 0, shape: 'round', diameter: 25.5, height: 270.25, color: '#ccc' }];
+  floor.rooms = [{ id: 'room', name: 'Kitchen', walls: floor.walls.map((wall: any) => wall.id), area: 12.5, floorTexture: 'oak', color: '#fff', roomType: 'kitchen', labelOffset: { x: 2.25, y: -4.5 } }];
+  floor.guides = [{ id: 'guide', orientation: 'vertical', position: -2.5 }];
+  floor.measurements = [{ id: 'measurement', x1: 0, y1: 0, x2: 10.25, y2: -4.5 }];
+  floor.annotations = [{ id: 'dimension', x1: 0, y1: 0, x2: 50.75, y2: 0, offset: -40.25, label: 'Entry' }];
+  floor.textAnnotations = [{ id: 'text', x: 20.25, y: 30.75, text: 'Kitchen notes', fontSize: 16, color: '#111', rotation: 90 }];
+  floor.groups = [{ id: 'group', elementIds: ['chair', 'column'] }];
+  floor.backgroundImage = { dataUrl: 'data:image/png;base64,AA==', position: { x: -30, y: 10 }, scale: 0.5, opacity: 0, rotation: -25, locked: true };
+  floor.entourage = [{ id: 'symbol', defId: 'custom-tree', position: { x: 20, y: 30 }, rotation: 45, width: 70.125, opacity: 0, locked: true }];
+  project.customEntourage = [{ id: 'custom-tree', name: 'Tree', dataUrl: 'data:image/png;base64,AA==', aspect: 1.25 }];
+  return project;
+}
+
+describe('native project reader', () => {
+  it('round trips complete geometry, mirrored objects, zero heights/sills, attachments and extension metadata without mutation', () => {
+    const source = completeProject(), before = structuredClone(source);
+    const loaded = readProject(JSON.parse(JSON.stringify(source)));
+    expect(loaded).toEqual(source); expect(source).toEqual(before);
+    expect(loaded.floors[0]).not.toBe(source.floors[0]);
+    expect(loaded.createdAt).toBeInstanceOf(Date);
+  });
+  it.each(houseTemplates.map(template => [template.name, template.create] as const))('accepts the shipped %s template unchanged', (_, create) => {
+    const source = create(); expect(readProject(source)).toEqual(source);
+  });
+  it.each(['connected-dimensions.openplan.json', 'sloped-walls.openplan.json'])('keeps %s stable after the first legacy migration', name => {
+    const value = JSON.parse(readFileSync(`tests/fixtures/${name}`, 'utf8'));
+    const loaded = readProject(value); expect(readProject(JSON.parse(JSON.stringify(loaded)))).toEqual(loaded);
+  });
+  it('accepts generated iPhone handoff geometry and preserves every floor', () => {
+    const source = createProjectFromRoomPlan(JSON.parse(readFileSync('tests/fixtures/handoff-roomplan.json', 'utf8')), 'iPhone');
+    expect(readProject(source)).toEqual(source);
+  });
+  it('migrates only missing legacy fields and keeps input bytes unchanged', () => {
+    const source: any = { id: 'legacy', floors: [{ id: 'ground', walls: [{ id: 'wall', start: { x: 0, y: 0 }, end: { x: 250.75, y: 0 }, thickness: 15 }], doors: [{ id: 'door', wallId: 'wall', position: 0.5, width: 90.25 }] }] };
+    const before = JSON.stringify(source), loaded = readProject(source), floor = loaded.floors[0];
+    expect(JSON.stringify(source)).toBe(before);
+    expect(loaded).toMatchObject({ id: 'legacy', name: 'Untitled Project', activeFloorId: 'ground', createdAt: new Date(0), updatedAt: new Date(0) });
+    expect(floor).toMatchObject({ name: 'Ground Floor', level: 0, rooms: [], furniture: [], windows: [], stairs: [], columns: [], guides: [], measurements: [], annotations: [], textAnnotations: [], groups: [] });
+    expect(floor.walls[0]).toMatchObject({ height: 280, color: '#444444', end: { x: 250.75, y: 0 } });
+    expect(floor.doors[0]).toMatchObject({ width: 90.25, height: 210, flipSide: false, swingDirection: 'left', type: 'single' });
+  });
+  it('allows floor-local repeated IDs, obsolete metadata memberships and legacy active-floor fallback', () => {
+    const project = completeProject();
+    project.floors.push({ ...structuredClone(project.floors[0]), id: 'upper', level: 1 });
+    project.activeFloorId = 'removed-floor';
+    project.floors[0].rooms[0].walls.push('removed-wall'); project.floors[0].groups[0].elementIds.push('removed-chair');
+    const loaded = readProject(project);
+    expect(loaded.activeFloorId).toBe(project.floors[0].id);
+    expect(loaded.floors).toEqual(project.floors);
+  });
+  const bad: [string, (p: any) => void, string][] = [
+    ['null point', p => p.floors[0].walls[0].start = null, 'walls[0].start'],
+    ['string coordinate', p => p.floors[0].walls[0].end.x = '20', 'walls[0].end.x'],
+    ['nonfinite coordinate', p => p.floors[0].walls[0].end.y = Infinity, 'walls[0].end.y'],
+    ['NaN coordinate', p => p.floors[0].furniture[0].position.x = NaN, 'furniture[0].position.x'],
+    ['negative thickness', p => p.floors[0].walls[0].thickness = -1, 'walls[0].thickness'],
+    ['null height', p => p.floors[0].walls[0].height = null, 'walls[0].height'],
+    ['negative endpoint height', p => p.floors[0].walls[0].startHeight = -1, 'walls[0].startHeight'],
+    ['invalid curve', p => p.floors[0].walls[0].curvePoint.y = null, 'walls[0].curvePoint.y'],
+    ['zero opening width', p => p.floors[0].doors[0].width = 0, 'doors[0].width'],
+    ['invalid opening position', p => p.floors[0].doors[0].position = 1.01, 'doors[0].position'],
+    ['missing parent wall', p => p.floors[0].doors[0].wallId = 'missing', 'doors[0].wallId'],
+    ['negative sill', p => p.floors[0].windows[0].sillHeight = -1, 'windows[0].sillHeight'],
+    ['unsupported door type', p => p.floors[0].doors[0].type = 'future-door', 'doors[0].type'],
+    ['invalid flip', p => p.floors[0].doors[0].flipSide = 1, 'doors[0].flipSide'],
+    ['null array', p => p.floors[0].rooms = null, 'floors[0].rooms'],
+    ['object array', p => p.floors[0].furniture = {}, 'floors[0].furniture'],
+    ['null array entry', p => p.floors[0].columns = [null], 'columns[0]'],
+    ['duplicate floor', p => p.floors.push(structuredClone(p.floors[0])), 'floors[1].id'],
+    ['duplicate element', p => p.floors[0].doors[0].id = p.floors[0].walls[0].id, 'doors[0].id'],
+    ['null scale', p => p.floors[0].furniture[0].scale = null, 'furniture[0].scale'],
+    ['invalid scale', p => p.floors[0].furniture[0].scale.z = Infinity, 'furniture[0].scale.z'],
+    ['invalid dimension override', p => p.floors[0].furniture[0].width = -50, 'furniture[0].width'],
+    ['fractional risers', p => p.floors[0].stairs[0].riserCount = 1.5, 'stairs[0].riserCount'],
+    ['null column height', p => p.floors[0].columns[0].height = null, 'columns[0].height'],
+    ['invalid guide', p => p.floors[0].guides[0].orientation = 'diagonal', 'guides[0].orientation'],
+    ['invalid measurement', p => p.floors[0].measurements[0].x1 = '0', 'measurements[0].x1'],
+    ['invalid annotation', p => p.floors[0].annotations[0].offset = null, 'annotations[0].offset'],
+    ['invalid text size', p => p.floors[0].textAnnotations[0].fontSize = -16, 'textAnnotations[0].fontSize'],
+    ['invalid group', p => p.floors[0].groups[0].elementIds = 'chair', 'groups[0].elementIds'],
+    ['invalid image scale', p => p.floors[0].backgroundImage.scale = 0, 'backgroundImage.scale'],
+    ['invalid symbol opacity', p => p.floors[0].entourage[0].opacity = 2, 'entourage[0].opacity'],
+    ['invalid attachment', p => p.customEntourage[0].aspect = 0, 'customEntourage[0].aspect'],
+    ['duplicate custom symbol', p => p.customEntourage.push({ ...p.customEntourage[0] }), 'customEntourage[1].id'],
+    ['invalid date', p => p.createdAt = 'not a date', 'createdAt'],
+    ['null date', p => p.updatedAt = null, 'updatedAt'],
+    ['nonfinite elevation', p => p.floors[0].elevation = Infinity, 'floors[0].elevation'],
+  ];
+  it.each(bad)('rejects %s before changing the input', (_, change, path) => {
+    const project = completeProject(); change(project); const before = structuredClone(project);
+    expect(() => readProject(project)).toThrow(path); expect(project).toEqual(before);
+  });
+  it.each([null, [], {}, { id: 'bad', floors: [] }, { id: 'bad', floors: [null] }, { id: 'bad', floors: [{ id: 'floor' }] }])('rejects an incomplete top-level structure: %s', data => {
+    expect(() => readProject(data)).toThrow('Invalid project:');
+  });
+});

--- a/tests/version-history.test.ts
+++ b/tests/version-history.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { currentProject, loadProject, updateWall, undo, redo, undoHistoryStore } from '$lib/stores/project';
+import { getSnapshots, saveSnapshot, restoreSnapshot, refreshSnapshots, snapshotError, snapshotsStore } from '$lib/stores/versionHistory';
+import { roomProject } from './fixtures/project';
+
+let data: Map<string, string>;
+beforeEach(() => {
+  data = new Map();
+  vi.stubGlobal('localStorage', { getItem: (key: string) => data.get(key) ?? null, setItem: (key: string, value: string) => data.set(key, value), removeItem: (key: string) => data.delete(key) });
+  loadProject(roomProject()); refreshSnapshots();
+});
+const state = () => JSON.stringify(get(currentProject));
+const key = () => `vh_${get(currentProject)!.id}`;
+
+describe('version restoration safety', () => {
+  it('restores a valid version with dates and keeps retained snapshot data intact', () => {
+    const before = state(), id = get(currentProject)!.id;
+    saveSnapshot(get(currentProject)!, 'Before edit'); const raw = data.get(key());
+    updateWall('a-0', { thickness: 32.5 });
+    expect(restoreSnapshot(id, 0)).toBe(true); expect(state()).toBe(before);
+    expect(get(currentProject)!.createdAt).toBeInstanceOf(Date); expect(data.get(key())).toBe(raw);
+    expect(get(snapshotError)).toBeNull();
+  });
+  it('rejects a malformed snapshot before replacing the plan or clearing redo', () => {
+    const project = get(currentProject)!; updateWall('a-0', { thickness: 32.5 }); undo();
+    const before = state(), history = get(undoHistoryStore), damaged: any = JSON.parse(before);
+    damaged.floors[0].walls[0].start = null;
+    const raw = JSON.stringify([{ timestamp: 1, description: 'Damaged', data: JSON.stringify(damaged) }]); data.set(key(), raw);
+    expect(restoreSnapshot(project.id, 0)).toBe(false); expect(state()).toBe(before);
+    expect(get(undoHistoryStore)).toEqual(history); expect(data.get(key())).toBe(raw);
+    expect(get(snapshotError)).toContain('walls[0].start');
+    redo(); expect(get(currentProject)!.floors[0].walls[0].thickness).toBe(32.5);
+  });
+  it('does not restore a version from another project', () => {
+    const before = state(), other = roomProject();
+    data.set(key(), JSON.stringify([{ timestamp: 1, description: 'Wrong project', data: JSON.stringify(other) }]));
+    expect(restoreSnapshot(get(currentProject)!.id, 0)).toBe(false); expect(state()).toBe(before);
+    expect(get(snapshotError)).toContain('different project');
+  });
+  it.each(['{broken', 'null', '{}', '[null]', '[{"timestamp":1,"description":{},"data":"{}"}]'])('keeps unreadable history bytes and exposes recovery: %s', raw => {
+    data.set(key(), raw); expect(() => getSnapshots(get(currentProject)!.id)).toThrow('could not be read');
+    refreshSnapshots(); expect(get(snapshotsStore)).toEqual([]); expect(get(snapshotError)).toContain('Download a backup');
+    saveSnapshot(get(currentProject)!, 'Auto-save'); expect(data.get(key())).toBe(raw);
+  });
+  it('retains the existing ten-snapshot bound for readable history', () => {
+    for (let i = 0; i < 12; i++) saveSnapshot(get(currentProject)!, `Version ${i}`);
+    const entries = getSnapshots(get(currentProject)!.id);
+    expect(entries).toHaveLength(10); expect(entries[0].description).toBe('Version 2');
+  });
+});


### PR DESCRIPTION
## Changes
Malformed native JSON could replace the active plan before nested geometry was checked, allowing renderer failures and autosave of damaged data. Native imports, local project reopening and snapshot restoration now validate known geometry and references before replacing editor state. Imported IDs are stored as data and encoded in project links, including reserved property names and punctuation. Rejected files leave the plan, undo/redo and saved bytes intact.

The shared reader supports missing legacy fields and preserves fractional geometry, mirrored furniture and extension metadata. Failed version restoration stays in the history panel with a raw backup option; unreadable history is not overwritten by autosnapshot attempts. Welcome import also accepts its advertised RoomPlan JSON using the existing lazy adapter.

Closes #47.

## Validation
- 350 unit tests pass, including 69 new reader/recovery cases and every shipped template.
- Final CI passes: https://github.com/laanlabs/openPlan3D/actions/runs/34054638071 (350 unit tests, 18 production-build browser workflows, zero Svelte errors with 24 existing warnings, successful build, zero audit vulnerabilities).
- Interactive production-build checks pass on desktop and phone layouts: welcome rejection/retry, legacy defaults, unchanged current plan/undo after a bad import, save/reopen, encoded library links, and 3D. Browser logs are empty.
- Eight added browser workflows cover desktop/mobile native rejection, native/RoomPlan welcome imports, damaged saved-project backup, and snapshot/history recovery, alongside the existing ten workflows.
- No added Firebase Storage traffic or iPhone schema changes.

See docs/reviews/2026-09-06-native-project-validation.md for defaults, compatibility and limits.
