### PR TITLE
Preserve edits and saved originals when opening projects

### DIFF
--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -339,3 +339,11 @@ files with missing arrays, and protects reopening/duplicate/version-restoration
 paths from malformed geometry. Damaged files and history retain raw-backup paths.
 See [the batch report](2026-09-06-native-project-validation.md). All processing
 remains local with no added Firebase Storage usage.
+
+## Twelfth batch: preserve work when opening projects
+
+Issue #49 protects pending edits before valid imports, templates and New Project
+replace the active plan. Duplicate imported IDs open as separate local copies;
+failed saves retain backup/retry paths, and superseded file reads cannot replace
+newer work. See [the batch report](2026-09-06-safe-project-opening.md). There are
+no new Firebase Storage operations or iPhone schema changes.

--- a/docs/reviews/2026-09-06-safe-project-opening.md
+++ b/docs/reviews/2026-09-06-safe-project-opening.md
@@ -1,0 +1,47 @@
+# Safe project opening — September 6, 2026
+
+Issue #49 addresses valid imports and new-project actions replacing the current
+plan before its pending autosave completed. Reimporting a native file with an
+existing ID could also overwrite that saved library entry.
+
+## Behavior
+
+The toolbar, RoomPlan sidebar, welcome screen and project library now use one
+project-opening service. It validates the candidate before any write, saves
+pending current work, then checks that no newer edit or project switch arrived
+during preparation. A failed current save leaves that plan active with backup
+and retry feedback. Invalid imports still leave all current state and stored
+bytes untouched.
+
+An existing destination ID opens as a separate imported copy, retaining the
+file's floors, geometry and extension metadata. The existence check does not
+decode the old entry, so damaged saved entries remain available for recovery.
+The file object is not mutated. Copies get a fresh project ID and creation time;
+their floor and element IDs remain unchanged. Explicit version restoration keeps
+its existing same-project behavior.
+
+The newest opening request wins; late reads and failures from earlier requests
+are ignored. Component teardown cancels pending reads before they can replace
+work after navigation. New Project uses the same save protection and the editor's
+existing SvelteKit URL synchronization.
+
+If the candidate itself cannot be saved, it stays available in memory for JSON
+export and retry. When the library cannot be read, a fresh candidate ID avoids
+assuming any stored ID is free, and existing storage error feedback remains
+available. Unreadable library bytes are never overwritten. Importing a copy does
+consume additional local browser storage; there is no automatic eviction.
+
+## Validation and costs
+
+365 unit tests pass, including 15 new cases covering pending edits, validation
+before writes, duplicate IDs, damaged entries, unavailable storage, candidate
+write failure, concurrent edits, superseded reads and navigation cancellation.
+New browser workflows cover desktop/390 px copies, library reopening, JSON
+backup/retry, storage failure, RoomPlan and new-project preservation, delayed
+imports, welcome/library templates and 3D. Final CI and live browser results are
+recorded on the linked PR.
+
+All changes run locally. No Firebase Storage operations, hosted endpoints,
+iPhone export schema or storage rules change. Existing asset/caching and
+zero-external-request browser checks remain in place. This does not resolve the
+client distribution, legacy rule cutover or billing work in issue #30.

--- a/docs/reviews/2026-09-06-safe-project-opening.md
+++ b/docs/reviews/2026-09-06-safe-project-opening.md
@@ -25,6 +25,10 @@ are ignored. Component teardown cancels pending reads before they can replace
 work after navigation. New Project uses the same save protection and the editor's
 existing SvelteKit URL synchronization.
 
+Saved library previews wait for the canvas to redraw and fit the new plan. A
+delayed preview is discarded after a newer edit or project switch, preventing
+New Project from displaying the previous plan's thumbnail.
+
 If the candidate itself cannot be saved, it stays available in memory for JSON
 export and retry. When the library cannot be read, a fresh candidate ID avoids
 assuming any stored ID is free, and existing storage error feedback remains
@@ -33,7 +37,7 @@ consume additional local browser storage; there is no automatic eviction.
 
 ## Validation and costs
 
-365 unit tests pass, including 15 new cases covering pending edits, validation
+367 unit tests pass, including 17 new cases covering pending edits, validation
 before writes, duplicate IDs, damaged entries, unavailable storage, candidate
 write failure, concurrent edits, superseded reads and navigation cancellation.
 New browser workflows cover desktop/390 px copies, library reopening, JSON

--- a/src/lib/components/ImportError.svelte
+++ b/src/lib/components/ImportError.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  let { message, onDismiss }: { message: string; onDismiss: () => void } = $props();
+  let { message, onDismiss, title = "Couldn't import plan" }: { message: string; onDismiss: () => void; title?: string } = $props();
 </script>
 
 <div role="alert" class="fixed top-16 left-1/2 -translate-x-1/2 z-[60] w-[min(28rem,calc(100vw-2rem))] rounded-xl border border-red-200 bg-white p-4 shadow-xl">
   <div class="flex items-start justify-between gap-3">
     <div>
-      <p class="font-semibold text-red-800">Couldn't import plan</p>
+      <p class="font-semibold text-red-800">{title}</p>
       <p class="mt-1 text-sm text-gray-700">{message}</p>
-      <p class="mt-2 text-xs text-gray-500">Choose another file or retry the export from the source app.</p>
+      <p class="mt-2 text-xs text-gray-500">Check the file or save your current plan, then try again.</p>
     </div>
     <button aria-label="Dismiss import error" class="rounded px-2 py-1 text-gray-600 hover:bg-gray-100" onclick={onDismiss}>✕</button>
   </div>

--- a/src/lib/components/WelcomeScreen.svelte
+++ b/src/lib/components/WelcomeScreen.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { isRoomPlanJson } from '$lib/utils/roomplanValidation';
-  import { readProject } from '$lib/utils/projectValidation';
+  import { openProject } from '$lib/services/projectOpening';
   import ImportError from '$lib/components/ImportError.svelte';
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import { autoSave } from '$lib/stores/saveStatus';
-  import { createDefaultProject, loadProject } from '$lib/stores/project';
+  import { createDefaultProject } from '$lib/stores/project';
   import { houseTemplates } from '$lib/utils/houseTemplates';
+
+  const openingLifetime = new AbortController();
+  onDestroy(() => openingLifetime.abort());
 
   let { onDismiss }: { onDismiss: () => void } = $props();
 
@@ -26,22 +29,18 @@
     onDismiss();
   }
 
-  async function startFromScratch() {
-    const p = createDefaultProject('Untitled Project');
-    loadProject(p);
-    await autoSave();
-    markSeen();
-    goto(`${base}/editor?id=${p.id}`);
+  async function createProject(create: () => unknown) {
+    importError = null;
+    try {
+      const project = await openProject(create, 'new', openingLifetime.signal);
+      if (!project) return;
+      markSeen();
+      goto(`${base}/editor?id=${encodeURIComponent(project.id)}`);
+    } catch (error) { importError = error instanceof Error ? error.message : 'Could not open a project.'; }
   }
 
-  async function useHouseTemplate(index: number) {
-    const template = houseTemplates[index];
-    const p = template.create();
-    loadProject(p);
-    await autoSave();
-    markSeen();
-    goto(`${base}/editor?id=${p.id}`);
-  }
+  function startFromScratch() { return createProject(() => createDefaultProject('Untitled Project')); }
+  function useHouseTemplate(index: number) { return createProject(houseTemplates[index].create); }
 
   let showTemplates = $state(false);
   let showImport = $state(false);
@@ -58,13 +57,13 @@
     if (!file) return;
     importError = null;
     try {
-      const data = JSON.parse(await file.text());
-      const project = isRoomPlanJson(data)
-        ? (await import('$lib/utils/roomplanImport')).createProjectFromRoomPlan(data, file.name.replace(/\.json$/i, ''))
-        : readProject(data);
-      project.updatedAt = new Date();
-      loadProject(project);
-      await autoSave();
+      const project = await openProject(async () => {
+        const data = JSON.parse(await file.text());
+        return isRoomPlanJson(data)
+          ? (await import('$lib/utils/roomplanImport')).createProjectFromRoomPlan(data, file.name.replace(/\.json$/i, ''))
+          : data;
+      }, 'import', openingLifetime.signal);
+      if (!project) return;
       markSeen();
       goto(`${base}/editor?id=${encodeURIComponent(project.id)}`);
     } catch (error) {
@@ -92,7 +91,7 @@
 
 <input type="file" accept=".json" class="hidden" bind:this={fileInput} onchange={onFileSelected} />
 
-{#if importError}<ImportError message={importError} onDismiss={() => importError = null} />{/if}
+{#if importError}<ImportError title="Couldn’t open plan" message={importError} onDismiss={() => importError = null} />{/if}
 
 <!-- Backdrop -->
 <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">

--- a/src/lib/components/sidebar/BuildPanel.svelte
+++ b/src/lib/components/sidebar/BuildPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { openProject } from '$lib/services/projectOpening';
   import ImportError from '$lib/components/ImportError.svelte';
   import { onDestroy } from 'svelte';
   import { activateMeasurementTool, selectedTool, placingFurnitureId, placingDoorType, placingWindowType, placingStair, addStair, placingColumn, placingColumnShape, activeFloor, setBackgroundImage, canvasCamX, canvasCamY, placingEntourageId, addCustomEntourage } from '$lib/stores/project';
@@ -11,7 +12,10 @@
   import type { FurnitureDef } from '$lib/utils/furnitureCatalog';
   import FurnitureThumbnail from './FurnitureThumbnail.svelte';
   import { createProjectFromRoomPlan, extractRoomJsonFromZip, roomPlanImportOptions, validateRoomPlan, ORTHO_VERSION } from '$lib/utils/roomplanImport';
-  import { currentProject, loadProject } from '$lib/stores/project';
+  import { currentProject } from '$lib/stores/project';
+
+  const openingLifetime = new AbortController();
+  onDestroy(() => openingLifetime.abort());
 
   let importError = $state<string | null>(null);
 
@@ -254,22 +258,25 @@
     input.click();
   }
 
-  function confirmImport() {
+  async function confirmImport() {
     if (!importJsonData) return;
+    const input = importJsonData;
+    importError = null;
     try {
       // Create a new project for the imported data instead of merging into current
       const projectName = importFileName ? importFileName.replace(/\.(json|zip)$/i, '') : 'RoomPlan Import';
-      const newProject = createProjectFromRoomPlan(importJsonData, projectName, {
+      await openProject(() => createProjectFromRoomPlan(input, projectName, {
         straighten: optStraighten,
         orthogonal: optOrthogonal,
         mergeDistance: optMergeDistance,
-      });
-      loadProject(newProject);
+      }), 'import', openingLifetime.signal);
     } catch (e: any) {
-      importError = e.message;
+      if (importJsonData === input) importError = e.message;
     }
-    showImportDialog = false;
-    importJsonData = null;
+    if (importJsonData === input) {
+      showImportDialog = false;
+      importJsonData = null;
+    }
   }
 
   function cancelImport() {

--- a/src/lib/components/toolbar/TopBar.svelte
+++ b/src/lib/components/toolbar/TopBar.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { readProject } from '$lib/utils/projectValidation';
+  import { openProject } from '$lib/services/projectOpening';
   import ImportError from '$lib/components/ImportError.svelte';
   import { onMount, onDestroy } from 'svelte';
   import { base } from '$app/paths';
   import { orderedFloors } from '$lib/utils/floors';
   import type { FloorSeed } from '$lib/stores/project';
-  import { currentProject, viewMode, undo, redo, addFloor, removeFloor, setActiveFloor, updateProjectName, loadProject, createDefaultProject, snapEnabled, canvasZoom, panMode, showFurnitureStore, layerVisibility, activeFloor, selectedElementId, elevationWallId, elevationPickMode } from '$lib/stores/project';
+  import { currentProject, viewMode, undo, redo, addFloor, removeFloor, setActiveFloor, updateProjectName, createDefaultProject, snapEnabled, canvasZoom, panMode, showFurnitureStore, layerVisibility, activeFloor, selectedElementId, elevationWallId, elevationPickMode } from '$lib/stores/project';
   import { get } from 'svelte/store';
   import type { Floor } from '$lib/models/types';
   import { exportAsPNG, exportAsJSON, exportAsSVG, exportPDF } from '$lib/utils/export';
@@ -16,6 +16,9 @@
   import { saveState, saveError, lastSavedAt, manualSave, autoSave, initAutoSave } from '$lib/stores/saveStatus';
   import { initVersionHistory, stopVersionHistory, snapshotOnAction } from '$lib/stores/versionHistory';
   import VersionHistoryPanel from './VersionHistoryPanel.svelte';
+
+  const openingLifetime = new AbortController();
+  onDestroy(() => openingLifetime.abort());
 
   let importError = $state<string | null>(null);
 
@@ -196,13 +199,11 @@
     URL.revokeObjectURL(url);
   }
 
-  function newProject() {
-    if (!confirm('Create a new project? Unsaved changes will be lost.')) return;
-    const project = createDefaultProject();
-    loadProject(project);
-    history.replaceState(null, '', `${base}/editor?id=${project.id}`);
-    void autoSave();
+  async function newProject() {
+    importError = null;
     exportOpen = false;
+    try { await openProject(() => createDefaultProject(), 'new', openingLifetime.signal); }
+    catch (error) { importError = error instanceof Error ? error.message : 'Could not open a new project.'; }
   }
 
   onMount(() => {
@@ -252,14 +253,14 @@
       const file = input.files?.[0];
       if (!file) return;
       try {
-        const data = /\.zip$/i.test(file.name)
-          ? await extractRoomJsonFromZip(file)
-          : JSON.parse(await file.text());
-        if (isRoomPlanJson(data)) {
-          loadProject(createProjectFromRoomPlan(data, file.name.replace(/\.(json|zip)$/i, '')));
-        } else {
-          loadProject(readProject(data));
-        }
+        await openProject(async () => {
+          const data = /\.zip$/i.test(file.name)
+            ? await extractRoomJsonFromZip(file)
+            : JSON.parse(await file.text());
+          return isRoomPlanJson(data)
+            ? createProjectFromRoomPlan(data, file.name.replace(/\.(json|zip)$/i, ''))
+            : data;
+        }, 'import', openingLifetime.signal);
       } catch (e: any) {
         const message = e?.message ?? 'Could not read this file.';
         importError = message.includes('No project was imported.') ? message : `${message} No project was imported.`;
@@ -615,5 +616,5 @@
 {/if}
 
 {#if importError}
-  <ImportError message={importError} onDismiss={() => importError = null} />
+  <ImportError title="Couldn’t open plan" message={importError} onDismiss={() => importError = null} />
 {/if}

--- a/src/lib/services/datastore.ts
+++ b/src/lib/services/datastore.ts
@@ -2,6 +2,7 @@ import { readProject } from '$lib/utils/projectValidation';
 import type { Project } from '$lib/models/types';
 
 export interface DataStore {
+  has(id: string): Promise<boolean>;
   save(project: Project): Promise<void>;
   load(id: string): Promise<Project | null>;
   list(): Promise<{ id: string; name: string; updatedAt: string }[]>;
@@ -52,6 +53,8 @@ export function downloadLibraryBackup() {
 }
 
 export const localStore: DataStore = {
+  async has(id) { return Object.hasOwn(getAll(), id); },
+
   async save(project) {
     const all = getAll();
     all[project.id] = JSON.stringify(project);

--- a/src/lib/services/projectOpening.ts
+++ b/src/lib/services/projectOpening.ts
@@ -1,0 +1,60 @@
+import { get } from 'svelte/store';
+import type { Project } from '$lib/models/types';
+import { currentProject, loadProject } from '$lib/stores/project';
+import { autoSave, saveError, saveState } from '$lib/stores/saveStatus';
+import { readProject } from '$lib/utils/projectValidation';
+import { localStore } from './datastore';
+import { prepareToLeave } from './deployment';
+
+let latestRequest = 0;
+
+/** Validate first, preserve the current plan, then open a separate local project. */
+export async function openProject(
+  readCandidate: () => unknown | Promise<unknown>,
+  kind: 'import' | 'new' = 'import',
+  signal?: AbortSignal,
+): Promise<Project | null> {
+  const request = ++latestRequest;
+  const originId = get(currentProject)?.id;
+  const superseded = () => signal?.aborted || request !== latestRequest || get(currentProject)?.id !== originId;
+  try {
+    if (signal?.aborted) return null;
+    const candidate = readProject(await readCandidate());
+    if (superseded()) return null;
+    const previous = get(currentProject);
+    if (!await prepareToLeave()) {
+      if (superseded()) return null;
+      throw new Error(`Your current plan could not be saved. ${get(saveError) ?? 'Retry saving or download a JSON backup before opening another plan.'}`);
+    }
+    if (superseded()) return null;
+    // Test existence without decoding a damaged entry: importing a recovery file
+    // must preserve those original bytes, too.
+    const newId = () => globalThis.crypto?.randomUUID?.() ?? `project-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    let collision = candidate.id === previous?.id;
+    let storageReadable = true;
+    try { collision = await localStore.has(candidate.id) || collision; }
+    catch { storageReadable = false; }
+    if (collision || !storageReadable) {
+      let attempts = 0;
+      do {
+        if (++attempts > 5) throw new Error('Could not choose a new project ID. Try opening the file again.');
+        candidate.id = newId();
+      } while (storageReadable && await localStore.has(candidate.id));
+      if (collision) candidate.name = `${candidate.name || 'Untitled Project'} (${kind === 'import' ? 'Imported copy' : 'Copy'})`;
+      candidate.createdAt = new Date();
+    }
+    if (superseded()) return null;
+    if (get(currentProject) !== previous || get(saveState) !== 'saved') {
+      throw new Error('Your plan changed while preparing to open another one. Try again so the latest edits can be saved first.');
+    }
+    candidate.updatedAt = new Date();
+    loadProject(candidate);
+    // A candidate that cannot fit in storage is still available for local export.
+    // The previously saved plan stays in the library and normal save feedback applies.
+    await autoSave();
+    return !signal?.aborted && request === latestRequest && get(currentProject)?.id === candidate.id ? candidate : null;
+  } catch (error) {
+    if (signal?.aborted || request !== latestRequest) return null;
+    throw error;
+  }
+}

--- a/src/lib/stores/saveStatus.ts
+++ b/src/lib/stores/saveStatus.ts
@@ -88,7 +88,16 @@ async function persist(manual: boolean): Promise<boolean> {
     await localStore.save(p);
     // A completed write must not mark newer edits or another project as saved.
     if (attempt === saveAttempt && savingRevision === revision && get(currentProject) === p) {
-      captureThumbnail(p.id);
+      // The canvas may still show the previous plan immediately after an import.
+      // Let reactive updates, zoom-to-fit and a paint finish before taking a preview.
+      // Preview work must not delay the save or capture a newer revision/project.
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          if (attempt === saveAttempt && savingRevision === revision && get(currentProject) === p) {
+            captureThumbnail(p.id);
+          }
+        }));
+      }
       if (manual) saveSnapshot(p, 'Manual save');
       saveState.set('saved');
       saveError.set(null);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { localStore, storageErrorMessage, downloadLibraryBackup } from '$lib/services/datastore';
-  import { autoSave } from '$lib/stores/saveStatus';
-  import { createDefaultProject, loadProject } from '$lib/stores/project';
+  import { openProject } from '$lib/services/projectOpening';
+  import { createDefaultProject } from '$lib/stores/project';
   import WelcomeScreen from '$lib/components/WelcomeScreen.svelte';
   import { houseTemplates } from '$lib/utils/houseTemplates';
+
+  const openingLifetime = new AbortController();
+  onDestroy(() => openingLifetime.abort());
 
   let projects = $state<{ id: string; name: string; updatedAt: string }[]>([]);
   let thumbnails = $state<Record<string, string | null>>({});
@@ -51,21 +54,17 @@
     });
   });
 
-  async function createFromTemplate(index: number) {
-    const template = houseTemplates[index];
-    const p = template.create();
-    loadProject(p);
-    await autoSave();
-    showTemplateModal = false;
-    goto(`${base}/editor?id=${p.id}`);
+  async function createProject(create: () => unknown) {
+    await withLibraryError(async () => {
+      const project = await openProject(create, 'new', openingLifetime.signal);
+      if (!project) return;
+      showTemplateModal = false;
+      goto(`${base}/editor?id=${encodeURIComponent(project.id)}`);
+    });
   }
 
-  async function newProject() {
-    const p = createDefaultProject('Untitled Project');
-    loadProject(p);
-    await autoSave();
-    goto(`${base}/editor?id=${p.id}`);
-  }
+  function createFromTemplate(index: number) { return createProject(houseTemplates[index].create); }
+  function newProject() { return createProject(() => createDefaultProject('Untitled Project')); }
 
   async function deleteProject(id: string) {
     await withLibraryError(async () => {

--- a/tests/browser/project-opening.spec.ts
+++ b/tests/browser/project-opening.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test, type Page } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const fixture = resolve('tests/fixtures/native-import.openplan.json');
+async function seed(page: Page) {
+  const source = JSON.parse(await readFile(fixture, 'utf8'));
+  await page.addInitScript(source => {
+    if (!localStorage.getItem('floorplan_projects')) {
+      localStorage.setItem('floorplan_projects', JSON.stringify({ [source.id]: JSON.stringify(source) }));
+    }
+    localStorage.setItem('hasSeenWelcome', 'true');
+    // Keep edits pending throughout UI actions, independent of CI machine speed.
+    const timeout = window.setTimeout.bind(window);
+    window.setTimeout = ((handler: TimerHandler, delay?: number, ...args: any[]) =>
+      timeout(handler, delay === 1000 ? 60_000 : delay, ...args)) as typeof window.setTimeout;
+  }, source);
+  await page.goto(`/editor?id=${source.id}`);
+  await expect(page.getByRole('application')).toContainText('1 room');
+  return source;
+}
+async function rename(page: Page, name: string) {
+  await page.getByTitle('Click to rename', { exact: true }).click();
+  await page.getByRole('textbox', { name: 'Project name' }).fill(name);
+  await page.getByRole('textbox', { name: 'Project name' }).press('Enter');
+}
+async function importJSON(page: Page, file = fixture) {
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const pending = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+  await (await pending).setFiles(file);
+}
+async function exportJSON(page: Page) {
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const pending = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download JSON', exact: true }).click();
+  return JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
+}
+async function library(page: Page) {
+  return page.evaluate(() => Object.fromEntries(Object.entries(JSON.parse(localStorage.getItem('floorplan_projects')!))
+    .map(([id, raw]) => [id, JSON.parse(raw as string)])));
+}
+function observe(page: Page) {
+  const errors: string[] = [], external: string[] = [];
+  page.on('pageerror', e => errors.push(e.message));
+  page.on('request', r => {
+    if (/^https?:/.test(r.url()) && new URL(r.url()).origin !== 'http://127.0.0.1:4188') external.push(r.url());
+  });
+  return () => { expect(errors).toEqual([]); expect(external).toEqual([]); };
+}
+async function failWrites(page: Page) {
+  await page.evaluate(() => {
+    const setItem = Storage.prototype.setItem;
+    (window as any).failProjectWrites = true;
+    Storage.prototype.setItem = function(key, value) {
+      if (key === 'floorplan_projects' && (window as any).failProjectWrites) throw new DOMException('Full', 'QuotaExceededError');
+      return setItem.call(this, key, value);
+    };
+  });
+}
+
+for (const width of [1440, 390]) {
+  test(`same-ID imports preserve pending edits and reopen as separate copies at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    const check = observe(page), source = await seed(page);
+    await rename(page, 'Latest original edits');
+    expect((await library(page))[source.id].name).toBe(source.name);
+    await importJSON(page);
+    await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(`${source.name} (Imported copy)`);
+    const copy = await exportJSON(page);
+    expect(copy.id).not.toBe(source.id);
+    expect(copy.floors).toEqual(source.floors);
+    expect(copy.extensions).toEqual(source.extensions);
+    const saved = await library(page);
+    expect(Object.keys(saved)).toHaveLength(2);
+    expect(saved[source.id].name).toBe('Latest original edits');
+    expect(saved[copy.id].floors).toEqual(source.floors);
+    await page.reload();
+    expect((await exportJSON(page)).id).toBe(copy.id);
+    await page.getByRole('link', { name: width < 768 ? 'Back to Projects' : 'Projects', exact: true }).click();
+    await page.getByRole('link', { name: 'Latest original edits', exact: true }).click();
+    expect((await exportJSON(page)).id).toBe(source.id);
+    await page.getByRole('button', { name: '3D', exact: true }).click();
+    await expect(page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
+    await testInfo.attach(`preserved-original-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+    check();
+  });
+}
+
+test('a failed current save blocks import and New Project, with backup and retry', async ({ page }) => {
+  const check = observe(page), source = await seed(page);
+  await rename(page, 'Unsaved work to recover');
+  await failWrites(page);
+  const url = page.url(), originalLibrary = await library(page);
+  await importJSON(page);
+  await expect(page.getByRole('alert').filter({ hasText: 'Your current plan could not be saved' })).toBeVisible();
+  expect(page.url()).toBe(url);
+  expect((await exportJSON(page)).name).toBe('Unsaved work to recover');
+  expect(await library(page)).toEqual(originalLibrary);
+  await page.getByRole('button', { name: 'Dismiss import error', exact: true }).click();
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  await page.getByRole('button', { name: 'New Project', exact: true }).click();
+  await expect(page.getByRole('alert').filter({ hasText: 'Your current plan could not be saved' })).toBeVisible();
+  expect(page.url()).toBe(url);
+  await page.getByRole('button', { name: 'Dismiss import error', exact: true }).click();
+  const backup = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download JSON backup', exact: true }).click();
+  const recovered = JSON.parse(await readFile((await (await backup).path())!, 'utf8'));
+  expect(recovered.name).toBe('Unsaved work to recover'); expect(recovered.id).toBe(source.id);
+  await page.evaluate(() => { (window as any).failProjectWrites = false; });
+  await page.getByRole('button', { name: 'Retry save', exact: true }).click();
+  await expect(page.getByRole('alert')).toHaveCount(0);
+  await importJSON(page);
+  await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(`${source.name} (Imported copy)`);
+  expect((await library(page))[source.id].name).toBe('Unsaved work to recover');
+  check();
+});
+
+test('a failed candidate save keeps the import in memory and its original safe in the library', async ({ page }) => {
+  const check = observe(page), source = await seed(page);
+  await failWrites(page);
+  await importJSON(page);
+  await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(`${source.name} (Imported copy)`);
+  await expect(page.getByRole('alert')).toContainText('Browser storage is full');
+  const copy = await exportJSON(page);
+  expect(copy.id).not.toBe(source.id); expect(copy.floors).toEqual(source.floors);
+  expect(Object.keys(await library(page))).toEqual([source.id]);
+  expect((await library(page))[source.id]).toEqual(source);
+  await page.evaluate(() => { (window as any).failProjectWrites = false; });
+  await page.getByRole('button', { name: 'Retry save', exact: true }).click();
+  await page.reload(); expect((await exportJSON(page)).id).toBe(copy.id);
+  check();
+});
+
+test('sidebar RoomPlan import and toolbar New Project preserve pending predecessor edits', async ({ page }) => {
+  const check = observe(page), source = await seed(page);
+  await rename(page, 'Before RoomPlan import');
+  const pending = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: /Import RoomPlan iOS LiDAR scan/ }).click();
+  await (await pending).setFiles(resolve('tests/fixtures/handoff-roomplan.json'));
+  await page.getByRole('button', { name: 'Import', exact: true }).click();
+  await expect(page.getByRole('combobox', { name: 'Current floor' }).locator('option')).toHaveText(['Entry', 'Loft', 'Future Floor']);
+  expect((await library(page))[source.id].name).toBe('Before RoomPlan import');
+  const imported = await exportJSON(page);
+  await rename(page, 'Before New Project');
+  expect((await library(page))[imported.id].name).toBe(imported.name);
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  await page.getByRole('button', { name: 'New Project', exact: true }).click();
+  await expect(page.getByRole('application')).toContainText('0 walls');
+  const created = await exportJSON(page);
+  expect(created.id).not.toBe(imported.id);
+  expect((await library(page))[imported.id].name).toBe('Before New Project');
+  await page.reload(); expect((await exportJSON(page)).id).toBe(created.id);
+  check();
+});
+
+test('leaving the editor cancels a slow import before it can replace a library project', async ({ page }) => {
+  const check = observe(page), source = await seed(page);
+  await page.evaluate(() => {
+    const read = File.prototype.text;
+    File.prototype.text = function() {
+      return new Promise<string>(resolve => { (window as any).finishImportRead = async () => resolve(await read.call(this)); });
+    };
+  });
+  await importJSON(page);
+  await page.getByRole('link', { name: 'Projects', exact: true }).click();
+  await expect(page.getByRole('link', { name: source.name, exact: true })).toBeVisible();
+  await page.evaluate(async () => { await (window as any).finishImportRead(); });
+  // A later UI action ensures completion cannot navigate back or create a copy.
+  await page.getByRole('link', { name: source.name, exact: true }).click();
+  expect((await exportJSON(page)).id).toBe(source.id);
+  expect(Object.keys(await library(page))).toEqual([source.id]);
+  check();
+});
+
+test('welcome and library templates create independent saved projects', async ({ page }) => {
+  const check = observe(page);
+  await page.goto('/');
+  await page.getByRole('button', { name: /Use a Template/ }).click();
+  await page.getByRole('button', { name: /Studio Apartment/ }).click();
+  await expect(page.getByRole('application')).toContainText('walls');
+  const first = await exportJSON(page);
+  await page.getByRole('link', { name: 'Projects', exact: true }).click();
+  await page.getByRole('button', { name: 'Templates', exact: true }).click();
+  await page.getByRole('button', { name: /1-Bedroom Apartment/ }).click();
+  const second = await exportJSON(page);
+  expect(first.id).not.toBe(second.id);
+  await page.getByRole('link', { name: 'Projects', exact: true }).click();
+  await page.getByRole('button', { name: 'New Project', exact: true }).click();
+  await expect(page.getByRole('application')).toContainText('0 walls');
+  const third = await exportJSON(page);
+  expect(new Set([first.id, second.id, third.id]).size).toBe(3);
+  const saved = await library(page);
+  expect(Object.keys(saved)).toHaveLength(3);
+  expect(saved[first.id].floors).toEqual(first.floors);
+  expect(saved[second.id].floors).toEqual(second.floors);
+  check();
+});

--- a/tests/browser/project-opening.spec.ts
+++ b/tests/browser/project-opening.spec.ts
@@ -63,18 +63,19 @@ for (const width of [1440, 390]) {
   test(`same-ID imports preserve pending edits and reopen as separate copies at ${width}px`, async ({ page }, testInfo) => {
     await page.setViewportSize({ width, height: 900 });
     const check = observe(page), source = await seed(page);
+    const normalized = await exportJSON(page);
     await rename(page, 'Latest original edits');
     expect((await library(page))[source.id].name).toBe(source.name);
     await importJSON(page);
     await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(`${source.name} (Imported copy)`);
     const copy = await exportJSON(page);
     expect(copy.id).not.toBe(source.id);
-    expect(copy.floors).toEqual(source.floors);
+    expect(copy.floors).toEqual(normalized.floors);
     expect(copy.extensions).toEqual(source.extensions);
     const saved = await library(page);
     expect(Object.keys(saved)).toHaveLength(2);
     expect(saved[source.id].name).toBe('Latest original edits');
-    expect(saved[copy.id].floors).toEqual(source.floors);
+    expect(saved[copy.id].floors).toEqual(normalized.floors);
     await page.reload();
     expect((await exportJSON(page)).id).toBe(copy.id);
     await page.getByRole('link', { name: width < 768 ? 'Back to Projects' : 'Projects', exact: true }).click();
@@ -118,12 +119,13 @@ test('a failed current save blocks import and New Project, with backup and retry
 
 test('a failed candidate save keeps the import in memory and its original safe in the library', async ({ page }) => {
   const check = observe(page), source = await seed(page);
+  const normalized = await exportJSON(page);
   await failWrites(page);
   await importJSON(page);
   await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(`${source.name} (Imported copy)`);
   await expect(page.getByRole('alert')).toContainText('Browser storage is full');
   const copy = await exportJSON(page);
-  expect(copy.id).not.toBe(source.id); expect(copy.floors).toEqual(source.floors);
+  expect(copy.id).not.toBe(source.id); expect(copy.floors).toEqual(normalized.floors);
   expect(Object.keys(await library(page))).toEqual([source.id]);
   expect((await library(page))[source.id]).toEqual(source);
   await page.evaluate(() => { (window as any).failProjectWrites = false; });
@@ -142,6 +144,8 @@ test('sidebar RoomPlan import and toolbar New Project preserve pending predecess
   await expect(page.getByRole('combobox', { name: 'Current floor' }).locator('option')).toHaveText(['Entry', 'Loft', 'Future Floor']);
   expect((await library(page))[source.id].name).toBe('Before RoomPlan import');
   const imported = await exportJSON(page);
+  const importedPreview = await page.evaluate(id => localStorage.getItem(`floorplan_thumb_${id}`), imported.id);
+  expect(importedPreview).toBeTruthy();
   await rename(page, 'Before New Project');
   expect((await library(page))[imported.id].name).toBe(imported.name);
   await page.getByRole('button', { name: 'Export', exact: true }).click();
@@ -149,6 +153,8 @@ test('sidebar RoomPlan import and toolbar New Project preserve pending predecess
   await expect(page.getByRole('application')).toContainText('0 walls');
   const created = await exportJSON(page);
   expect(created.id).not.toBe(imported.id);
+  await expect.poll(() => page.evaluate(id => localStorage.getItem(`floorplan_thumb_${id}`), created.id)).toBeTruthy();
+  expect(await page.evaluate(id => localStorage.getItem(`floorplan_thumb_${id}`), created.id)).not.toBe(importedPreview);
   expect((await library(page))[imported.id].name).toBe('Before New Project');
   await page.reload(); expect((await exportJSON(page)).id).toBe(created.id);
   check();

--- a/tests/projectOpening.test.ts
+++ b/tests/projectOpening.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { openProject } from '$lib/services/projectOpening';
+import { localStore } from '$lib/services/datastore';
+import { currentProject, loadProject, updateProjectName } from '$lib/stores/project';
+import { initAutoSave, markClean, saveError, saveState } from '$lib/stores/saveStatus';
+import { roomProject } from './fixtures/project';
+
+vi.mock('$lib/stores/versionHistory', () => ({ saveSnapshot: vi.fn() }));
+let stop: () => void;
+let storage: Map<string, string>;
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  storage = new Map();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  });
+  loadProject(roomProject());
+  markClean();
+  await localStore.save(get(currentProject)!);
+  stop = initAutoSave();
+});
+afterEach(() => { stop(); markClean(); vi.useRealTimers(); });
+
+it('saves pending current edits before importing, then saves the candidate separately', async () => {
+  const previousId = get(currentProject)!.id;
+  updateProjectName('Keep these latest edits');
+  const candidate = roomProject();
+  const saved = vi.spyOn(localStore, 'save');
+  const opened = await openProject(() => candidate);
+  expect(saved.mock.calls.map(([p]) => p.id)).toEqual([previousId, candidate.id]);
+  expect((await localStore.load(previousId))!.name).toBe('Keep these latest edits');
+  expect((await localStore.load(opened!.id))!.floors).toEqual(candidate.floors);
+  expect(get(saveState)).toBe('saved');
+  expect(get(currentProject)).toBe(opened);
+});
+
+it('does not write the previous project again when it is already saved', async () => {
+  const saved = vi.spyOn(localStore, 'save');
+  await openProject(roomProject, 'new');
+  expect(saved).toHaveBeenCalledOnce();
+});
+
+it('validates before any save or state change, even with pending current edits', async () => {
+  updateProjectName('Unsaved but safe');
+  const before = get(currentProject), raw = storage.get('floorplan_projects');
+  const candidate: any = roomProject(); candidate.floors[0].walls[0].start = null;
+  const saved = vi.spyOn(localStore, 'save');
+  await expect(openProject(() => candidate)).rejects.toThrow('walls[0].start');
+  expect(saved).not.toHaveBeenCalled();
+  expect(get(currentProject)).toBe(before);
+  expect(storage.get('floorplan_projects')).toBe(raw);
+  expect(get(saveState)).toBe('unsaved');
+});
+
+it('retains current work and refuses replacement after a failed current save', async () => {
+  updateProjectName('Cannot lose this');
+  const before = get(currentProject), raw = storage.get('floorplan_projects');
+  vi.spyOn(localStore, 'save').mockRejectedValue(new DOMException('Full', 'QuotaExceededError'));
+  await expect(openProject(roomProject)).rejects.toThrow('Your current plan could not be saved. Browser storage is full');
+  expect(get(currentProject)).toBe(before);
+  expect(storage.get('floorplan_projects')).toBe(raw);
+  expect(get(saveState)).toBe('unsaved');
+});
+
+it('imports a current-ID collision as a copy without changing the input or losing pending edits', async () => {
+  const candidate = structuredClone(get(currentProject)!);
+  updateProjectName('Current revised plan');
+  const opened = await openProject(() => candidate);
+  expect(opened!.id).not.toBe(candidate.id);
+  expect(opened!.name).toBe(`${candidate.name} (Imported copy)`);
+  expect(opened!.floors).toEqual(candidate.floors);
+  expect((await localStore.load(candidate.id))!.name).toBe('Current revised plan');
+  expect(candidate.name).toBe('Regression plan');
+  expect((await localStore.list())).toHaveLength(2);
+});
+
+it('preserves a different saved entry with a colliding ID, including unreadable geometry', async () => {
+  const candidate = roomProject(); candidate.id = '__proto__';
+  const raw = JSON.parse(storage.get('floorplan_projects')!);
+  Object.defineProperty(raw, candidate.id, { value: '{original damaged bytes', enumerable: true });
+  storage.set('floorplan_projects', JSON.stringify(raw));
+  expect(await localStore.has(candidate.id)).toBe(true);
+  const opened = await openProject(() => candidate);
+  expect(opened!.id).not.toBe(candidate.id);
+  expect(JSON.parse(storage.get('floorplan_projects')!)[candidate.id]).toBe('{original damaged bytes');
+});
+
+it('keeps a candidate available for export if its own save fails after preserving the old work', async () => {
+  const previousId = get(currentProject)!.id;
+  updateProjectName('Preserved first');
+  const candidate = roomProject(), save = localStore.save;
+  vi.spyOn(localStore, 'save').mockImplementation(p => p.id === candidate.id
+    ? Promise.reject(new DOMException('Full', 'QuotaExceededError')) : save(p));
+  const opened = await openProject(() => candidate);
+  expect(get(currentProject)).toBe(opened);
+  expect(get(saveState)).toBe('unsaved');
+  expect(get(saveError)).toContain('Browser storage is full');
+  expect((await localStore.load(previousId))!.name).toBe('Preserved first');
+  expect(await localStore.has(candidate.id)).toBe(false);
+});
+
+it('can open an in-memory project without overwriting an unreadable library', async () => {
+  storage.set('floorplan_projects', '{original library bytes');
+  const candidate = roomProject();
+  const opened = await openProject(() => candidate, 'new');
+  expect(opened!.id).not.toBe(candidate.id);
+  expect(get(currentProject)).toBe(opened);
+  expect(get(saveState)).toBe('unsaved');
+  expect(get(saveError)).toContain('library could not be read');
+  expect(storage.get('floorplan_projects')).toBe('{original library bytes');
+});
+
+it('can open a first in-memory project when browser storage is denied', async () => {
+  currentProject.set(null); markClean();
+  vi.spyOn(localStorage, 'getItem').mockImplementation(() => { throw new DOMException('Denied', 'SecurityError'); });
+  const opened = await openProject(roomProject);
+  expect(get(currentProject)).toBe(opened);
+  expect(opened).not.toBeNull();
+  expect(get(saveState)).toBe('unsaved');
+  expect(get(saveError)).toContain('Browser storage is unavailable');
+});
+
+it('does not replace a current project edited during its pending save', async () => {
+  updateProjectName('First edit');
+  const write = deferred<void>(), started = deferred<void>();
+  vi.spyOn(localStore, 'save').mockImplementationOnce(() => { started.resolve(); return write.promise; });
+  const pending = openProject(roomProject);
+  await started.promise;
+  updateProjectName('Later edit');
+  write.resolve();
+  await expect(pending).rejects.toThrow('Your current plan could not be saved');
+  expect(get(currentProject)!.name).toBe('Later edit');
+  expect(get(saveState)).toBe('unsaved');
+});
+
+it('does not discard edits made while checking destination storage', async () => {
+  const checking = deferred<boolean>(), started = deferred<void>();
+  vi.spyOn(localStore, 'has').mockImplementationOnce(() => { started.resolve(); return checking.promise; });
+  const pending = openProject(roomProject);
+  await started.promise;
+  updateProjectName('Edited during destination check');
+  checking.resolve(false);
+  await expect(pending).rejects.toThrow('Your plan changed while preparing');
+  expect(get(currentProject)!.name).toBe('Edited during destination check');
+});
+
+it('lets the latest import win when an older file finishes reading later', async () => {
+  const old = deferred<unknown>();
+  const first = openProject(() => old.promise);
+  const latest = await openProject(roomProject);
+  old.resolve(roomProject());
+  expect(await first).toBeNull();
+  expect(get(currentProject)).toBe(latest);
+  expect(await localStore.list()).toHaveLength(2);
+});
+
+it('suppresses an outdated file error after a newer import succeeds', async () => {
+  const old = deferred<unknown>();
+  const first = openProject(() => old.promise);
+  const latest = await openProject(roomProject);
+  old.reject(new Error('Old file failed'));
+  expect(await first).toBeNull();
+  expect(get(currentProject)).toBe(latest);
+});
+
+it('ignores a read that completes after navigation or component teardown', async () => {
+  const old = deferred<unknown>(), lifetime = new AbortController();
+  const before = get(currentProject);
+  const pending = openProject(() => old.promise, 'import', lifetime.signal);
+  lifetime.abort(); old.resolve(roomProject());
+  expect(await pending).toBeNull();
+  expect(get(currentProject)).toBe(before);
+});
+
+it('ignores an import if another project was loaded during the file read', async () => {
+  const old = deferred<unknown>(), pending = openProject(() => old.promise);
+  const next = roomProject(); loadProject(next); markClean();
+  old.resolve(roomProject());
+  expect(await pending).toBeNull();
+  expect(get(currentProject)).toBe(next);
+});

--- a/tests/saveStatus.test.ts
+++ b/tests/saveStatus.test.ts
@@ -108,3 +108,38 @@ it('does not show another project\'s save time if creation fails outside the edi
   expect(get(lastSavedAt)).toBeNull();
   expect(get(saveError)).toContain('Browser storage is full');
 });
+
+it('saves immediately but captures a thumbnail only after the canvas redraws', async () => {
+  const frames: FrameRequestCallback[] = [];
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => frames.push(callback));
+  let renderedPlan = 'previous plan';
+  const drawImage = vi.fn();
+  vi.stubGlobal('document', {
+    querySelector: () => ({ width: 600, height: 400 }),
+    createElement: () => ({ getContext: () => ({ drawImage }), toDataURL: () => renderedPlan }),
+  });
+  const preview = vi.spyOn(localStore, 'saveThumbnail').mockImplementation(() => {});
+  expect(await autoSave()).toBe(true);
+  expect(get(saveState)).toBe('saved');
+  expect(preview).not.toHaveBeenCalled();
+  frames.shift()!(0);
+  renderedPlan = 'current plan';
+  frames.shift()!(16);
+  expect(preview).toHaveBeenCalledWith(get(currentProject)!.id, 'current plan');
+});
+
+it('discards delayed thumbnail work after a later edit or project switch', async () => {
+  const frames: FrameRequestCallback[] = [];
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => frames.push(callback));
+  const querySelector = vi.fn();
+  vi.stubGlobal('document', { querySelector });
+  await autoSave();
+  updateProjectName('Newer revision');
+  frames.shift()!(0); frames.shift()!(16);
+  expect(querySelector).not.toHaveBeenCalled();
+  await autoSave();
+  currentProject.set(createDefaultProject('Another plan'));
+  markClean();
+  frames.shift()!(32); frames.shift()!(48);
+  expect(querySelector).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
Valid imports and New Project could discard pending current edits, and importing a native file with an existing ID could overwrite that saved plan. Save pending work before replacement, open colliding IDs as separate local copies, and ignore superseded reads or imports that finish after navigation. Failed current saves retain the active plan; failed candidate saves retain the candidate for JSON backup and retry.

Toolbar, sidebar RoomPlan, welcome and library creation/template actions share the same validation and save guard. Library previews wait for the new canvas to render and discard stale capture work. All processing stays local with no Firebase Storage operations, iPhone schema changes or storage rule changes.

Validation: 367 unit tests pass; production build passes; Svelte check has 0 errors and the existing 24 warnings. Seven added browser workflows cover desktop/mobile copies, save failures, backup/retry, sidebar/New Project preservation, correct previews, delayed imports and templates. Interactive production-build checks pass for duplicate imports, original-library reopening, New Project, a 33.75 cm mobile wall edit, save/reload and 3D with no browser errors. Full 25-test browser CI and post-merge live verification are recorded below.

Closes #49.
