### PR TITLE
Prevent stale browser tabs from overwriting saved projects

### DIFF
--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -347,3 +347,11 @@ replace the active plan. Duplicate imported IDs open as separate local copies;
 failed saves retain backup/retry paths, and superseded file reads cannot replace
 newer work. See [the batch report](2026-09-06-safe-project-opening.md). There are
 no new Firebase Storage operations or iPhone schema changes.
+
+## Thirteenth batch: local save conflicts
+
+Issue #51 prevents older tabs from silently overwriting newer saved edits or
+recreating deleted projects. Current tabs coordinate library writes, retain
+conflicting work for backup and offer Save as copy. Recovery preserves later
+edits and failed-copy paths. See [the batch report](2026-09-06-local-save-conflicts.md)
+for browser compatibility limits and validation. All processing remains local.

--- a/docs/reviews/2026-09-06-local-save-conflicts.md
+++ b/docs/reviews/2026-09-06-local-save-conflicts.md
@@ -1,0 +1,51 @@
+# Local save conflicts — September 6, 2026
+
+Issue #51 addresses older browser tabs silently overwriting a newer saved project
+or recreating one deleted from the library. The entire library is stored in one
+localStorage value, so different-project writes also need coordination.
+
+## Changes
+
+- Each browser document remembers the exact stored revision it opened or saved.
+  Save compares that revision with current storage before writing. A changed,
+  deleted or unexpectedly existing project raises a conflict and leaves both
+  the saved library and in-memory work intact. Listing the library does not
+  silently rebase an open editor. Library deletion checks the listed revision.
+- Current tabs serialize library mutations under a shared Web Lock and reread the
+  library inside the lock. A queued save freezes its data before waiting; later
+  edits remain unsaved. A project reopened during the wait invalidates the old
+  save. Failed writes do not advance the remembered revision.
+- Storage events notify an open editor without replacing its plan. Conflicts
+  retain JSON backup and expose Save as copy. Normal autosave pauses for a known
+  conflict; an explicit retry still performs the revision check. Other-project
+  changes do not disturb the active plan. The listener is removed on editor exit.
+- Recovery copies are validated and saved with a fresh ID before switching the
+  editor. Full storage leaves current work active and the recovery action
+  available. Edits made while copying remain in the current tab, with feedback
+  that another copy is needed for those later edits. Delayed thumbnail writes
+  cannot overwrite previews belonging to a newer stored revision.
+- Project-library action buttons now have accessible names and remain visible
+  on touch layouts, making rename, duplicate and delete easier to find.
+
+## Validation and compatibility
+
+390 unit tests pass, including 23 new cases for separate store sessions, stale
+saves/deletes, independent writes, queued immutable data, recovery, storage
+notifications and preview protection. Five added browser workflows cover two-tab
+desktop/390 px conflicts, JSON backup, failed copy recovery, deletion,
+different-project writes and edits made while a real Web Lock delays copying.
+The PR records final CI and interactive local/live browser results.
+
+The coordination uses the browser's [Web Locks API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API)
+and [storage events](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event).
+Web Locks requires a supported secure context. Older browsers or insecure
+self-hosted sites retain revision checks but lack coordination for simultaneous
+writes. Tabs running an older app build do not participate in the new lock or
+revision checks; refresh those tabs before editing the same plan concurrently.
+This is conflict prevention and explicit copying, not collaborative editing,
+automatic geometry merging or cross-device synchronization.
+
+The file format and existing stored bytes are unchanged until an explicit save.
+No Firebase Storage operations, hosted endpoints, iPhone schema changes or live
+storage-rule changes are introduced. Issue #30's client distribution and billing
+work remains separate.

--- a/src/lib/components/toolbar/TopBar.svelte
+++ b/src/lib/components/toolbar/TopBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { openProject } from '$lib/services/projectOpening';
+  import { saveConflict, savingCopy, saveCurrentAsCopy } from '$lib/stores/saveStatus';
   import ImportError from '$lib/components/ImportError.svelte';
   import { onMount, onDestroy } from 'svelte';
   import { base } from '$app/paths';
@@ -591,7 +592,11 @@
 {#if $saveError}
   <div role="alert" class="flex flex-wrap items-center gap-3 bg-red-50 border-b border-red-200 px-4 py-3 text-sm text-red-900">
     <span class="flex-1 min-w-48">Changes are not saved. {$saveError}</span>
-    <button class="font-semibold underline" onclick={save}>Retry save</button>
+    {#if $saveConflict}
+      <button class="font-semibold underline disabled:opacity-50" disabled={$savingCopy} onclick={saveCurrentAsCopy}>{$savingCopy ? 'Saving copy…' : 'Save as copy'}</button>
+    {:else}
+      <button class="font-semibold underline" onclick={save}>Retry save</button>
+    {/if}
     <button class="font-semibold underline" onclick={onExportJSON}>Download JSON backup</button>
   </div>
 {/if}

--- a/src/lib/services/datastore.ts
+++ b/src/lib/services/datastore.ts
@@ -3,6 +3,8 @@ import type { Project } from '$lib/models/types';
 
 export interface DataStore {
   has(id: string): Promise<boolean>;
+  assertCurrent(id: string): void;
+  saveCopy(project: Project, suffix?: string): Promise<Project>;
   save(project: Project): Promise<void>;
   load(id: string): Promise<Project | null>;
   list(): Promise<{ id: string; name: string; updatedAt: string }[]>;
@@ -12,7 +14,25 @@ export interface DataStore {
   getThumbnail(id: string): string | null;
 }
 
-const KEY = 'floorplan_projects';
+export const PROJECTS_STORAGE_KEY = 'floorplan_projects';
+const KEY = PROJECTS_STORAGE_KEY;
+
+export class ProjectConflictError extends Error {
+  constructor() {
+    super('This project changed or was deleted in another tab. Save your version as a copy or download a JSON backup to keep both versions.');
+    this.name = 'ProjectConflictError';
+  }
+}
+
+/** Current tabs share one lock because localStorage holds the entire library. */
+async function mutateLibrary<T>(change: () => T): Promise<T> {
+  if (typeof window !== 'undefined' && typeof navigator !== 'undefined' && navigator.locks?.request) {
+    return navigator.locks.request('openplan3d-project-library', change);
+  }
+  // Older/insecure self-hosted contexts retain revision checks, but cannot
+  // coordinate simultaneous writes across tabs without Web Locks.
+  return change();
+}
 
 function getAll(): Record<string, string> {
   const raw = localStorage.getItem(KEY);
@@ -52,66 +72,114 @@ export function downloadLibraryBackup() {
   URL.revokeObjectURL(url);
 }
 
-export const localStore: DataStore = {
-  async has(id) { return Object.hasOwn(getAll(), id); },
+/** Each browser document remembers only revisions it actually opened or saved. */
+export function createLocalStore(): DataStore {
+  const opened = new Map<string, string | null>();
+  const listed = new Map<string, string>();
+  const generations = new Map<string, number>();
+  const entry = (all: Record<string, string>, id: string) => all[id] ?? null;
+  return {
+    async has(id) { return Object.hasOwn(getAll(), id); },
 
-  async save(project) {
-    const all = getAll();
-    all[project.id] = JSON.stringify(project);
-    // setItem is atomic on failure. Never evict another project to make space.
-    localStorage.setItem(KEY, JSON.stringify(all));
-  },
+    assertCurrent(id) {
+      if (entry(getAll(), id) !== (opened.get(id) ?? null)) throw new ProjectConflictError();
+    },
 
-  async load(id) {
-    const all = getAll();
-    const raw = all[id];
-    if (!raw) return null;
-    const project = readProject(JSON.parse(raw));
-    if (project.id !== id) throw new Error('The saved project ID does not match its library entry. Download a library backup before recovery.');
-    return project;
-  },
+    async save(project) {
+      // Freeze before waiting for a lock: callers can continue editing meanwhile.
+      const id = project.id, raw = JSON.stringify(project);
+      const generation = generations.get(id);
+      await mutateLibrary(() => {
+        const all = getAll();
+        if (generation !== generations.get(id) || entry(all, id) !== (opened.get(id) ?? null)) {
+          throw new ProjectConflictError();
+        }
+        all[id] = raw;
+        // setItem is atomic on failure. Never evict another project to make space.
+        localStorage.setItem(KEY, JSON.stringify(all));
+        opened.set(id, raw);
+      });
+    },
 
-  async list() {
-    const all = getAll();
-    return Object.values(all).map((raw) => {
-      const p = JSON.parse(raw as string);
-      return { id: p.id, name: p.name, updatedAt: p.updatedAt };
-    });
-  },
+    async saveCopy(project, suffix = 'Recovered copy') {
+      const copy = readProject(project);
+      copy.name = `${copy.name || 'Untitled Project'} (${suffix})`;
+      copy.createdAt = copy.updatedAt = new Date();
+      return mutateLibrary(() => {
+        const all = getAll();
+        let attempts = 0;
+        do {
+          if (++attempts > 5) throw new Error('Could not choose a new project ID. Try saving a copy again.');
+          copy.id = globalThis.crypto?.randomUUID?.() ?? `project-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+        } while (Object.hasOwn(all, copy.id));
+        const raw = JSON.stringify(copy);
+        all[copy.id] = raw;
+        localStorage.setItem(KEY, JSON.stringify(all));
+        opened.set(copy.id, raw);
+        return copy;
+      });
+    },
 
-  async delete(id) {
-    const all = getAll();
-    delete all[id];
-    localStorage.setItem(KEY, JSON.stringify(all));
-    // Also remove thumbnail
-    try { localStorage.removeItem(`floorplan_thumb_${id}`); } catch {}
-  },
+    async load(id) {
+      const all = getAll();
+      const raw = all[id];
+      if (raw === undefined) {
+        opened.set(id, null);
+        generations.set(id, (generations.get(id) ?? 0) + 1);
+        return null;
+      }
+      const project = readProject(JSON.parse(raw));
+      if (project.id !== id) throw new Error('The saved project ID does not match its library entry. Download a library backup before recovery.');
+      opened.set(id, raw);
+      generations.set(id, (generations.get(id) ?? 0) + 1);
+      return project;
+    },
 
-  async duplicate(id: string): Promise<Project | null> {
-    const original = await this.load(id);
-    if (!original) return null;
-    const newId = Math.random().toString(36).slice(2, 10);
-    const dup: Project = {
-      ...original,
-      id: newId,
-      name: `${original.name} (Copy)`,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-    await this.save(dup);
-    // Copy thumbnail if exists
-    try {
-      const thumb = localStorage.getItem(`floorplan_thumb_${id}`);
-      if (thumb) localStorage.setItem(`floorplan_thumb_${newId}`, thumb);
-    } catch {}
-    return dup;
-  },
+    async list() {
+      const all = getAll();
+      const projects = Object.entries(all).map(([id, raw]) => {
+        const p = JSON.parse(raw);
+        return { id, name: p.name, updatedAt: p.updatedAt };
+      });
+      // Listing must not rebase an editor's separately loaded revision.
+      listed.clear();
+      for (const [id, raw] of Object.entries(all)) listed.set(id, raw);
+      return projects;
+    },
 
-  saveThumbnail(id: string, dataUrl: string) {
-    try { localStorage.setItem(`floorplan_thumb_${id}`, dataUrl); } catch {}
-  },
+    async delete(id) {
+      await mutateLibrary(() => {
+        const all = getAll();
+        const expected = listed.has(id) ? listed.get(id) : opened.get(id);
+        if (entry(all, id) !== (expected ?? null)) throw new ProjectConflictError();
+        delete all[id];
+        localStorage.setItem(KEY, JSON.stringify(all));
+        // Keep the old opened revision so a deleted editor cannot recreate it.
+        listed.delete(id);
+        try { localStorage.removeItem(`floorplan_thumb_${id}`); } catch {}
+      });
+    },
 
-  getThumbnail(id: string): string | null {
-    try { return localStorage.getItem(`floorplan_thumb_${id}`); } catch { return null; }
-  },
-};
+    async duplicate(id: string): Promise<Project | null> {
+      const original = await this.load(id);
+      if (!original) return null;
+      const dup = await this.saveCopy(original, 'Copy');
+      // Copy thumbnail if exists
+      try {
+        const thumb = localStorage.getItem(`floorplan_thumb_${id}`);
+        if (thumb) localStorage.setItem(`floorplan_thumb_${dup.id}`, thumb);
+      } catch {}
+      return dup;
+    },
+
+    saveThumbnail(id: string, dataUrl: string) {
+      try { this.assertCurrent(id); localStorage.setItem(`floorplan_thumb_${id}`, dataUrl); } catch {}
+    },
+
+    getThumbnail(id: string): string | null {
+      try { return localStorage.getItem(`floorplan_thumb_${id}`); } catch { return null; }
+    },
+  };
+}
+
+export const localStore = createLocalStore();

--- a/src/lib/stores/saveStatus.ts
+++ b/src/lib/stores/saveStatus.ts
@@ -1,13 +1,16 @@
 import { writable, get } from 'svelte/store';
-import { currentProject } from './project';
-import { localStore, storageErrorMessage } from '$lib/services/datastore';
+import { currentProject, loadProject } from './project';
+import { localStore, storageErrorMessage, ProjectConflictError, PROJECTS_STORAGE_KEY } from '$lib/services/datastore';
 import { saveSnapshot } from '$lib/stores/versionHistory';
+import type { Project } from '$lib/models/types';
 
 export type SaveState = 'saved' | 'unsaved' | 'saving';
 
 export const saveState = writable<SaveState>('saved');
 export const lastSavedAt = writable<Date | null>(null);
 export const saveError = writable<string | null>(null);
+export const saveConflict = writable(false);
+export const savingCopy = writable(false);
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let stopWatching: (() => void) | null = null;
@@ -28,12 +31,29 @@ export function initAutoSave() {
       projectId = _p.id;
       lastSavedAt.set(null);
       saveError.set(null);
+      saveConflict.set(false);
     }
     markDirty();
   });
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== null && event.key !== PROJECTS_STORAGE_KEY) return;
+    if (event.storageArea && event.storageArea !== localStorage) return;
+    const project = get(currentProject);
+    if (!project) return;
+    try { localStore.assertCurrent(project.id); }
+    catch (error) {
+      clearSaveTimer();
+      saveAttempt++;
+      saveState.set('unsaved');
+      saveError.set(storageErrorMessage(error));
+      saveConflict.set(error instanceof ProjectConflictError);
+    }
+  };
+  if (typeof window !== 'undefined') window.addEventListener('storage', onStorage);
   const stop = () => {
     unsubscribe();
     clearSaveTimer();
+    if (typeof window !== 'undefined') window.removeEventListener('storage', onStorage);
     if (stopWatching === stop) stopWatching = null;
   };
   stopWatching = stop;
@@ -50,6 +70,7 @@ export function markDirty() {
   revision++;
   saveState.set('unsaved');
   clearSaveTimer();
+  if (get(saveConflict)) return;
   debounceTimer = setTimeout(() => {
     void autoSave();
   }, 1000);
@@ -71,6 +92,16 @@ function captureThumbnail(projectId: string) {
   } catch {}
 }
 
+function scheduleThumbnail(project: Project) {
+  const renderedRevision = revision, attempt = saveAttempt;
+  if (typeof requestAnimationFrame !== 'function') return;
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    if (attempt === saveAttempt && renderedRevision === revision && get(currentProject) === project) {
+      captureThumbnail(project.id);
+    }
+  }));
+}
+
 /** Saves remain local; failures leave the current project available for export. */
 async function persist(manual: boolean): Promise<boolean> {
   clearSaveTimer();
@@ -79,6 +110,7 @@ async function persist(manual: boolean): Promise<boolean> {
   if (lastProjectId !== p.id) {
     lastSavedAt.set(null);
     saveError.set(null);
+    saveConflict.set(false);
     lastProjectId = p.id;
   }
   const savingRevision = revision;
@@ -91,16 +123,11 @@ async function persist(manual: boolean): Promise<boolean> {
       // The canvas may still show the previous plan immediately after an import.
       // Let reactive updates, zoom-to-fit and a paint finish before taking a preview.
       // Preview work must not delay the save or capture a newer revision/project.
-      if (typeof requestAnimationFrame === 'function') {
-        requestAnimationFrame(() => requestAnimationFrame(() => {
-          if (attempt === saveAttempt && savingRevision === revision && get(currentProject) === p) {
-            captureThumbnail(p.id);
-          }
-        }));
-      }
+      scheduleThumbnail(p);
       if (manual) saveSnapshot(p, 'Manual save');
       saveState.set('saved');
       saveError.set(null);
+      saveConflict.set(false);
       lastSavedAt.set(new Date());
     }
     return true;
@@ -108,6 +135,7 @@ async function persist(manual: boolean): Promise<boolean> {
     if (attempt === saveAttempt && get(currentProject) === p) {
       saveState.set('unsaved');
       saveError.set(storageErrorMessage(e));
+      saveConflict.set(e instanceof ProjectConflictError);
     }
     return false;
   }
@@ -118,6 +146,33 @@ export function autoSave() { return persist(false); }
 /** Manual save */
 export function manualSave() { return persist(true); }
 
+/** Preserve this tab's version under a fresh ID before changing editor state. */
+export async function saveCurrentAsCopy(): Promise<boolean> {
+  if (get(savingCopy)) return false;
+  const project = get(currentProject);
+  if (!project) return false;
+  clearSaveTimer();
+  saveAttempt++;
+  const copyingRevision = revision;
+  savingCopy.set(true);
+  try {
+    const copy = await localStore.saveCopy(project);
+    if (get(currentProject)?.id !== project.id) return false;
+    if (revision !== copyingRevision || get(currentProject) !== project) {
+      if (get(saveState) !== 'saved') saveError.set('A copy was saved, but you made more edits while it was saving. Save another copy to keep the latest version.');
+      return false;
+    }
+    loadProject(copy);
+    markClean();
+    lastSavedAt.set(new Date());
+    scheduleThumbnail(copy);
+    return true;
+  } catch (error) {
+    if (get(currentProject)?.id === project.id) saveError.set(storageErrorMessage(error));
+    return false;
+  } finally { savingCopy.set(false); }
+}
+
 /** Call after loading a project that is already persisted. */
 export function markClean() {
   clearSaveTimer();
@@ -125,6 +180,7 @@ export function markClean() {
   saveAttempt++;
   saveState.set('saved');
   saveError.set(null);
+  saveConflict.set(false);
   lastSavedAt.set(null);
   lastProjectId = get(currentProject)?.id;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -223,7 +223,9 @@
             <!-- Actions menu button -->
             <button
               onclick={(e) => { e.stopPropagation(); contextMenuId = contextMenuId === project.id ? null : project.id; }}
-              class="absolute top-3 right-3 w-8 h-8 bg-white/90 backdrop-blur rounded-lg shadow-sm border border-gray-200 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-gray-50"
+              aria-label={`Project actions for ${project.name || 'Untitled Project'}`}
+              aria-expanded={contextMenuId === project.id}
+              class="absolute top-3 right-3 w-8 h-8 bg-white/90 backdrop-blur rounded-lg shadow-sm border border-gray-200 flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-gray-50"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" class="text-gray-500"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>
             </button>

--- a/tests/browser/save-conflicts.spec.ts
+++ b/tests/browser/save-conflicts.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+async function seed(context: BrowserContext, neighbor = false) {
+  const source = JSON.parse(await readFile(resolve('tests/fixtures/save-conflicts.openplan.json'), 'utf8'));
+  await context.addInitScript(({ source, neighbor }) => {
+    if (!localStorage.getItem('floorplan_projects')) {
+      const projects: Record<string, string> = { [source.id]: JSON.stringify(source) };
+      if (neighbor) projects['qa-neighbor'] = JSON.stringify({ ...source, id: 'qa-neighbor', name: 'QA Neighbor' });
+      localStorage.setItem('floorplan_projects', JSON.stringify(projects));
+    }
+    localStorage.setItem('hasSeenWelcome', 'true');
+    const timeout = window.setTimeout.bind(window);
+    window.setTimeout = ((handler: TimerHandler, delay?: number, ...args: any[]) =>
+      timeout(handler, delay === 1000 ? 60_000 : delay, ...args)) as typeof window.setTimeout;
+  }, { source, neighbor });
+  return source;
+}
+async function rename(page: Page, name: string) {
+  await page.getByTitle('Click to rename', { exact: true }).click();
+  await page.getByRole('textbox', { name: 'Project name' }).fill(name);
+  await page.getByRole('textbox', { name: 'Project name' }).press('Enter');
+}
+async function exported(page: Page) {
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const pending = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download JSON', exact: true }).click();
+  return JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
+}
+async function saved(page: Page) {
+  return page.evaluate(() => Object.fromEntries(Object.entries(JSON.parse(localStorage.getItem('floorplan_projects')!))
+    .map(([id, raw]) => [id, JSON.parse(raw as string)])));
+}
+function observe(page: Page) {
+  const errors: string[] = [], external: string[] = [];
+  page.on('pageerror', e => errors.push(e.message));
+  page.on('request', r => {
+    if (/^https?:/.test(r.url()) && new URL(r.url()).origin !== 'http://127.0.0.1:4188') external.push(r.url());
+  });
+  return () => { expect(errors).toEqual([]); expect(external).toEqual([]); };
+}
+
+for (const width of [1440, 390]) {
+  test(`conflicting tabs preserve both versions with backup and copy recovery at ${width}px`, async ({ page, context }, testInfo) => {
+    test.setTimeout(90_000);
+    const source = await seed(context), other = await context.newPage();
+    const check = observe(page), checkOther = observe(other);
+    await page.setViewportSize({ width, height: 900 });
+    await other.setViewportSize({ width, height: 900 });
+    await page.goto(`/editor?id=${source.id}`); await other.goto(`/editor?id=${source.id}`);
+    await expect(page.getByRole('application')).toContainText('1 room');
+    await expect(other.getByRole('application')).toContainText('1 room');
+    await rename(other, 'My local alternative');
+    await rename(page, 'Newer saved version');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(other.getByRole('alert')).toContainText('another tab');
+    const newer = (await saved(page))[source.id];
+    await other.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(other.getByRole('alert')).toContainText('another tab');
+    expect((await saved(page))[source.id]).toEqual(newer);
+    expect((await exported(other)).name).toBe('My local alternative');
+    const backup = other.waitForEvent('download');
+    await other.getByRole('button', { name: 'Download JSON backup', exact: true }).click();
+    const backedUp = JSON.parse(await readFile((await (await backup).path())!, 'utf8'));
+    expect(backedUp.id).toBe(source.id); expect(backedUp.name).toBe('My local alternative');
+
+    // A full-storage recovery failure must leave the conflicting plan in memory.
+    if (width === 1440) {
+      await other.evaluate(() => {
+        const original = Storage.prototype.setItem;
+        (window as any).failCopyWrite = true;
+        Storage.prototype.setItem = function(key, value) {
+          if (key === 'floorplan_projects' && (window as any).failCopyWrite) throw new DOMException('Full', 'QuotaExceededError');
+          return original.call(this, key, value);
+        };
+      });
+      await other.getByRole('button', { name: 'Save as copy', exact: true }).click();
+      await expect(other.getByRole('alert')).toContainText('Browser storage is full');
+      expect((await exported(other)).id).toBe(source.id);
+      expect(Object.keys(await saved(page))).toEqual([source.id]);
+      await other.evaluate(() => { (window as any).failCopyWrite = false; });
+    }
+    await other.getByRole('button', { name: 'Save as copy', exact: true }).click();
+    await expect(other.getByRole('alert')).toHaveCount(0);
+    await expect(other.getByTitle('Click to rename', { exact: true })).toHaveText('My local alternative (Recovered copy)');
+    const copy = await exported(other);
+    expect(copy.id).not.toBe(source.id); expect(copy.floors).toEqual(backedUp.floors);
+    expect((await saved(page))[source.id]).toEqual(newer);
+    expect(Object.keys(await saved(page))).toHaveLength(2);
+    await other.reload(); expect((await exported(other)).id).toBe(copy.id);
+    await page.reload(); expect((await exported(page)).name).toBe('Newer saved version');
+    await other.getByRole('button', { name: '3D', exact: true }).click();
+    await expect(other.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
+    await testInfo.attach(`recovered-copy-${width}`, { body: await other.screenshot(), contentType: 'image/png' });
+    check(); checkOther();
+  });
+}
+
+test('deleting a library project cannot be undone by an older editor autosave', async ({ page, context }) => {
+  const source = await seed(context), library = await context.newPage();
+  const check = observe(page), checkLibrary = observe(library);
+  await page.goto(`/editor?id=${source.id}`);
+  await expect(page.getByRole('application')).toContainText('1 room');
+  await library.goto('/');
+  await library.getByRole('button', { name: `Project actions for ${source.name}`, exact: true }).click();
+  await library.getByRole('button', { name: 'Delete', exact: true }).click();
+  await library.getByRole('button', { name: 'Yes', exact: true }).click();
+  await expect(page.getByRole('alert')).toContainText('deleted in another tab');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  expect(Object.keys(await saved(page))).toHaveLength(0);
+  await page.getByRole('button', { name: 'Save as copy', exact: true }).click();
+  await expect(page.getByRole('alert')).toHaveCount(0);
+  const recovered = await exported(page);
+  expect(recovered.id).not.toBe(source.id);
+  expect(Object.keys(await saved(page))).toEqual([recovered.id]);
+  check(); checkLibrary();
+});
+
+test('simultaneous edits to different projects preserve both library entries', async ({ page, context }) => {
+  const source = await seed(context, true), other = await context.newPage();
+  const check = observe(page), checkOther = observe(other);
+  await page.goto(`/editor?id=${source.id}`); await other.goto('/editor?id=qa-neighbor');
+  await rename(page, 'First independent edit'); await rename(other, 'Second independent edit');
+  await Promise.all([
+    page.getByRole('button', { name: 'Save', exact: true }).click(),
+    other.getByRole('button', { name: 'Save', exact: true }).click(),
+  ]);
+  await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
+  await expect(other.getByText('Saved ✓', { exact: true })).toBeVisible();
+  await expect(page.getByRole('alert')).toHaveCount(0); await expect(other.getByRole('alert')).toHaveCount(0);
+  const projects = await saved(page);
+  expect(projects[source.id].name).toBe('First independent edit');
+  expect(projects['qa-neighbor'].name).toBe('Second independent edit');
+  await page.reload(); await other.reload();
+  expect((await exported(page)).name).toBe('First independent edit');
+  expect((await exported(other)).name).toBe('Second independent edit');
+  check(); checkOther();
+});
+
+test('edits made while a recovery copy waits for a lock remain in the current tab', async ({ page, context }) => {
+  const source = await seed(context), other = await context.newPage();
+  const check = observe(page), checkOther = observe(other);
+  await page.goto(`/editor?id=${source.id}`); await other.goto(`/editor?id=${source.id}`);
+  await rename(page, 'Other tab update'); await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(other.getByRole('alert')).toContainText('another tab');
+  await rename(other, 'Copy at click time');
+  // Hold a real browser lock, without blocking the page that needs to stay editable.
+  await page.evaluate(() => new Promise<void>(resolve => {
+    void navigator.locks.request('openplan3d-project-library', () => new Promise<void>(release => {
+      (window as any).releaseLibraryLock = release; resolve();
+    }));
+  }));
+  await other.getByRole('button', { name: 'Save as copy', exact: true }).click();
+  await expect(other.getByRole('button', { name: 'Saving copy…', exact: true })).toBeDisabled();
+  await rename(other, 'Edited while copy waited');
+  await page.evaluate(() => { (window as any).releaseLibraryLock(); });
+  await expect(other.getByRole('alert')).toContainText('made more edits');
+  const stillEditing = await exported(other);
+  expect(stillEditing.id).toBe(source.id); expect(stillEditing.name).toBe('Edited while copy waited');
+  const projects = Object.values(await saved(other)) as any[];
+  expect(projects.map(p => p.name).sort()).toEqual(['Copy at click time (Recovered copy)', 'Other tab update'].sort());
+  await other.getByRole('button', { name: 'Save as copy', exact: true }).click();
+  await expect(other.getByRole('alert')).toHaveCount(0);
+  expect((await exported(other)).name).toBe('Edited while copy waited (Recovered copy)');
+  check(); checkOther();
+});

--- a/tests/fixtures/save-conflicts.openplan.json
+++ b/tests/fixtures/save-conflicts.openplan.json
@@ -1,0 +1,127 @@
+{
+  "id": "qa-save-conflicts",
+  "name": "QA Save Conflicts",
+  "floors": [
+    {
+      "id": "dimensions-floor",
+      "name": "Ground Floor",
+      "level": 0,
+      "walls": [
+        {
+          "id": "qa-wall-0",
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "end": {
+            "x": 600.5,
+            "y": 0
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-1",
+          "start": {
+            "x": 600.5,
+            "y": 0
+          },
+          "end": {
+            "x": 600,
+            "y": 400
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-2",
+          "start": {
+            "x": 600,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 400
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        },
+        {
+          "id": "qa-wall-3",
+          "start": {
+            "x": 0,
+            "y": 400
+          },
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "thickness": 20,
+          "height": 250,
+          "color": "#94a3b8"
+        }
+      ],
+      "rooms": [
+        {
+          "id": "qa-named-room",
+          "name": "Kitchen & Dining",
+          "walls": [
+            "qa-wall-0",
+            "qa-wall-1",
+            "qa-wall-2",
+            "qa-wall-3"
+          ],
+          "area": 24.01,
+          "floorTexture": "light-oak",
+          "color": "#ddf2ff",
+          "roomType": "kitchen",
+          "labelOffset": {
+            "x": 0,
+            "y": 0
+          }
+        }
+      ],
+      "doors": [
+        {
+          "id": "qa-door",
+          "wallId": "qa-wall-0",
+          "position": 0.5,
+          "width": 90.5,
+          "height": 205.25,
+          "type": "opening",
+          "swingDirection": "left",
+          "opensInward": true
+        }
+      ],
+      "windows": [
+        {
+          "id": "qa-window",
+          "wallId": "qa-wall-1",
+          "position": 0.5,
+          "width": 110.25,
+          "height": 120.5,
+          "sillHeight": 90,
+          "type": "standard"
+        }
+      ],
+      "furniture": [],
+      "stairs": [],
+      "columns": [],
+      "guides": [],
+      "measurements": [],
+      "annotations": [],
+      "textAnnotations": [],
+      "groups": []
+    }
+  ],
+  "activeFloorId": "dimensions-floor",
+  "createdAt": "2026-09-05T00:00:00.000Z",
+  "updatedAt": "2026-09-05T00:00:00.000Z",
+  "extensions": {
+    "source": "local tab conflict regression",
+    "revision": 7
+  }
+}

--- a/tests/saveConflicts.test.ts
+++ b/tests/saveConflicts.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { createLocalStore, ProjectConflictError, PROJECTS_STORAGE_KEY as key } from '$lib/services/datastore';
+import { roomProject } from './fixtures/project';
+
+let data: Map<string, string>;
+beforeEach(() => {
+  data = new Map();
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => data.set(key, value),
+    removeItem: (key: string) => data.delete(key),
+  });
+});
+
+async function twoTabs() {
+  const first = createLocalStore(), second = createLocalStore();
+  const project = roomProject(); await first.save(project);
+  return { first, second, a: (await first.load(project.id))!, b: (await second.load(project.id))! };
+}
+
+function controlledLocks() {
+  const queue: (() => void)[] = [];
+  const request = vi.fn((_name: string, run: () => unknown) => new Promise((resolve, reject) => {
+    queue.push(() => { try { resolve(run()); } catch (error) { reject(error); } });
+  }));
+  vi.stubGlobal('window', {});
+  vi.stubGlobal('navigator', { locks: { request } });
+  return { request, release: () => queue.shift()!() };
+}
+
+it('rejects repeated saves from an older tab and retains the newer saved bytes', async () => {
+  const { first, second, a, b } = await twoTabs();
+  a.name = 'Newer version'; await first.save(a);
+  const raw = data.get(key);
+  b.name = 'Older tab edits';
+  await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
+  await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
+  expect(data.get(key)).toBe(raw);
+  expect(b.name).toBe('Older tab edits');
+});
+
+it('accepts edits after explicitly reopening the latest saved version', async () => {
+  const { first, second, a } = await twoTabs();
+  a.name = 'Newer version'; await first.save(a);
+  const reopened = (await second.load(a.id))!;
+  reopened.name = 'Reviewed latest'; await second.save(reopened);
+  expect((await first.load(a.id))!.name).toBe('Reviewed latest');
+});
+
+it('does not confuse another project changing with a conflict', async () => {
+  const { first, second, b } = await twoTabs();
+  const neighbor = roomProject(); await first.save(neighbor);
+  neighbor.name = 'Other project edits'; await first.save(neighbor);
+  expect(() => second.assertCurrent(b.id)).not.toThrow();
+  b.name = 'Independent edit'; await second.save(b);
+  expect((await first.load(neighbor.id))!.name).toBe('Other project edits');
+});
+
+it('refuses an unobserved existing ID instead of assuming it is safe to overwrite', async () => {
+  const first = createLocalStore(), second = createLocalStore(), project = roomProject();
+  await first.save(project);
+  await expect(second.save({ ...project, name: 'Collision' })).rejects.toBeInstanceOf(ProjectConflictError);
+});
+
+it('does not allow an open tab to recreate a project deleted elsewhere', async () => {
+  const { first, second, a, b } = await twoTabs();
+  await first.list(); await first.delete(a.id);
+  await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
+  expect(await first.has(a.id)).toBe(false);
+});
+
+it('guards deleting a stale library card until the library has been refreshed', async () => {
+  const { first, second, a } = await twoTabs();
+  await second.list();
+  a.name = 'Changed since listing'; await first.save(a);
+  const raw = data.get(key);
+  await expect(second.delete(a.id)).rejects.toBeInstanceOf(ProjectConflictError);
+  expect(data.get(key)).toBe(raw);
+  await second.list(); await second.delete(a.id);
+  expect(await first.has(a.id)).toBe(false);
+});
+
+it('does not silently rebase an open editor when its library is listed', async () => {
+  const { first, second, a, b } = await twoTabs();
+  a.name = 'Newer version'; await first.save(a);
+  await second.list();
+  await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
+});
+
+it('does not advance the saved baseline when a write fails, so retry can succeed', async () => {
+  const { first, a } = await twoTabs();
+  a.name = 'Retry this edit';
+  vi.spyOn(localStorage, 'setItem').mockImplementationOnce(() => { throw new DOMException('Full', 'QuotaExceededError'); });
+  await expect(first.save(a)).rejects.toMatchObject({ name: 'QuotaExceededError' });
+  await first.save(a);
+  expect((await first.load(a.id))!.name).toBe('Retry this edit');
+});
+
+it('treats external library removal as a conflict instead of a new empty library', async () => {
+  const { second, b } = await twoTabs();
+  data.delete(key);
+  await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
+  expect(data.has(key)).toBe(false);
+});
+
+it('creates an independent recovery copy without rebasing the conflicting original', async () => {
+  const { first, second, a, b } = await twoTabs();
+  a.name = 'Newer version'; await first.save(a);
+  b.name = 'My alternative'; b.floors[0].walls[0].thickness = 42.5;
+  const copy = await second.saveCopy(b);
+  expect(copy.id).not.toBe(b.id);
+  expect(copy.name).toBe('My alternative (Recovered copy)');
+  expect(copy.floors).toEqual(b.floors);
+  expect(b.id).toBe(a.id);
+  expect((await first.load(a.id))!.name).toBe('Newer version');
+  expect((await first.load(copy.id))!.floors[0].walls[0].thickness).toBe(42.5);
+  await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
+  copy.name = 'Continue editing copy'; await second.save(copy);
+});
+
+it('keeps all saved bytes intact when a recovery copy cannot fit in storage', async () => {
+  const { second, b } = await twoTabs();
+  const before = data.get(key), original = structuredClone(b);
+  vi.spyOn(localStorage, 'setItem').mockImplementationOnce(() => { throw new DOMException('Full', 'QuotaExceededError'); });
+  await expect(second.saveCopy(b)).rejects.toMatchObject({ name: 'QuotaExceededError' });
+  expect(data.get(key)).toBe(before); expect(b).toEqual(original);
+  expect((await second.saveCopy(b)).id).not.toBe(b.id);
+});
+
+it('freezes pending writes before acquiring the browser lock', async () => {
+  const { first, a } = await twoTabs();
+  const locks = controlledLocks();
+  a.name = 'At save time';
+  const pending = first.save(a);
+  a.name = 'Later edit'; a.floors[0].walls[0].thickness = 80;
+  locks.release(); await pending;
+  const saved = JSON.parse(JSON.parse(data.get(key)!)[a.id]);
+  expect(saved.name).toBe('At save time'); expect(saved.floors[0].walls[0].thickness).toBe(15);
+  const retry = first.save(a); locks.release(); await retry;
+  expect((await first.load(a.id))!.name).toBe('Later edit');
+});
+
+it('serializes concurrent writes and rereads the full library inside the lock', async () => {
+  const first = createLocalStore(), second = createLocalStore();
+  const locks = controlledLocks(), a = roomProject(), b = roomProject();
+  const one = first.save(a), two = second.save(b);
+  expect(data.has(key)).toBe(false);
+  expect(locks.request.mock.calls.map(([name]) => name)).toEqual(['openplan3d-project-library', 'openplan3d-project-library']);
+  locks.release(); await one;
+  locks.release(); await two;
+  expect(Object.keys(JSON.parse(data.get(key)!)).sort()).toEqual([a.id, b.id].sort());
+});
+
+it('rejects the second simultaneous writer to the same project', async () => {
+  const { first, second, a, b } = await twoTabs();
+  const locks = controlledLocks();
+  a.name = 'First writer'; b.name = 'Second writer';
+  const one = first.save(a), two = second.save(b);
+  const rejected = expect(two).rejects.toBeInstanceOf(ProjectConflictError);
+  locks.release(); await one;
+  locks.release(); await rejected;
+  expect((await first.load(a.id))!.name).toBe('First writer');
+});
+
+it('discards a pending save if its project was reopened before the lock arrived', async () => {
+  const { first, a } = await twoTabs();
+  const locks = controlledLocks(), before = data.get(key);
+  a.name = 'Old pending edit';
+  const pending = first.save(a), rejected = expect(pending).rejects.toBeInstanceOf(ProjectConflictError);
+  await first.load(a.id);
+  locks.release(); await rejected;
+  expect(data.get(key)).toBe(before);
+});
+
+it('does not overwrite a newer project thumbnail from a stale editor', async () => {
+  const { first, second, a } = await twoTabs();
+  a.name = 'Changed'; await first.save(a);
+  first.saveThumbnail(a.id, 'new thumbnail');
+  second.saveThumbnail(a.id, 'old thumbnail');
+  expect(first.getThumbnail(a.id)).toBe('new thumbnail');
+});
+
+it('checks copy IDs against the library while holding the mutation lock', async () => {
+  const { first, a } = await twoTabs();
+  const uuid = vi.fn().mockReturnValueOnce(a.id).mockReturnValueOnce('fresh-copy-id');
+  vi.stubGlobal('crypto', { randomUUID: uuid });
+  const copy = await first.saveCopy(a);
+  expect(copy.id).toBe('fresh-copy-id'); expect(uuid).toHaveBeenCalledTimes(2);
+  expect((await first.load(a.id))!.name).toBe(a.name);
+});

--- a/tests/saveStatus.test.ts
+++ b/tests/saveStatus.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
-import { localStore } from '$lib/services/datastore';
+import type { Project } from '$lib/models/types';
+import { localStore, ProjectConflictError } from '$lib/services/datastore';
 import { createDefaultProject, currentProject, updateProjectName } from '$lib/stores/project';
-import { autoSave, initAutoSave, lastSavedAt, manualSave, markClean, saveError, saveState } from '$lib/stores/saveStatus';
+import { autoSave, initAutoSave, lastSavedAt, manualSave, markClean, saveError, saveState, saveConflict, saveCurrentAsCopy, savingCopy } from '$lib/stores/saveStatus';
 
 vi.mock('$lib/stores/versionHistory', () => ({ saveSnapshot: vi.fn() }));
 let stop: () => void;
@@ -142,4 +143,80 @@ it('discards delayed thumbnail work after a later edit or project switch', async
   markClean();
   frames.shift()!(32); frames.shift()!(48);
   expect(querySelector).not.toHaveBeenCalled();
+});
+
+it('keeps conflicting edits unsaved without repeatedly autosaving over another tab', async () => {
+  vi.mocked(localStore.save).mockRejectedValue(new ProjectConflictError());
+  updateProjectName('My version');
+  expect(await manualSave()).toBe(false);
+  expect(get(saveConflict)).toBe(true);
+  expect(get(saveError)).toContain('another tab');
+  updateProjectName('More local edits');
+  await vi.advanceTimersByTimeAsync(2000);
+  expect(localStore.save).toHaveBeenCalledOnce();
+  expect(get(saveState)).toBe('unsaved');
+});
+
+it('notifies about external project changes without replacing local work and removes its listener', async () => {
+  stop();
+  const events = new EventTarget();
+  vi.stubGlobal('window', events);
+  const removed = vi.spyOn(events, 'removeEventListener');
+  const check = vi.spyOn(localStore, 'assertCurrent').mockImplementation(() => { throw new ProjectConflictError(); });
+  stop = initAutoSave();
+  const before = get(currentProject);
+  events.dispatchEvent(Object.assign(new Event('storage'), { key: 'floorplan_projects' }));
+  expect(get(saveState)).toBe('unsaved'); expect(get(saveConflict)).toBe(true);
+  expect(get(currentProject)).toBe(before);
+  stop(); expect(removed).toHaveBeenCalledWith('storage', expect.any(Function));
+  events.dispatchEvent(Object.assign(new Event('storage'), { key: 'floorplan_projects' }));
+  expect(check).toHaveBeenCalledOnce();
+});
+
+it('ignores unrelated storage events and other project writes', () => {
+  stop();
+  const events = new EventTarget(); vi.stubGlobal('window', events);
+  const check = vi.spyOn(localStore, 'assertCurrent').mockImplementation(() => {});
+  stop = initAutoSave();
+  events.dispatchEvent(Object.assign(new Event('storage'), { key: 'settings' }));
+  expect(check).not.toHaveBeenCalled();
+  events.dispatchEvent(Object.assign(new Event('storage'), { key: 'floorplan_projects' }));
+  expect(get(saveState)).toBe('saved'); expect(get(saveConflict)).toBe(false);
+});
+
+it('switches to a recovery copy only after that copy is saved', async () => {
+  updateProjectName('Recover me'); saveConflict.set(true);
+  const copy = { ...get(currentProject)!, id: 'recovered', name: 'Recover me (Recovered copy)' };
+  vi.spyOn(localStore, 'saveCopy').mockResolvedValue(copy);
+  expect(await saveCurrentAsCopy()).toBe(true);
+  expect(get(currentProject)).toBe(copy);
+  expect(get(saveState)).toBe('saved'); expect(get(saveConflict)).toBe(false);
+  expect(get(lastSavedAt)).toBeInstanceOf(Date); expect(get(savingCopy)).toBe(false);
+  await vi.advanceTimersByTimeAsync(2000);
+  expect(localStore.save).not.toHaveBeenCalled();
+});
+
+it('retains conflicting work and its retry option if saving a copy fails', async () => {
+  updateProjectName('Keep me in memory'); saveConflict.set(true);
+  const before = get(currentProject);
+  vi.spyOn(localStore, 'saveCopy').mockRejectedValue(new DOMException('Full', 'QuotaExceededError'));
+  expect(await saveCurrentAsCopy()).toBe(false);
+  expect(get(currentProject)).toBe(before);
+  expect(get(saveState)).toBe('unsaved'); expect(get(saveConflict)).toBe(true);
+  expect(get(saveError)).toContain('Browser storage is full');
+  expect(get(savingCopy)).toBe(false);
+});
+
+it('does not discard edits made while a recovery copy is being saved', async () => {
+  updateProjectName('Copy this revision'); saveConflict.set(true);
+  let finish!: (value: Project) => void;
+  const copy = { ...get(currentProject)!, id: 'recovered' };
+  vi.spyOn(localStore, 'saveCopy').mockImplementation(() => new Promise(resolve => { finish = resolve; }));
+  const pending = saveCurrentAsCopy();
+  expect(await saveCurrentAsCopy()).toBe(false);
+  updateProjectName('Later edits');
+  finish(copy); expect(await pending).toBe(false);
+  expect(get(currentProject)!.name).toBe('Later edits');
+  expect(get(saveError)).toContain('made more edits');
+  expect(get(saveState)).toBe('unsaved'); expect(get(saveConflict)).toBe(true);
 });


### PR DESCRIPTION
An older editor tab could silently overwrite newer saved edits or recreate a deleted project. Compare the project revision before writes, coordinate current tabs under a shared browser lock, and surface conflicts without replacing local work. Save as copy preserves the tab's version under a fresh ID; failures and edits made while copying retain the current plan.

Library deletion checks its listed revision; unrelated projects remain independent; queued saves freeze their data before waiting; old thumbnail writes are rejected. Library action buttons gain accessible labels and remain visible on touch screens. Existing local files and iPhone formats are unchanged, with no Firebase Storage traffic or new hosted services.

Validation: 390 unit tests, zero type errors, 23 existing warnings, and a passing production build. Five new browser workflows cover real two-tab desktop/mobile conflicts, backup/copy recovery, quota failure, deletion, concurrent different-project writes, and editing during a held Web Lock. All 30 browser tests passed in [PR CI](https://github.com/laanlabs/openPlan3D/actions/runs/34058737003). Interactive production-build checks passed for stale-tab Save refusal, recovery copies, original/copy reload, a retained 44.25 cm mobile edit, 3D, and preventing recreation after library deletion, with no browser errors. Post-merge live verification is recorded below.

Web Locks coordination requires a supported secure context and current app tabs. Older app tabs do not participate; refresh them before concurrent editing. Unsupported/insecure contexts retain revision checks without simultaneous-write coordination. This does not implement automatic merging or cloud synchronization.

Closes #51.
