### PR TITLE
Store local projects and history in IndexedDB with safe migration

### DIFF
--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -355,3 +355,7 @@ recreating deleted projects. Current tabs coordinate library writes, retain
 conflicting work for backup and offer Save as copy. Recovery preserves later
 edits and failed-copy paths. See [the batch report](2026-09-06-local-save-conflicts.md)
 for browser compatibility limits and validation. All processing remains local.
+
+## Fourteenth batch — IndexedDB local library
+
+Projects, previews and ten-version histories move into separate IndexedDB stores with atomic migration, retained legacy recovery bytes, transaction-complete save status and old-tab recovery copies. Full-library backups are available from the library. This removes localStorage's project-size bottleneck without adding Firebase storage. See [implementation and verification](2026-09-06-indexeddb-library.md). Whole-library restore UI, image deduplication and complete two-way iPhone file exchange remain follow-up work; issue #30 still covers the device release, quota cutover and billing controls.

--- a/docs/reviews/2026-09-06-indexeddb-library.md
+++ b/docs/reviews/2026-09-06-indexeddb-library.md
@@ -18,7 +18,7 @@ No Firebase upload, paid storage, schema change to the iPhone handoff, or cloud 
 
 ## Verification
 
-- 403 unit tests pass, including full migration rollback/retry, commit abort after request success, concurrent clients, late old-release recovery, reserved IDs, histories and a project exceeding the old localStorage quota.
+- 404 unit tests pass, including full migration rollback/retry, commit abort after request success, concurrent clients, late old-release recovery, reserved IDs, histories and a project exceeding the old localStorage quota.
 - Type checking: zero errors; 23 pre-existing warnings. Production build passes. npm audit: zero vulnerabilities.
 - Browser suite now targets actual IndexedDB writes/reads for all existing import and conflict regression checks, with added migration, rollback/retry, large local project and older-release recovery cases. GitHub CI and release verification are recorded in the PR.
-- Manual upgrade test: imported and manually saved a project in the previous production build, then opened the new build on the same origin. Its project, preview and previous manual/session history remained available.
+- Manual upgrade test: imported and manually saved a project in the previous production build, then opened the new build on the same origin. Its project, preview and previous manual/session history remained available. Saving further edits in the still-open old release created a separate visible recovery copy while retaining the current IndexedDB version.

--- a/docs/reviews/2026-09-06-indexeddb-library.md
+++ b/docs/reviews/2026-09-06-indexeddb-library.md
@@ -1,0 +1,24 @@
+# IndexedDB local library — 2026-09-06
+
+## Behavior
+
+Projects (including embedded images), previews and version history now live in separate IndexedDB object stores. Each save updates one project record. Browser transactions compare the revision and commit the write atomically, including browsers without Web Locks. The editor reports Saved only after the transaction commits. Previews remain optional and history retains its ten-version limit without destructive quota retries.
+
+The first access imports the legacy project map, previews and raw history together. Migration failure rolls back all records and its marker; retry starts from the untouched original localStorage bytes. This release deliberately retains that original storage for recovery. It is no longer updated by new saves. A small optional localStorage signal notifies other tabs; saving and focusing also verify persisted revisions.
+
+Tabs running the previous release can continue writing the old library. A changed valid old project appears as a separate “Recovered from older tab” project. Further old-tab edits update that recovery copy only while its current saved bytes still match the last recovery; editing or deleting the copy makes subsequent recovery independent. Old deletes never erase or resurrect current projects. Close or refresh older tabs after upgrading. Invalid old-project bytes remain in the legacy portion of the library backup.
+
+Version reads and restore are asynchronous. Restore verifies the selected snapshot and refuses to replace work edited while the read was pending. History errors remain visible after reopening the panel until a successful retry or clear.
+
+## Backups and limits
+
+Download library backup is available in the library and during recovery. The version 1 `openplan3d-library` JSON bundle contains raw per-project strings under `projects`, per-project `thumbnails` and `history`, and original/previous/current legacy storage snapshots under `legacy`. Corrupt legacy libraries that could not migrate are downloaded byte-for-byte in the original format. Recovery bypasses migration/geometry validation. Individual project JSON import/export continues unchanged; a whole-library bundle requires extracting a project's JSON string into a `.json` file for the existing importer. One-click whole-library restoration is follow-up work.
+
+No Firebase upload, paid storage, schema change to the iPhone handoff, or cloud setting is introduced. IndexedDB still uses browser-managed storage; it is not an off-device backup. Embedded images remain inside each project's JSON (and snapshots), so blob deduplication and more efficient metadata-only listing remain possible follow-ups. This release retains the bounded existing legacy data instead of automatically clearing it.
+
+## Verification
+
+- 403 unit tests pass, including full migration rollback/retry, commit abort after request success, concurrent clients, late old-release recovery, reserved IDs, histories and a project exceeding the old localStorage quota.
+- Type checking: zero errors; 23 pre-existing warnings. Production build passes. npm audit: zero vulnerabilities.
+- Browser suite now targets actual IndexedDB writes/reads for all existing import and conflict regression checks, with added migration, rollback/retry, large local project and older-release recovery cases. GitHub CI and release verification are recorded in the PR.
+- Manual upgrade test: imported and manually saved a project in the previous production build, then opened the new build on the same origin. Its project, preview and previous manual/session history remained available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@tailwindcss/vite": "^4.1.18",
 				"@types/three": "^0.182.0",
+				"fake-indexeddb": "^6.2.5",
 				"firebase": "^12.18.0",
 				"svelte": "^5.57.0",
 				"svelte-check": "^4.3.6",
@@ -2909,6 +2910,16 @@
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"license": "MIT"
+		},
+		"node_modules/fake-indexeddb": {
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+			"integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/fast-png": {
 			"version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/vite": "^4.1.18",
 		"@types/three": "^0.182.0",
+		"fake-indexeddb": "^6.2.5",
 		"firebase": "^12.18.0",
 		"svelte": "^5.57.0",
 		"svelte-check": "^4.3.6",

--- a/src/lib/components/toolbar/VersionHistoryPanel.svelte
+++ b/src/lib/components/toolbar/VersionHistoryPanel.svelte
@@ -23,24 +23,24 @@
     return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
 
-  function onRestore(index: number) {
+  async function onRestore(index: number, snapshot: Snapshot) {
     const p = get(currentProject);
     if (!p) return;
     if (!confirm('Restore this version? Current unsaved changes will be lost.')) return;
-    if (restoreSnapshot(p.id, index)) open = false;
+    if (await restoreSnapshot(p.id, index, snapshot)) open = false;
   }
 
-  function onClearAll() {
+  async function onClearAll() {
     const p = get(currentProject);
     if (!p) return;
     if (!confirm('Delete all version history for this project?')) return;
-    try { deleteAllSnapshots(p.id); }
+    try { await deleteAllSnapshots(p.id); }
     catch { snapshotError.set('Could not clear version history. Allow site storage and try again.'); }
   }
-  function backupHistory() {
+  async function backupHistory() {
     const project = get(currentProject);
     if (!project) return;
-    try { downloadSnapshotBackup(project.id); }
+    try { await downloadSnapshotBackup(project.id); }
     catch (error) { snapshotError.set(error instanceof Error ? error.message : 'Could not download version history.'); }
   }
 </script>
@@ -79,7 +79,7 @@
                 <div class="text-xs text-gray-400">{formatTime(snap.timestamp)}</div>
               </div>
               <button
-                onclick={() => onRestore(realIndex)}
+                onclick={() => onRestore(realIndex, snap)}
                 class="text-xs px-2.5 py-1 bg-blue-50 text-blue-600 rounded-md hover:bg-blue-100 transition-colors opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 font-medium shrink-0 ml-2"
               >
                 Restore

--- a/src/lib/services/datastore.ts
+++ b/src/lib/services/datastore.ts
@@ -1,21 +1,22 @@
 import { readProject } from '$lib/utils/projectValidation';
 import type { Project } from '$lib/models/types';
+import { withDatabase, transaction, request, records, readRecord, libraryBackup, notifyLibraryChange } from './localDatabase';
+export { PROJECTS_STORAGE_KEY, LIBRARY_CHANGE_KEY } from './localDatabase';
 
 export interface DataStore {
   has(id: string): Promise<boolean>;
-  assertCurrent(id: string): void;
+  assertCurrent(id: string): Promise<void>;
   saveCopy(project: Project, suffix?: string): Promise<Project>;
   save(project: Project): Promise<void>;
   load(id: string): Promise<Project | null>;
   list(): Promise<{ id: string; name: string; updatedAt: string }[]>;
   delete(id: string): Promise<void>;
   duplicate(id: string): Promise<Project | null>;
-  saveThumbnail(id: string, dataUrl: string): void;
-  getThumbnail(id: string): string | null;
+  saveThumbnail(id: string, dataUrl: string): Promise<void>;
+  getThumbnail(id: string): Promise<string | null>;
+  getThumbnails(): Promise<Record<string, string>>;
 }
 
-export const PROJECTS_STORAGE_KEY = 'floorplan_projects';
-const KEY = PROJECTS_STORAGE_KEY;
 
 export class ProjectConflictError extends Error {
   constructor() {
@@ -24,29 +25,13 @@ export class ProjectConflictError extends Error {
   }
 }
 
-/** Current tabs share one lock because localStorage holds the entire library. */
-async function mutateLibrary<T>(change: () => T): Promise<T> {
+/** Keep in-document saves ordered; IndexedDB transactions also protect browsers without Web Locks. */
+async function mutateLibrary<T>(change: () => Promise<T>): Promise<T> {
   if (typeof window !== 'undefined' && typeof navigator !== 'undefined' && navigator.locks?.request) {
     return navigator.locks.request('openplan3d-project-library', change);
   }
-  // Older/insecure self-hosted contexts retain revision checks, but cannot
-  // coordinate simultaneous writes across tabs without Web Locks.
+  // IndexedDB compare-and-write transactions remain atomic without Web Locks.
   return change();
-}
-
-function getAll(): Record<string, string> {
-  const raw = localStorage.getItem(KEY);
-  try {
-    const all = JSON.parse(raw ?? '{}');
-    if (!all || typeof all !== 'object' || Array.isArray(all) ||
-        Object.values(all).some(value => typeof value !== 'string')) {
-      throw new Error('Invalid project library');
-    }
-    // Imported IDs are data, including names such as "__proto__" and "constructor".
-    return Object.assign(Object.create(null), all);
-  } catch {
-    throw new Error('The saved project library could not be read. Download a backup before attempting recovery.');
-  }
 }
 
 export function storageErrorMessage(error: unknown): string {
@@ -61,9 +46,8 @@ export function storageErrorMessage(error: unknown): string {
 }
 
 /** Preserve the original bytes, including a damaged library, for manual recovery. */
-export function downloadLibraryBackup() {
-  const raw = localStorage.getItem(KEY);
-  if (raw === null) throw new Error('No saved project library was found.');
+export async function downloadLibraryBackup() {
+  const raw = await libraryBackup();
   const url = URL.createObjectURL(new Blob([raw], { type: 'application/json' }));
   const link = document.createElement('a');
   link.href = url;
@@ -77,27 +61,27 @@ export function createLocalStore(): DataStore {
   const opened = new Map<string, string | null>();
   const listed = new Map<string, string>();
   const generations = new Map<string, number>();
-  const entry = (all: Record<string, string>, id: string) => all[id] ?? null;
+  const check = (id: string, raw: string | null) => {
+    if (raw !== (opened.get(id) ?? null)) throw new ProjectConflictError();
+  };
   return {
-    async has(id) { return Object.hasOwn(getAll(), id); },
+    async has(id) { return (await readRecord('projects', id)) !== null; },
 
-    assertCurrent(id) {
-      if (entry(getAll(), id) !== (opened.get(id) ?? null)) throw new ProjectConflictError();
-    },
+    async assertCurrent(id) { check(id, await readRecord('projects', id)); },
 
     async save(project) {
-      // Freeze before waiting for a lock: callers can continue editing meanwhile.
-      const id = project.id, raw = JSON.stringify(project);
-      const generation = generations.get(id);
-      await mutateLibrary(() => {
-        const all = getAll();
-        if (generation !== generations.get(id) || entry(all, id) !== (opened.get(id) ?? null)) {
-          throw new ProjectConflictError();
-        }
-        all[id] = raw;
-        // setItem is atomic on failure. Never evict another project to make space.
-        localStorage.setItem(KEY, JSON.stringify(all));
+      const id = project.id, raw = JSON.stringify(project), generation = generations.get(id);
+      await mutateLibrary(async () => {
+        await withDatabase(db => transaction(db, ['projects'], 'readwrite', async tx => {
+          const projects = tx.objectStore('projects');
+          const stored = (await request(projects.get(id))) ?? null;
+          if (generation !== generations.get(id)) throw new ProjectConflictError();
+          check(id, stored);
+          projects.put(raw, id);
+        }));
+        // A successful request alone is not a committed transaction.
         opened.set(id, raw);
+        notifyLibraryChange(id);
       });
     },
 
@@ -105,79 +89,86 @@ export function createLocalStore(): DataStore {
       const copy = readProject(project);
       copy.name = `${copy.name || 'Untitled Project'} (${suffix})`;
       copy.createdAt = copy.updatedAt = new Date();
-      return mutateLibrary(() => {
-        const all = getAll();
-        let attempts = 0;
-        do {
-          if (++attempts > 5) throw new Error('Could not choose a new project ID. Try saving a copy again.');
-          copy.id = globalThis.crypto?.randomUUID?.() ?? `project-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-        } while (Object.hasOwn(all, copy.id));
-        const raw = JSON.stringify(copy);
-        all[copy.id] = raw;
-        localStorage.setItem(KEY, JSON.stringify(all));
-        opened.set(copy.id, raw);
+      return mutateLibrary(async () => {
+        await withDatabase(db => transaction(db, ['projects'], 'readwrite', async tx => {
+          const projects = tx.objectStore('projects');
+          let attempts = 0;
+          do {
+            if (++attempts > 5) throw new Error('Could not choose a new project ID. Try saving a copy again.');
+            copy.id = globalThis.crypto?.randomUUID?.() ?? `project-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+          } while (await request(projects.get(copy.id)) !== undefined);
+          projects.add(JSON.stringify(copy), copy.id);
+        }));
+        opened.set(copy.id, JSON.stringify(copy));
+        notifyLibraryChange(copy.id);
         return copy;
       });
     },
 
     async load(id) {
-      const all = getAll();
-      const raw = all[id];
-      if (raw === undefined) {
-        opened.set(id, null);
-        generations.set(id, (generations.get(id) ?? 0) + 1);
-        return null;
-      }
+      // Invalidate queued saves immediately, including while this read is waiting.
+      generations.set(id, (generations.get(id) ?? 0) + 1);
+      const raw = await readRecord('projects', id);
+      if (raw === null) { opened.set(id, null); return null; }
       const project = readProject(JSON.parse(raw));
       if (project.id !== id) throw new Error('The saved project ID does not match its library entry. Download a library backup before recovery.');
       opened.set(id, raw);
-      generations.set(id, (generations.get(id) ?? 0) + 1);
       return project;
     },
 
     async list() {
-      const all = getAll();
+      const all = await withDatabase(db => transaction(db, ['projects'], 'readonly', tx => records(tx, 'projects')));
       const projects = Object.entries(all).map(([id, raw]) => {
         const p = JSON.parse(raw);
         return { id, name: p.name, updatedAt: p.updatedAt };
       });
-      // Listing must not rebase an editor's separately loaded revision.
       listed.clear();
       for (const [id, raw] of Object.entries(all)) listed.set(id, raw);
       return projects;
     },
 
     async delete(id) {
-      await mutateLibrary(() => {
-        const all = getAll();
-        const expected = listed.has(id) ? listed.get(id) : opened.get(id);
-        if (entry(all, id) !== (expected ?? null)) throw new ProjectConflictError();
-        delete all[id];
-        localStorage.setItem(KEY, JSON.stringify(all));
-        // Keep the old opened revision so a deleted editor cannot recreate it.
+      await mutateLibrary(async () => {
+        await withDatabase(db => transaction(db, ['projects', 'thumbnails', 'history'], 'readwrite', async tx => {
+          const projects = tx.objectStore('projects');
+          const expected = listed.has(id) ? listed.get(id) : opened.get(id);
+          if (((await request(projects.get(id))) ?? null) !== (expected ?? null)) throw new ProjectConflictError();
+          projects.delete(id);
+          tx.objectStore('thumbnails').delete(id);
+          tx.objectStore('history').delete(id);
+        }));
+        // Retain the opened revision so this editor cannot recreate a deleted plan.
         listed.delete(id);
-        try { localStorage.removeItem(`floorplan_thumb_${id}`); } catch {}
+        notifyLibraryChange(id);
       });
     },
 
-    async duplicate(id: string): Promise<Project | null> {
+    async duplicate(id) {
       const original = await this.load(id);
       if (!original) return null;
       const dup = await this.saveCopy(original, 'Copy');
-      // Copy thumbnail if exists
-      try {
-        const thumb = localStorage.getItem(`floorplan_thumb_${id}`);
-        if (thumb) localStorage.setItem(`floorplan_thumb_${dup.id}`, thumb);
-      } catch {}
+      const thumb = await this.getThumbnail(id);
+      if (thumb) await this.saveThumbnail(dup.id, thumb);
       return dup;
     },
 
-    saveThumbnail(id: string, dataUrl: string) {
-      try { this.assertCurrent(id); localStorage.setItem(`floorplan_thumb_${id}`, dataUrl); } catch {}
+    async saveThumbnail(id, dataUrl) {
+      const expected = opened.get(id);
+      try {
+        await withDatabase(db => transaction(db, ['projects', 'thumbnails'], 'readwrite', async tx => {
+          if (expected === undefined || expected === null || await request(tx.objectStore('projects').get(id)) !== expected) return;
+          tx.objectStore('thumbnails').put(dataUrl, id);
+        }));
+      } catch {} // Previews are optional; a failed preview cannot invalidate a saved plan.
     },
 
-    getThumbnail(id: string): string | null {
-      try { return localStorage.getItem(`floorplan_thumb_${id}`); } catch { return null; }
+    async getThumbnail(id) {
+      try { return await readRecord('thumbnails', id); } catch { return null; }
+    },
+
+    async getThumbnails() {
+      try { return await withDatabase(db => transaction(db, ['thumbnails'], 'readonly', tx => records(tx, 'thumbnails'))); }
+      catch { return {}; }
     },
   };
 }

--- a/src/lib/services/localDatabase.ts
+++ b/src/lib/services/localDatabase.ts
@@ -1,0 +1,181 @@
+import { readProject } from '$lib/utils/projectValidation';
+
+export const DATABASE_NAME = 'openplan3d-local';
+export const PROJECTS_STORAGE_KEY = 'floorplan_projects';
+export const LIBRARY_CHANGE_KEY = 'openplan3d-library-change';
+export const STORES = ['projects', 'thumbnails', 'history', 'meta'] as const;
+export type StoreName = typeof STORES[number];
+type Legacy = Record<string, string>;
+
+export function request<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function openDatabase(): Promise<IDBDatabase> {
+  if (typeof indexedDB === 'undefined') throw new Error('Browser storage is unavailable. Allow site storage or download your project as JSON.');
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DATABASE_NAME, 1);
+    let blocked = false;
+    req.onupgradeneeded = () => {
+      if (blocked) { req.transaction?.abort(); return; }
+      for (const name of STORES) req.result.createObjectStore(name);
+    };
+    req.onblocked = () => {
+      blocked = true;
+      reject(new Error('Close other OpenPlan3D tabs, then retry loading to update browser storage. Your saved projects have not been removed.'));
+    };
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => {
+      const db = req.result;
+      if (blocked) { db.close(); return; }
+      db.onversionchange = () => db.close();
+      resolve(db);
+    };
+  });
+}
+
+/** Only await IndexedDB requests inside run: other work can let a transaction expire. */
+export async function transaction<T>(db: IDBDatabase, stores: StoreName[], mode: IDBTransactionMode,
+  run: (tx: IDBTransaction) => Promise<T>): Promise<T> {
+  const tx = db.transaction(stores, mode);
+  const done = new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onabort = () => reject(tx.error ?? new DOMException('The storage transaction was interrupted. Try saving again.', 'AbortError'));
+    tx.onerror = () => {}; // Request errors abort; completion, not request success, confirms a save.
+  });
+  // Observe aborts even when a synchronous validation error stops run first.
+  void done.catch(() => {});
+  try {
+    const value = await run(tx);
+    await done;
+    return value;
+  } catch (error) {
+    try { tx.abort(); } catch {}
+    await done.catch(() => {});
+    throw error;
+  }
+}
+
+function legacyStorage(): Legacy {
+  const result: Legacy = Object.create(null);
+  const library = localStorage.getItem(PROJECTS_STORAGE_KEY);
+  if (library !== null) result[PROJECTS_STORAGE_KEY] = library;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith('floorplan_thumb_') || key?.startsWith('vh_')) {
+      const raw = localStorage.getItem(key);
+      if (raw !== null) result[key] = raw;
+    }
+  }
+  return result;
+}
+
+function library(raw?: string): Record<string, string> {
+  try {
+    const value = JSON.parse(raw ?? '{}');
+    if (!value || typeof value !== 'object' || Array.isArray(value) || Object.values(value).some(v => typeof v !== 'string')) throw new Error();
+    return Object.assign(Object.create(null), value);
+  } catch {
+    throw new Error('The saved project library could not be read. Download a backup before attempting recovery.');
+  }
+}
+
+/** Import once in a single transaction; leave all source bytes untouched for recovery.
+ * Older releases may still write localStorage. Preserve their subsequent changes as
+ * separate copies, never overwrite or resurrect a project in the new library.
+ */
+async function migrate(db: IDBDatabase) {
+  await transaction(db, [...STORES], 'readwrite', async tx => {
+    const meta = tx.objectStore('meta');
+    const previous: Legacy | undefined = await request(meta.get('legacy-current'));
+    const current = legacyStorage();
+    if (previous && JSON.stringify(previous) === JSON.stringify(current)) return;
+    const projects = tx.objectStore('projects');
+    const entries = library(current[PROJECTS_STORAGE_KEY]);
+    if (!previous) {
+      for (const [id, raw] of Object.entries(entries)) projects.add(raw, id);
+      for (const [key, raw] of Object.entries(current)) {
+        if (key.startsWith('floorplan_thumb_')) tx.objectStore('thumbnails').add(raw, key.slice(16));
+        if (key.startsWith('vh_')) tx.objectStore('history').add(raw, key.slice(3));
+      }
+      meta.add(current, 'legacy-original');
+    } else {
+      const before = library(previous[PROJECTS_STORAGE_KEY]);
+      for (const [id, raw] of Object.entries(entries)) {
+        if (before[id] === raw || await request(projects.get(id)) === raw) continue;
+        // Invalid bytes stay available in the full backup. Valid old-tab edits are
+        // immediately visible in the library, with their own independent history.
+        try {
+          const copy = readProject(JSON.parse(raw));
+          const link: { id: string; raw: string } | undefined = await request(meta.get(`recovered:${id}`));
+          // Continuing work in an old tab updates its untouched recovery copy.
+          // Editing/deleting that copy in the new app makes the next recovery independent.
+          const reuse = link && await request(projects.get(link.id)) === link.raw;
+          copy.id = reuse ? link.id : crypto.randomUUID();
+          copy.name = `${copy.name || 'Untitled Project'} (Recovered from older tab)`;
+          const recoveredRaw = JSON.stringify(copy);
+          if (reuse) projects.put(recoveredRaw, copy.id); else projects.add(recoveredRaw, copy.id);
+          meta.put({ id: copy.id, raw: recoveredRaw }, `recovered:${id}`);
+          const thumb = current[`floorplan_thumb_${id}`];
+          if (thumb) tx.objectStore('thumbnails').put(thumb, copy.id);
+        } catch (error) {
+          // Parsing failures must not make the existing IndexedDB library unavailable.
+          // IDB failures, however, must abort migration and leave its marker unchanged.
+          if (error instanceof DOMException) throw error;
+        }
+      }
+    }
+    meta.put(current, 'legacy-current');
+  });
+}
+
+export async function withDatabase<T>(run: (db: IDBDatabase) => Promise<T>): Promise<T> {
+  const db = await openDatabase();
+  try { await migrate(db); return await run(db); }
+  finally { db.close(); }
+}
+
+export function readRecord(store: StoreName, id: string): Promise<string | null> {
+  return withDatabase(db => transaction(db, [store], 'readonly', async tx =>
+    (await request(tx.objectStore(store).get(id))) ?? null));
+}
+
+export function updateRecord(store: StoreName, id: string, update: (raw: string | null) => string | null): Promise<void> {
+  return withDatabase(db => transaction(db, [store], 'readwrite', async tx => {
+    const records = tx.objectStore(store);
+    const raw = update((await request(records.get(id))) ?? null);
+    if (raw === null) records.delete(id); else records.put(raw, id);
+  }));
+}
+
+export async function records(tx: IDBTransaction, name: StoreName): Promise<Record<string, string>> {
+  const store = tx.objectStore(name);
+  const [keys, values] = await Promise.all([request(store.getAllKeys()), request(store.getAll())]);
+  return Object.fromEntries(keys.map((key, index) => [String(key), values[index]]));
+}
+
+/** Recovery deliberately bypasses migration and validation, including damaged bytes. */
+export async function libraryBackup(): Promise<string> {
+  const db = await openDatabase();
+  try {
+    return await transaction(db, [...STORES], 'readonly', async tx => {
+      const [projects, thumbnails, history, original, previous] = await Promise.all([
+        records(tx, 'projects'), records(tx, 'thumbnails'), records(tx, 'history'),
+        request(tx.objectStore('meta').get('legacy-original')), request(tx.objectStore('meta').get('legacy-current')),
+      ]);
+      const current = legacyStorage();
+      if (!original && !Object.keys(projects).length && current[PROJECTS_STORAGE_KEY] !== undefined) return current[PROJECTS_STORAGE_KEY];
+      return JSON.stringify({ format: 'openplan3d-library', version: 1, projects, thumbnails, history,
+        legacy: { original, previous, current } });
+    });
+  } finally { db.close(); }
+}
+
+export function notifyLibraryChange(id: string) {
+  // A tiny optional signal, never project data. Commit correctness does not depend
+  // on notifications or localStorage quota; focus and saves recheck the database.
+  try { localStorage.setItem(LIBRARY_CHANGE_KEY, JSON.stringify({ id, nonce: crypto.randomUUID() })); } catch {}
+}

--- a/src/lib/services/localDatabase.ts
+++ b/src/lib/services/localDatabase.ts
@@ -92,7 +92,8 @@ async function migrate(db: IDBDatabase) {
     const meta = tx.objectStore('meta');
     const previous: Legacy | undefined = await request(meta.get('legacy-current'));
     const current = legacyStorage();
-    if (previous && JSON.stringify(previous) === JSON.stringify(current)) return;
+    if (previous && Object.keys(previous).length === Object.keys(current).length &&
+        Object.entries(current).every(([key, raw]) => previous[key] === raw)) return;
     const projects = tx.objectStore('projects');
     const entries = library(current[PROJECTS_STORAGE_KEY]);
     if (!previous) {
@@ -106,26 +107,30 @@ async function migrate(db: IDBDatabase) {
       const before = library(previous[PROJECTS_STORAGE_KEY]);
       for (const [id, raw] of Object.entries(entries)) {
         if (before[id] === raw || await request(projects.get(id)) === raw) continue;
-        // Invalid bytes stay available in the full backup. Valid old-tab edits are
-        // immediately visible in the library, with their own independent history.
+        // Invalid bytes stay available in the full backup. Only validation errors
+        // are skippable; any failure while storing a recovery must abort migration.
+        let copy;
         try {
-          const copy = readProject(JSON.parse(raw));
-          const link: { id: string; raw: string } | undefined = await request(meta.get(`recovered:${id}`));
-          // Continuing work in an old tab updates its untouched recovery copy.
-          // Editing/deleting that copy in the new app makes the next recovery independent.
-          const reuse = link && await request(projects.get(link.id)) === link.raw;
-          copy.id = reuse ? link.id : crypto.randomUUID();
-          copy.name = `${copy.name || 'Untitled Project'} (Recovered from older tab)`;
-          const recoveredRaw = JSON.stringify(copy);
-          if (reuse) projects.put(recoveredRaw, copy.id); else projects.add(recoveredRaw, copy.id);
-          meta.put({ id: copy.id, raw: recoveredRaw }, `recovered:${id}`);
-          const thumb = current[`floorplan_thumb_${id}`];
-          if (thumb) tx.objectStore('thumbnails').put(thumb, copy.id);
-        } catch (error) {
-          // Parsing failures must not make the existing IndexedDB library unavailable.
-          // IDB failures, however, must abort migration and leave its marker unchanged.
-          if (error instanceof DOMException) throw error;
+          copy = readProject(JSON.parse(raw));
+        } catch { continue; }
+        const link: { id: string; raw: string } | undefined = await request(meta.get(`recovered:${id}`));
+        // Continuing work in an old tab updates its untouched recovery copy.
+        // Editing/deleting that copy in the new app makes the next recovery independent.
+        const reuse = link && await request(projects.get(link.id)) === link.raw;
+        if (reuse) copy.id = link.id;
+        else {
+          let attempts = 0;
+          do {
+            if (++attempts > 5) throw new Error('Could not choose a recovery project ID. Try loading again.');
+            copy.id = globalThis.crypto?.randomUUID?.() ?? `project-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+          } while (await request(projects.get(copy.id)) !== undefined);
         }
+        copy.name = `${copy.name || 'Untitled Project'} (Recovered from older tab)`;
+        const recoveredRaw = JSON.stringify(copy);
+        if (reuse) projects.put(recoveredRaw, copy.id); else projects.add(recoveredRaw, copy.id);
+        meta.put({ id: copy.id, raw: recoveredRaw }, `recovered:${id}`);
+        const thumb = current[`floorplan_thumb_${id}`];
+        if (thumb) tx.objectStore('thumbnails').put(thumb, copy.id);
       }
     }
     meta.put(current, 'legacy-current');

--- a/src/lib/stores/saveStatus.ts
+++ b/src/lib/stores/saveStatus.ts
@@ -1,6 +1,6 @@
 import { writable, get } from 'svelte/store';
 import { currentProject, loadProject } from './project';
-import { localStore, storageErrorMessage, ProjectConflictError, PROJECTS_STORAGE_KEY } from '$lib/services/datastore';
+import { localStore, storageErrorMessage, ProjectConflictError, PROJECTS_STORAGE_KEY, LIBRARY_CHANGE_KEY } from '$lib/services/datastore';
 import { saveSnapshot } from '$lib/stores/versionHistory';
 import type { Project } from '$lib/models/types';
 
@@ -35,13 +35,14 @@ export function initAutoSave() {
     }
     markDirty();
   });
-  const onStorage = (event: StorageEvent) => {
-    if (event.key !== null && event.key !== PROJECTS_STORAGE_KEY) return;
-    if (event.storageArea && event.storageArea !== localStorage) return;
+  let disposed = false;
+  const checkCurrent = async () => {
     const project = get(currentProject);
     if (!project) return;
-    try { localStore.assertCurrent(project.id); }
+    const attempt = saveAttempt;
+    try { await localStore.assertCurrent(project.id); }
     catch (error) {
+      if (disposed || get(currentProject) !== project || attempt !== saveAttempt) return;
       clearSaveTimer();
       saveAttempt++;
       saveState.set('unsaved');
@@ -49,11 +50,23 @@ export function initAutoSave() {
       saveConflict.set(error instanceof ProjectConflictError);
     }
   };
-  if (typeof window !== 'undefined') window.addEventListener('storage', onStorage);
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== null && event.key !== PROJECTS_STORAGE_KEY && event.key !== LIBRARY_CHANGE_KEY) return;
+    if (event.storageArea && event.storageArea !== localStorage) return;
+    void checkCurrent();
+  };
+  if (typeof window !== 'undefined') {
+    window.addEventListener('storage', onStorage);
+    window.addEventListener('focus', checkCurrent);
+  }
   const stop = () => {
+    disposed = true;
     unsubscribe();
     clearSaveTimer();
-    if (typeof window !== 'undefined') window.removeEventListener('storage', onStorage);
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener('focus', checkCurrent);
+    }
     if (stopWatching === stop) stopWatching = null;
   };
   stopWatching = stop;

--- a/src/lib/stores/versionHistory.ts
+++ b/src/lib/stores/versionHistory.ts
@@ -2,6 +2,8 @@ import { writable, get } from 'svelte/store';
 import { currentProject, loadProject } from './project';
 import { readProject } from '$lib/utils/projectValidation';
 import type { Project } from '$lib/models/types';
+import { readRecord, updateRecord } from '$lib/services/localDatabase';
+import { storageErrorMessage } from '$lib/services/datastore';
 
 export interface Snapshot {
   timestamp: number;
@@ -12,14 +14,9 @@ export interface Snapshot {
 const MAX_SNAPSHOTS = 10;
 const SNAPSHOT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
-function storageKey(projectId: string): string {
-  return `vh_${projectId}`;
-}
-
 export const snapshotError = writable<string | null>(null);
 
-export function getSnapshots(projectId: string): Snapshot[] {
-  const raw = localStorage.getItem(storageKey(projectId));
+function parseSnapshots(raw: string | null): Snapshot[] {
   if (raw === null) return [];
   try {
     const snapshots = JSON.parse(raw);
@@ -32,9 +29,13 @@ export function getSnapshots(projectId: string): Snapshot[] {
   }
 }
 
+export async function getSnapshots(projectId: string): Promise<Snapshot[]> {
+  return parseSnapshots(await readRecord('history', projectId));
+}
+
 /** Keep the raw history bytes available even if a snapshot cannot be opened. */
-export function downloadSnapshotBackup(projectId: string) {
-  const raw = localStorage.getItem(storageKey(projectId));
+export async function downloadSnapshotBackup(projectId: string) {
+  const raw = await readRecord('history', projectId);
   if (raw === null) throw new Error('No saved version history was found.');
   const url = URL.createObjectURL(new Blob([raw], { type: 'application/json' }));
   const link = document.createElement('a');
@@ -42,102 +43,88 @@ export function downloadSnapshotBackup(projectId: string) {
   URL.revokeObjectURL(url);
 }
 
-function persistSnapshots(projectId: string, snapshots: Snapshot[]) {
+export const snapshotsStore = writable<Snapshot[]>([]);
+let refreshRequest = 0;
+const writeErrors = new Map<string, string>();
+
+export async function saveSnapshot(project: Project, description: string) {
+  // Freeze now: the editor may keep changing while storage is busy.
+  const snapshot = { timestamp: Date.now(), description, data: JSON.stringify(project) };
   try {
-    localStorage.setItem(storageKey(projectId), JSON.stringify(snapshots));
-  } catch (e) {
-    // localStorage full — prune harder
-    console.warn('[VersionHistory] Storage full, pruning to 5 snapshots');
-    const pruned = snapshots.slice(-5);
-    try {
-      localStorage.setItem(storageKey(projectId), JSON.stringify(pruned));
-    } catch {
-      console.error('[VersionHistory] Cannot save snapshots');
+    await updateRecord('history', project.id, raw => {
+      const snapshots = parseSnapshots(raw);
+      return JSON.stringify([...snapshots, snapshot].slice(-MAX_SNAPSHOTS));
+    });
+    writeErrors.delete(project.id);
+    if (get(currentProject)?.id === project.id) await refreshSnapshots();
+    return true;
+  } catch (error) {
+    const message = storageErrorMessage(error);
+    writeErrors.set(project.id, message);
+    if (get(currentProject)?.id === project.id) snapshotError.set(message);
+    return false; // Failed writes retain all previous versions, with no pruning retry.
+  }
+}
+
+export async function restoreSnapshot(projectId: string, index: number, expected?: Snapshot): Promise<boolean> {
+  const before = get(currentProject);
+  try {
+    const snapshots = await getSnapshots(projectId);
+    if (get(currentProject) !== before || before?.id !== projectId) return false;
+    if (!Number.isInteger(index) || index < 0 || index >= snapshots.length ||
+        (expected && JSON.stringify(snapshots[index]) !== JSON.stringify(expected))) {
+      throw new Error('This version changed. Close and reopen version history, then choose it again.');
     }
-  }
-}
-
-export function saveSnapshot(project: Project, description: string) {
-  let snapshots: Snapshot[];
-  try { snapshots = getSnapshots(project.id); }
-  catch (error) {
-    snapshotError.set(error instanceof Error ? error.message : 'Could not read version history.');
-    return; // Never replace an unreadable history with a new, empty one.
-  }
-  snapshots.push({
-    timestamp: Date.now(),
-    description,
-    data: JSON.stringify(project),
-  });
-  // Prune to keep last MAX_SNAPSHOTS
-  while (snapshots.length > MAX_SNAPSHOTS) {
-    snapshots.shift();
-  }
-  persistSnapshots(project.id, snapshots);
-  snapshotsStore.set(snapshots);
-}
-
-export function restoreSnapshot(projectId: string, index: number): boolean {
-  try {
-    const snapshots = getSnapshots(projectId);
-    if (!Number.isInteger(index) || index < 0 || index >= snapshots.length) throw new Error('This version is no longer available.');
     const project = readProject(JSON.parse(snapshots[index].data));
     if (project.id !== projectId) throw new Error('This version belongs to a different project.');
     loadProject(project);
     snapshotError.set(null);
     return true;
   } catch (error) {
-    snapshotError.set(`${error instanceof Error ? error.message : 'Could not read this version.'} Your current plan has not changed.`);
+    if (get(currentProject) === before) snapshotError.set(`${error instanceof Error ? error.message : 'Could not read this version.'} Your current plan has not changed.`);
     return false;
   }
 }
 
-export function deleteAllSnapshots(projectId: string) {
-  localStorage.removeItem(storageKey(projectId));
-  snapshotsStore.set([]);
-  snapshotError.set(null);
+export async function deleteAllSnapshots(projectId: string) {
+  await updateRecord('history', projectId, () => null);
+  writeErrors.delete(projectId);
+  if (get(currentProject)?.id === projectId) await refreshSnapshots();
 }
 
-// Reactive store for current project's snapshots
-export const snapshotsStore = writable<Snapshot[]>([]);
-
-// Refresh snapshots store for current project
-export function refreshSnapshots() {
-  snapshotError.set(null);
-  const p = get(currentProject);
-  try { snapshotsStore.set(p ? getSnapshots(p.id) : []); }
-  catch (error) {
+export async function refreshSnapshots() {
+  const request = ++refreshRequest, p = get(currentProject);
+  try {
+    const snapshots = p ? await getSnapshots(p.id) : [];
+    if (request === refreshRequest && get(currentProject)?.id === p?.id) {
+      snapshotsStore.set(snapshots);
+      snapshotError.set(p ? writeErrors.get(p.id) ?? null : null);
+    }
+  } catch (error) {
+    if (request !== refreshRequest || get(currentProject)?.id !== p?.id) return;
     snapshotsStore.set([]);
-    snapshotError.set(error instanceof Error ? error.message : 'Could not read version history.');
+    snapshotError.set(storageErrorMessage(error));
   }
 }
 
-// Auto-snapshot timer
 let intervalId: ReturnType<typeof setInterval> | null = null;
 
 export function initVersionHistory() {
   if (intervalId) return;
-  // Take a snapshot every 5 minutes
   intervalId = setInterval(() => {
     const p = get(currentProject);
-    if (p) saveSnapshot(p, 'Auto-save');
+    if (p) void saveSnapshot(p, 'Auto-save');
   }, SNAPSHOT_INTERVAL_MS);
-  // Initial snapshot
   const p = get(currentProject);
-  if (p) {
-    saveSnapshot(p, 'Session start');
-  }
+  if (p) void saveSnapshot(p, 'Session start');
 }
 
 export function stopVersionHistory() {
-  if (intervalId) {
-    clearInterval(intervalId);
-    intervalId = null;
-  }
+  if (intervalId) clearInterval(intervalId);
+  intervalId = null;
 }
 
-/** Create a snapshot on major actions (call manually) */
 export function snapshotOnAction(description: string) {
   const p = get(currentProject);
-  if (p) saveSnapshot(p, description);
+  if (p) void saveSnapshot(p, description);
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,8 +27,8 @@
     catch (error) { libraryError = storageErrorMessage(error); }
   }
 
-  function backupLibrary() {
-    try { downloadLibraryBackup(); }
+  async function backupLibrary() {
+    try { await downloadLibraryBackup(); }
     catch (error) { libraryError = storageErrorMessage(error); }
   }
 
@@ -36,12 +36,7 @@
     projects = await localStore.list();
     // Sort by most recent
     projects.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-    // Load thumbnails
-    const thumbs: Record<string, string | null> = {};
-    for (const p of projects) {
-      thumbs[p.id] = localStore.getThumbnail(p.id);
-    }
-    thumbnails = thumbs;
+    thumbnails = await localStore.getThumbnails();
   }
 
   onMount(() => {
@@ -79,7 +74,7 @@
       const dup = await localStore.duplicate(id);
       if (dup) {
         projects = (await localStore.list()).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-        thumbnails = { ...thumbnails, [dup.id]: localStore.getThumbnail(dup.id) };
+        thumbnails = { ...thumbnails, [dup.id]: await localStore.getThumbnail(dup.id) };
       }
       contextMenuId = null;
     });
@@ -159,6 +154,12 @@
   </div>
 
   <div class="max-w-5xl mx-auto px-6 py-8">
+    {#if !libraryError && projects.length > 0}
+      <div class="mb-5 flex flex-wrap items-center justify-between gap-2 text-sm text-gray-500">
+        <p>Projects and version history are saved in this browser.</p>
+        <button class="font-semibold text-blue-600 underline" onclick={backupLibrary}>Download library backup</button>
+      </div>
+    {/if}
     {#if libraryError}
       <div role="alert" class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-900">
         <p>{libraryError}</p>

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -54,8 +54,8 @@
   let importError = $state<string | null>(null);
   let loadError = $state<string | null>(null);
 
-  function backupLibrary() {
-    try { downloadLibraryBackup(); }
+  async function backupLibrary() {
+    try { await downloadLibraryBackup(); }
     catch (error) { loadError = storageErrorMessage(error); }
   }
 

--- a/tests/browser/indexeddb.spec.ts
+++ b/tests/browser/indexeddb.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { storedRecords, savedProjects } from './storage';
+
+test('legacy migration preserves images and history, then saves beyond the old quota locally', async ({ page }, testInfo) => {
+  const source = JSON.parse(await readFile('tests/fixtures/save-conflicts.openplan.json', 'utf8'));
+  const history = JSON.stringify([{ timestamp: 1, description: 'Before migration', data: JSON.stringify(source) }]);
+  const legacy = JSON.stringify({ [source.id]: JSON.stringify(source) });
+  const errors: string[] = [], external: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  page.on('request', request => { if (/^https?:/.test(request.url()) && new URL(request.url()).origin !== 'http://127.0.0.1:4188') external.push(request.url()); });
+  await page.addInitScript(({ legacy, history, id }) => {
+    if (!localStorage.getItem('floorplan_projects')) {
+      localStorage.setItem('floorplan_projects', legacy);
+      localStorage.setItem(`vh_${id}`, history);
+      localStorage.setItem(`floorplan_thumb_${id}`, 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7');
+      localStorage.setItem('hasSeenWelcome', 'true');
+    }
+  }, { legacy, history, id: source.id });
+  await page.goto('/');
+  await expect(page.getByRole('link', { name: source.name, exact: true })).toBeVisible();
+  expect((await storedRecords(page, 'history'))[source.id]).toBe(history);
+  expect((await storedRecords(page, 'thumbnails'))[source.id]).toContain('data:image/gif');
+  const backupDownload = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download library backup', exact: true }).click();
+  const backup = JSON.parse(await readFile((await (await backupDownload).path())!, 'utf8'));
+  expect(backup.legacy.original.floorplan_projects).toBe(legacy);
+  expect(backup.history[source.id]).toBe(history);
+  await page.getByRole('link', { name: source.name, exact: true }).click();
+  await page.getByRole('button', { name: 'Version History', exact: true }).click();
+  await expect(page.getByRole('group', { name: 'Before migration', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Close', exact: true }).click();
+  // Large embedded image payload is ordinary project JSON; no cloud storage needed.
+  const large = { ...source, id: 'qa-large-local-project', name: 'QA Large local project', extensions: { image: 'data:image/png;base64,' + 'A'.repeat(6 * 1024 * 1024) } };
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const chooser = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+  await (await chooser).setFiles({ name: 'large.json', mimeType: 'application/json', buffer: Buffer.from(JSON.stringify(large)) });
+  await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(large.name);
+  await expect(page.getByRole('alert')).toHaveCount(0);
+  await page.reload();
+  await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(large.name);
+  expect((await savedProjects(page))[large.id].extensions).toEqual(large.extensions);
+  expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBe(legacy);
+  await page.setViewportSize({ width: 390, height: 900 });
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  await expect(page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
+  await testInfo.attach('large-local-project-mobile', { body: await page.screenshot(), contentType: 'image/png' });
+  expect(errors).toEqual([]); expect(external).toEqual([]);
+});
+
+test('interrupted migration leaves legacy bytes recoverable and retries without duplicate projects', async ({ page }) => {
+  const source = JSON.parse(await readFile('tests/fixtures/save-conflicts.openplan.json', 'utf8'));
+  const legacy = JSON.stringify({ [source.id]: JSON.stringify(source) });
+  await page.addInitScript(legacy => {
+    localStorage.setItem('floorplan_projects', legacy);
+    localStorage.setItem('hasSeenWelcome', 'true');
+    (window as any).failMigration = true;
+    const add = IDBObjectStore.prototype.add;
+    IDBObjectStore.prototype.add = function(...args) {
+      if (this.name === 'meta' && (window as any).failMigration) throw new DOMException('Full', 'QuotaExceededError');
+      return add.apply(this, args);
+    };
+  }, legacy);
+  await page.goto('/');
+  await expect(page.getByRole('alert')).toContainText('Browser storage is full');
+  expect(await storedRecords(page)).toEqual({});
+  const pending = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download library backup', exact: true }).click();
+  expect(await readFile((await (await pending).path())!, 'utf8')).toBe(legacy);
+  await page.evaluate(() => { (window as any).failMigration = false; });
+  await page.getByRole('button', { name: 'Retry loading', exact: true }).click();
+  await expect(page.getByRole('link', { name: source.name, exact: true })).toBeVisible();
+  expect(Object.keys(await savedProjects(page))).toEqual([source.id]);
+  expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBe(legacy);
+});
+
+test('late writes from an older release produce a visible recovery copy', async ({ page, context }) => {
+  const source = JSON.parse(await readFile('tests/fixtures/save-conflicts.openplan.json', 'utf8'));
+  await page.addInitScript(source => {
+    if (!localStorage.getItem('floorplan_projects')) localStorage.setItem('floorplan_projects', JSON.stringify({ [source.id]: JSON.stringify(source) }));
+    localStorage.setItem('hasSeenWelcome', 'true');
+  }, source);
+  await page.goto(`/editor?id=${source.id}`);
+  await page.getByTitle('Click to rename', { exact: true }).click();
+  await page.getByRole('textbox', { name: 'Project name' }).fill('Current release edit');
+  await page.getByRole('textbox', { name: 'Project name' }).press('Enter');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
+  const older = await context.newPage(); await older.goto('/');
+  await older.evaluate(source => localStorage.setItem('floorplan_projects', JSON.stringify({ [source.id]: JSON.stringify({ ...source, name: 'Older release edit' }) })), source);
+  await page.getByRole('link', { name: 'Projects', exact: true }).click();
+  await expect(page.getByRole('link', { name: 'Older release edit (Recovered from older tab)', exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Current release edit', exact: true })).toBeVisible();
+  expect(Object.keys(await savedProjects(page))).toHaveLength(2);
+});

--- a/tests/browser/project-opening.spec.ts
+++ b/tests/browser/project-opening.spec.ts
@@ -1,3 +1,4 @@
+import { savedProjects as library, storedRecords, failProjectWrites as failWrites } from './storage';
 import { expect, test, type Page } from '@playwright/test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
@@ -36,10 +37,6 @@ async function exportJSON(page: Page) {
   await page.getByRole('button', { name: 'Download JSON', exact: true }).click();
   return JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
 }
-async function library(page: Page) {
-  return page.evaluate(() => Object.fromEntries(Object.entries(JSON.parse(localStorage.getItem('floorplan_projects')!))
-    .map(([id, raw]) => [id, JSON.parse(raw as string)])));
-}
 function observe(page: Page) {
   const errors: string[] = [], external: string[] = [];
   page.on('pageerror', e => errors.push(e.message));
@@ -48,17 +45,6 @@ function observe(page: Page) {
   });
   return () => { expect(errors).toEqual([]); expect(external).toEqual([]); };
 }
-async function failWrites(page: Page) {
-  await page.evaluate(() => {
-    const setItem = Storage.prototype.setItem;
-    (window as any).failProjectWrites = true;
-    Storage.prototype.setItem = function(key, value) {
-      if (key === 'floorplan_projects' && (window as any).failProjectWrites) throw new DOMException('Full', 'QuotaExceededError');
-      return setItem.call(this, key, value);
-    };
-  });
-}
-
 for (const width of [1440, 390]) {
   test(`same-ID imports preserve pending edits and reopen as separate copies at ${width}px`, async ({ page }, testInfo) => {
     await page.setViewportSize({ width, height: 900 });
@@ -144,7 +130,7 @@ test('sidebar RoomPlan import and toolbar New Project preserve pending predecess
   await expect(page.getByRole('combobox', { name: 'Current floor' }).locator('option')).toHaveText(['Entry', 'Loft', 'Future Floor']);
   expect((await library(page))[source.id].name).toBe('Before RoomPlan import');
   const imported = await exportJSON(page);
-  const importedPreview = await page.evaluate(id => localStorage.getItem(`floorplan_thumb_${id}`), imported.id);
+  const importedPreview = (await storedRecords(page, 'thumbnails'))[imported.id];
   expect(importedPreview).toBeTruthy();
   await rename(page, 'Before New Project');
   expect((await library(page))[imported.id].name).toBe(imported.name);
@@ -153,8 +139,8 @@ test('sidebar RoomPlan import and toolbar New Project preserve pending predecess
   await expect(page.getByRole('application')).toContainText('0 walls');
   const created = await exportJSON(page);
   expect(created.id).not.toBe(imported.id);
-  await expect.poll(() => page.evaluate(id => localStorage.getItem(`floorplan_thumb_${id}`), created.id)).toBeTruthy();
-  expect(await page.evaluate(id => localStorage.getItem(`floorplan_thumb_${id}`), created.id)).not.toBe(importedPreview);
+  await expect.poll(async () => (await storedRecords(page, 'thumbnails'))[created.id]).toBeTruthy();
+  expect((await storedRecords(page, 'thumbnails'))[created.id]).not.toBe(importedPreview);
   expect((await library(page))[imported.id].name).toBe('Before New Project');
   await page.reload(); expect((await exportJSON(page)).id).toBe(created.id);
   check();

--- a/tests/browser/project-validation.spec.ts
+++ b/tests/browser/project-validation.spec.ts
@@ -1,3 +1,4 @@
+import { storedRecords } from './storage';
 import { expect, test, type Page } from '@playwright/test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
@@ -40,7 +41,7 @@ for (const width of [1440, 390]) {
     await thickness.fill('32.5'); await thickness.press('Tab');
     await page.getByRole('button', { name: 'Save', exact: true }).click();
     const saved = await exportProject(page), url = page.url();
-    const library = await page.evaluate(() => localStorage.getItem('floorplan_projects'));
+    const library = await storedRecords(page);
     const changes: [string, (project: any) => void][] = [
       ['walls[0].start', p => p.floors[0].walls[0].start = null],
       ['doors[0].wallId', p => p.floors[0].doors[0].wallId = 'missing'],
@@ -55,7 +56,7 @@ for (const width of [1440, 390]) {
       await expect(page.getByRole('alert')).toContainText('No project was imported.');
       expect(page.url()).toBe(url);
       expect(await exportProject(page)).toEqual(saved);
-      expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBe(library);
+      expect(await storedRecords(page)).toEqual(library);
       await expect(thickness).toHaveValue('32.5');
       await page.getByRole('button', { name: 'Dismiss import error', exact: true }).click();
     }
@@ -84,7 +85,7 @@ test('welcome import recovers from a damaged file and accepts missing legacy fie
   await (await pending).setFiles(damagedFixture);
   await expect(page.getByRole('alert')).toContainText('walls[0].start');
   await expect(page.getByRole('heading', { name: 'Welcome', exact: true })).toBeVisible();
-  expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBeNull();
+  expect(await storedRecords(page)).toEqual({});
   await page.getByRole('button', { name: 'Dismiss import error', exact: true }).click();
   const retry = page.waitForEvent('filechooser'); await importButton.click();
   await (await retry).setFiles(resolve('tests/fixtures/legacy-native.openplan.json'));
@@ -109,7 +110,9 @@ test('damaged saved geometry offers an exact raw backup without hiding healthy p
   await expect(page.getByRole('alert')).toContainText('walls[0].start');
   const pending = page.waitForEvent('download');
   await page.getByRole('button', { name: 'Download library backup', exact: true }).click();
-  expect(await readFile((await (await pending).path())!, 'utf8')).toBe(raw);
+  const backup = JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
+  expect(backup.projects).toEqual(JSON.parse(raw));
+  expect(backup.legacy.original.floorplan_projects).toBe(raw);
   expect(await page.evaluate(() => localStorage.getItem('floorplan_projects'))).toBe(raw);
   await page.goto('/editor?id=qa-healthy-neighbor');
   await expect(page.getByRole('application')).toContainText('1 room');
@@ -134,7 +137,7 @@ test('a damaged version stays available for backup and cannot replace the curren
   await dialog.getByRole('group', { name: 'Damaged snapshot', exact: true }).getByRole('button', { name: 'Restore', exact: true }).click();
   await expect(dialog.getByRole('alert')).toContainText('walls[0].start');
   await expect(dialog.getByRole('alert')).toContainText('Your current plan has not changed.');
-  const raw = await page.evaluate(id => localStorage.getItem(`vh_${id}`), source.id);
+  const raw = (await storedRecords(page, 'history'))[source.id];
   const pending = page.waitForEvent('download');
   await dialog.getByRole('button', { name: 'Download version backup', exact: true }).click();
   expect(await readFile((await (await pending).path())!, 'utf8')).toBe(raw);

--- a/tests/browser/save-conflicts.spec.ts
+++ b/tests/browser/save-conflicts.spec.ts
@@ -1,3 +1,4 @@
+import { savedProjects as saved, failProjectWrites } from './storage';
 import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
@@ -27,10 +28,6 @@ async function exported(page: Page) {
   const pending = page.waitForEvent('download');
   await page.getByRole('button', { name: 'Download JSON', exact: true }).click();
   return JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
-}
-async function saved(page: Page) {
-  return page.evaluate(() => Object.fromEntries(Object.entries(JSON.parse(localStorage.getItem('floorplan_projects')!))
-    .map(([id, raw]) => [id, JSON.parse(raw as string)])));
 }
 function observe(page: Page) {
   const errors: string[] = [], external: string[] = [];
@@ -67,14 +64,7 @@ for (const width of [1440, 390]) {
 
     // A full-storage recovery failure must leave the conflicting plan in memory.
     if (width === 1440) {
-      await other.evaluate(() => {
-        const original = Storage.prototype.setItem;
-        (window as any).failCopyWrite = true;
-        Storage.prototype.setItem = function(key, value) {
-          if (key === 'floorplan_projects' && (window as any).failCopyWrite) throw new DOMException('Full', 'QuotaExceededError');
-          return original.call(this, key, value);
-        };
-      });
+      await failProjectWrites(other, 'failCopyWrite');
       await other.getByRole('button', { name: 'Save as copy', exact: true }).click();
       await expect(other.getByRole('alert')).toContainText('Browser storage is full');
       expect((await exported(other)).id).toBe(source.id);

--- a/tests/browser/storage.ts
+++ b/tests/browser/storage.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+
+export async function storedRecords(page: Page, store = 'projects'): Promise<Record<string, string>> {
+  return page.evaluate(store => new Promise((resolve, reject) => {
+    const open = indexedDB.open('openplan3d-local', 1);
+    open.onerror = () => reject(open.error);
+    open.onsuccess = () => {
+      const db = open.result, tx = db.transaction(store, 'readonly'), records = tx.objectStore(store);
+      const keys = records.getAllKeys(), values = records.getAll();
+      tx.oncomplete = () => { db.close(); resolve(Object.fromEntries(keys.result.map((key, i) => [String(key), values.result[i]]))); };
+      tx.onabort = () => { db.close(); reject(tx.error); };
+    };
+  }), store);
+}
+
+export async function savedProjects(page: Page) {
+  return Object.fromEntries(Object.entries(await storedRecords(page)).map(([id, raw]) => [id, JSON.parse(raw)]));
+}
+
+/** Inject failure at the actual persistence boundary, without changing app code. */
+export async function failProjectWrites(page: Page, flag = 'failProjectWrites') {
+  await page.evaluate(flag => {
+    (window as any)[flag] = true;
+    for (const name of ['put', 'add'] as const) {
+      const original = IDBObjectStore.prototype[name];
+      IDBObjectStore.prototype[name] = function(...args) {
+        if (this.name === 'projects' && (window as any)[flag]) throw new DOMException('Full', 'QuotaExceededError');
+        return original.apply(this, args);
+      };
+    }
+  }, flag);
+}

--- a/tests/datastore.test.ts
+++ b/tests/datastore.test.ts
@@ -1,3 +1,4 @@
+import { mockStorage, rawRecords, failWrites } from './fixtures/indexeddb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { localStore } from '$lib/services/datastore';
 import { createDefaultProject } from '$lib/stores/project';
@@ -7,13 +8,8 @@ let data: Map<string, string>;
 let setItem: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
-  data = new Map();
-  setItem = vi.fn((key: string, value: string) => { data.set(key, value); });
-  vi.stubGlobal('localStorage', {
-    getItem: (key: string) => data.get(key) ?? null,
-    setItem,
-    removeItem: (key: string) => data.delete(key),
-  });
+  data = mockStorage();
+  setItem = vi.mocked(localStorage.setItem);
 });
 
 describe('local project persistence', () => {
@@ -35,17 +31,12 @@ describe('local project persistence', () => {
     const second = createDefaultProject('Second');
     await localStore.save(first);
     await localStore.save(second);
-    const before = data.get(key);
-    // A smaller retry would succeed, reproducing the old destructive fallback.
-    setItem.mockImplementation((key: string, value: string) => {
-      if (Object.keys(JSON.parse(value)).length > 1) throw new DOMException('Full', 'QuotaExceededError');
-      data.set(key, value);
-    });
-    setItem.mockClear();
+    const before = await rawRecords();
+    const restore = failWrites();
     second.name = 'Unsaved change';
     await expect(localStore.save(second)).rejects.toMatchObject({ name: 'QuotaExceededError' });
-    expect(setItem).toHaveBeenCalledTimes(1);
-    expect(data.get(key)).toBe(before);
+    expect(await rawRecords()).toEqual(before);
+    restore();
   });
 
   it.each(['{broken', 'null', '[]', '{"existing":42}'])('refuses to overwrite an unreadable library: %s', async (raw) => {
@@ -64,10 +55,10 @@ describe('local project persistence', () => {
   it('does not create a partial duplicate when storage fills up', async () => {
     const project = createDefaultProject();
     await localStore.save(project);
-    const before = data.get(key);
-    setItem.mockImplementation(() => { throw new DOMException('Full', 'QuotaExceededError'); });
+    const before = await rawRecords();
+    failWrites();
     await expect(localStore.duplicate(project.id)).rejects.toMatchObject({ name: 'QuotaExceededError' });
-    expect(data.get(key)).toBe(before);
+    expect(await rawRecords()).toEqual(before);
   });
 });
 

--- a/tests/fixtures/indexeddb.ts
+++ b/tests/fixtures/indexeddb.ts
@@ -1,0 +1,34 @@
+import { beforeEach, vi } from 'vitest';
+import { IDBFactory, IDBObjectStore } from 'fake-indexeddb';
+import { withDatabase, transaction, request, records, type StoreName } from '$lib/services/localDatabase';
+
+beforeEach(() => { vi.stubGlobal('indexedDB', new IDBFactory()); });
+
+export function mockStorage(data = new Map<string, string>()) {
+  vi.stubGlobal('localStorage', {
+    get length() { return data.size; },
+    key: (index: number) => [...data.keys()][index] ?? null,
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: vi.fn((key: string, value: string) => { data.set(key, value); }),
+    removeItem: (key: string) => data.delete(key),
+  });
+  return data;
+}
+export function rawRecords(store: StoreName = 'projects') {
+  return withDatabase(db => transaction(db, [store], 'readonly', tx => records(tx, store)));
+}
+export function putRaw(store: StoreName, id: string, raw: string) {
+  return withDatabase(db => transaction(db, [store], 'readwrite', async tx => { await request(tx.objectStore(store).put(raw, id)); }));
+}
+export function failWrites(store: StoreName = 'projects') {
+  const originalPut = IDBObjectStore.prototype.put, originalAdd = IDBObjectStore.prototype.add;
+  const put = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (this: IDBObjectStore, ...args) {
+    if (this.name === store) throw new DOMException('Full', 'QuotaExceededError');
+    return originalPut.apply(this, args);
+  });
+  const add = vi.spyOn(IDBObjectStore.prototype, 'add').mockImplementation(function (this: IDBObjectStore, ...args) {
+    if (this.name === store) throw new DOMException('Full', 'QuotaExceededError');
+    return originalAdd.apply(this, args);
+  });
+  return () => { put.mockRestore(); add.mockRestore(); };
+}

--- a/tests/localDatabase.test.ts
+++ b/tests/localDatabase.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { IDBObjectStore } from 'fake-indexeddb';
+import { createLocalStore } from '$lib/services/datastore';
+import { DATABASE_NAME, PROJECTS_STORAGE_KEY as key, libraryBackup, readRecord, updateRecord } from '$lib/services/localDatabase';
+import { roomProject } from './fixtures/project';
+import { mockStorage, rawRecords, failWrites } from './fixtures/indexeddb';
+
+let data: Map<string, string>;
+beforeEach(() => { data = mockStorage(); });
+
+it('migrates project, preview, embedded image and unreadable history bytes together only once', async () => {
+  const project = { ...roomProject(), extensions: { image: 'data:image/png;base64,original' } };
+  const raw = JSON.stringify({ [project.id]: JSON.stringify(project), damaged: '{broken project bytes' });
+  data.set(key, raw); data.set(`floorplan_thumb_${project.id}`, 'original preview'); data.set(`vh_${project.id}`, '{broken history bytes');
+  const before = new Map(data), store = createLocalStore();
+  expect((await store.load(project.id))!.floors).toEqual(project.floors);
+  expect(await store.getThumbnail(project.id)).toBe('original preview');
+  expect(await readRecord('history', project.id)).toBe('{broken history bytes');
+  expect(await readRecord('projects', 'damaged')).toBe('{broken project bytes');
+  expect(data).toEqual(before);
+  await updateRecord('projects', 'damaged', () => null);
+  await store.list(); await store.delete(project.id);
+  expect(await createLocalStore().list()).toEqual([]);
+  expect(await readRecord('history', project.id)).toBeNull();
+  expect(await store.getThumbnail(project.id)).toBeNull();
+  expect(data.get(key)).toBe(raw);
+  const backup = JSON.parse(await libraryBackup());
+  expect(backup.projects).toEqual({}); expect(backup.legacy.original[key]).toBe(raw);
+});
+
+it('aborts the entire migration on a preview quota failure, then retries from intact source bytes', async () => {
+  const project = roomProject(), raw = JSON.stringify({ [project.id]: JSON.stringify(project) });
+  data.set(key, raw); data.set(`floorplan_thumb_${project.id}`, 'preview');
+  const restore = failWrites('thumbnails');
+  await expect(createLocalStore().list()).rejects.toMatchObject({ name: 'QuotaExceededError' });
+  // Backup bypasses migration; no partially imported projects or marker survived.
+  expect(await libraryBackup()).toBe(raw); expect(data.get(key)).toBe(raw);
+  restore();
+  expect(await createLocalStore().list()).toHaveLength(1);
+  expect(await readRecord('thumbnails', project.id)).toBe('preview');
+});
+
+it('rejects an abort after a successful put request and retains its old revision for retry', async () => {
+  const store = createLocalStore(), project = roomProject(); await store.save(project);
+  const before = await rawRecords(), original = IDBObjectStore.prototype.put;
+  const spy = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function(this: IDBObjectStore, ...args) {
+    const req = original.apply(this, args);
+    if (this.name === 'projects') req.addEventListener('success', () => this.transaction.abort());
+    return req;
+  });
+  project.name = 'Interrupted edit';
+  await expect(store.save(project)).rejects.toMatchObject({ name: 'AbortError' });
+  expect(await rawRecords()).toEqual(before);
+  spy.mockRestore(); await store.save(project);
+  expect((await store.load(project.id))!.name).toBe('Interrupted edit');
+});
+
+it('saves a project larger than localStorage allows even when notification writes are denied', async () => {
+  const store = createLocalStore(), project = { ...roomProject(), extensions: { image: 'x'.repeat(6 * 1024 * 1024) } };
+  vi.spyOn(localStorage, 'setItem').mockImplementation(() => { throw new DOMException('Full', 'QuotaExceededError'); });
+  await store.save(project);
+  expect(JSON.parse((await rawRecords())[project.id]).extensions.image).toHaveLength(6 * 1024 * 1024);
+  expect(data.has(key)).toBe(false);
+});
+
+it('preserves late old-release edits as a reusable independent copy without resurrecting deleted originals', async () => {
+  const project = roomProject(); data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) }));
+  const store = createLocalStore(); await store.load(project.id); await store.list(); await store.delete(project.id);
+  project.name = 'Old tab first edit'; data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) }));
+  let list = await store.list(); expect(list).toHaveLength(1); expect(list[0].id).not.toBe(project.id);
+  const recoveryId = list[0].id;
+  project.name = 'Old tab second edit'; data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) }));
+  list = await store.list(); expect(list).toHaveLength(1); expect(list[0].id).toBe(recoveryId);
+  expect(list[0].name).toBe('Old tab second edit (Recovered from older tab)');
+  const recovered = (await store.load(recoveryId))!; recovered.name = 'Edited recovered version'; await store.save(recovered);
+  project.name = 'Old tab third edit'; data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) }));
+  list = await store.list(); expect(list).toHaveLength(2);
+  expect((await store.load(recoveryId))!.name).toBe('Edited recovered version');
+  expect(await store.has(project.id)).toBe(false);
+});
+
+it('migrates once when two fresh clients open simultaneously', async () => {
+  const project = roomProject(); data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) }));
+  const [a, b] = await Promise.all([createLocalStore().load(project.id), createLocalStore().load(project.id)]);
+  expect(a).toEqual(b); expect(await createLocalStore().list()).toHaveLength(1);
+});
+
+it('returns exact damaged legacy bytes for backup even when migration cannot parse them', async () => {
+  data.set(key, '{unreadable library');
+  await expect(createLocalStore().list()).rejects.toThrow('could not be read');
+  expect(await libraryBackup()).toBe('{unreadable library');
+});
+
+it('backs up current projects, previews, history and untouched legacy originals together', async () => {
+  const project = roomProject(); data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) }));
+  const store = createLocalStore(); const next = (await store.load(project.id))!; next.name = 'Current IndexedDB version'; await store.save(next);
+  await store.saveThumbnail(project.id, 'current preview'); await updateRecord('history', project.id, () => '{raw damaged history');
+  const backup = JSON.parse(await libraryBackup());
+  expect(JSON.parse(backup.projects[project.id]).name).toBe(next.name);
+  expect(backup.thumbnails[project.id]).toBe('current preview'); expect(backup.history[project.id]).toBe('{raw damaged history');
+  expect(JSON.parse(JSON.parse(backup.legacy.original[key])[project.id]).name).toBe(project.name);
+});
+
+it('reports denied IndexedDB access without writing or erasing legacy data', async () => {
+  const project = roomProject(); data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) })); const before = new Map(data);
+  vi.spyOn(indexedDB, 'open').mockImplementation(() => { throw new DOMException('Denied', 'SecurityError'); });
+  await expect(createLocalStore().load(project.id)).rejects.toMatchObject({ name: 'SecurityError' });
+  expect(data).toEqual(before);
+});
+
+it('closes its connections so a database upgrade is not blocked after a save', async () => {
+  await createLocalStore().save(roomProject());
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.open(DATABASE_NAME, 2);
+    req.onblocked = () => reject(new Error('Connection leaked'));
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => { req.result.close(); resolve(); };
+  });
+});

--- a/tests/localDatabase.test.ts
+++ b/tests/localDatabase.test.ts
@@ -85,6 +85,19 @@ it('migrates once when two fresh clients open simultaneously', async () => {
   expect(a).toEqual(b); expect(await createLocalStore().list()).toHaveLength(1);
 });
 
+it('retries recovery failures and supports self-hosted contexts without randomUUID', async () => {
+  const project = roomProject(); data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) }));
+  const store = createLocalStore(); await store.load(project.id);
+  project.name = 'Old tab edit'; data.set(key, JSON.stringify({ [project.id]: JSON.stringify(project) }));
+  const restore = failWrites();
+  await expect(store.list()).rejects.toMatchObject({ name: 'QuotaExceededError' });
+  const backup = JSON.parse(await libraryBackup()); expect(Object.keys(backup.projects)).toEqual([project.id]);
+  expect(JSON.parse(JSON.parse(backup.legacy.previous[key])[project.id]).name).not.toBe(project.name);
+  restore(); vi.stubGlobal('crypto', undefined);
+  expect(await store.list()).toHaveLength(2);
+  expect((await store.load(project.id))!.name).not.toBe(project.name);
+});
+
 it('returns exact damaged legacy bytes for backup even when migration cannot parse them', async () => {
   data.set(key, '{unreadable library');
   await expect(createLocalStore().list()).rejects.toThrow('could not be read');

--- a/tests/projectOpening.test.ts
+++ b/tests/projectOpening.test.ts
@@ -1,3 +1,4 @@
+import { rawRecords, putRaw } from './fixtures/indexeddb';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { openProject } from '$lib/services/projectOpening';
@@ -17,7 +18,7 @@ function deferred<T>() {
 }
 
 beforeEach(async () => {
-  vi.useFakeTimers();
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
   storage = new Map();
   vi.stubGlobal('localStorage', {
     getItem: (key: string) => storage.get(key) ?? null,
@@ -52,23 +53,23 @@ it('does not write the previous project again when it is already saved', async (
 
 it('validates before any save or state change, even with pending current edits', async () => {
   updateProjectName('Unsaved but safe');
-  const before = get(currentProject), raw = storage.get('floorplan_projects');
+  const before = get(currentProject), raw = await rawRecords();
   const candidate: any = roomProject(); candidate.floors[0].walls[0].start = null;
   const saved = vi.spyOn(localStore, 'save');
   await expect(openProject(() => candidate)).rejects.toThrow('walls[0].start');
   expect(saved).not.toHaveBeenCalled();
   expect(get(currentProject)).toBe(before);
-  expect(storage.get('floorplan_projects')).toBe(raw);
+  expect(await rawRecords()).toEqual(raw);
   expect(get(saveState)).toBe('unsaved');
 });
 
 it('retains current work and refuses replacement after a failed current save', async () => {
   updateProjectName('Cannot lose this');
-  const before = get(currentProject), raw = storage.get('floorplan_projects');
+  const before = get(currentProject), raw = await rawRecords();
   vi.spyOn(localStore, 'save').mockRejectedValue(new DOMException('Full', 'QuotaExceededError'));
   await expect(openProject(roomProject)).rejects.toThrow('Your current plan could not be saved. Browser storage is full');
   expect(get(currentProject)).toBe(before);
-  expect(storage.get('floorplan_projects')).toBe(raw);
+  expect(await rawRecords()).toEqual(raw);
   expect(get(saveState)).toBe('unsaved');
 });
 
@@ -86,13 +87,11 @@ it('imports a current-ID collision as a copy without changing the input or losin
 
 it('preserves a different saved entry with a colliding ID, including unreadable geometry', async () => {
   const candidate = roomProject(); candidate.id = '__proto__';
-  const raw = JSON.parse(storage.get('floorplan_projects')!);
-  Object.defineProperty(raw, candidate.id, { value: '{original damaged bytes', enumerable: true });
-  storage.set('floorplan_projects', JSON.stringify(raw));
+  await putRaw('projects', candidate.id, '{original damaged bytes');
   expect(await localStore.has(candidate.id)).toBe(true);
   const opened = await openProject(() => candidate);
   expect(opened!.id).not.toBe(candidate.id);
-  expect(JSON.parse(storage.get('floorplan_projects')!)[candidate.id]).toBe('{original damaged bytes');
+  expect((await rawRecords())[candidate.id]).toBe('{original damaged bytes');
 });
 
 it('keeps a candidate available for export if its own save fails after preserving the old work', async () => {

--- a/tests/saveConflicts.test.ts
+++ b/tests/saveConflicts.test.ts
@@ -1,15 +1,11 @@
+import { mockStorage, rawRecords, failWrites } from './fixtures/indexeddb';
 import { beforeEach, expect, it, vi } from 'vitest';
 import { createLocalStore, ProjectConflictError, PROJECTS_STORAGE_KEY as key } from '$lib/services/datastore';
 import { roomProject } from './fixtures/project';
 
 let data: Map<string, string>;
 beforeEach(() => {
-  data = new Map();
-  vi.stubGlobal('localStorage', {
-    getItem: (key: string) => data.get(key) ?? null,
-    setItem: (key: string, value: string) => data.set(key, value),
-    removeItem: (key: string) => data.delete(key),
-  });
+  data = mockStorage();
 });
 
 async function twoTabs() {
@@ -31,11 +27,11 @@ function controlledLocks() {
 it('rejects repeated saves from an older tab and retains the newer saved bytes', async () => {
   const { first, second, a, b } = await twoTabs();
   a.name = 'Newer version'; await first.save(a);
-  const raw = data.get(key);
+  const raw = await rawRecords();
   b.name = 'Older tab edits';
   await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
   await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
-  expect(data.get(key)).toBe(raw);
+  expect(await rawRecords()).toEqual(raw);
   expect(b.name).toBe('Older tab edits');
 });
 
@@ -51,7 +47,7 @@ it('does not confuse another project changing with a conflict', async () => {
   const { first, second, b } = await twoTabs();
   const neighbor = roomProject(); await first.save(neighbor);
   neighbor.name = 'Other project edits'; await first.save(neighbor);
-  expect(() => second.assertCurrent(b.id)).not.toThrow();
+  await expect(second.assertCurrent(b.id)).resolves.toBeUndefined();
   b.name = 'Independent edit'; await second.save(b);
   expect((await first.load(neighbor.id))!.name).toBe('Other project edits');
 });
@@ -73,9 +69,9 @@ it('guards deleting a stale library card until the library has been refreshed', 
   const { first, second, a } = await twoTabs();
   await second.list();
   a.name = 'Changed since listing'; await first.save(a);
-  const raw = data.get(key);
+  const raw = await rawRecords();
   await expect(second.delete(a.id)).rejects.toBeInstanceOf(ProjectConflictError);
-  expect(data.get(key)).toBe(raw);
+  expect(await rawRecords()).toEqual(raw);
   await second.list(); await second.delete(a.id);
   expect(await first.has(a.id)).toBe(false);
 });
@@ -90,17 +86,18 @@ it('does not silently rebase an open editor when its library is listed', async (
 it('does not advance the saved baseline when a write fails, so retry can succeed', async () => {
   const { first, a } = await twoTabs();
   a.name = 'Retry this edit';
-  vi.spyOn(localStorage, 'setItem').mockImplementationOnce(() => { throw new DOMException('Full', 'QuotaExceededError'); });
+  const restore = failWrites();
   await expect(first.save(a)).rejects.toMatchObject({ name: 'QuotaExceededError' });
+  restore();
   await first.save(a);
   expect((await first.load(a.id))!.name).toBe('Retry this edit');
 });
 
-it('treats external library removal as a conflict instead of a new empty library', async () => {
-  const { second, b } = await twoTabs();
+it('does not erase the migrated library when legacy storage is removed', async () => {
+  const { first, second, b } = await twoTabs();
   data.delete(key);
-  await expect(second.save(b)).rejects.toBeInstanceOf(ProjectConflictError);
-  expect(data.has(key)).toBe(false);
+  await second.save(b);
+  expect(await first.has(b.id)).toBe(true);
 });
 
 it('creates an independent recovery copy without rebasing the conflicting original', async () => {
@@ -120,10 +117,11 @@ it('creates an independent recovery copy without rebasing the conflicting origin
 
 it('keeps all saved bytes intact when a recovery copy cannot fit in storage', async () => {
   const { second, b } = await twoTabs();
-  const before = data.get(key), original = structuredClone(b);
-  vi.spyOn(localStorage, 'setItem').mockImplementationOnce(() => { throw new DOMException('Full', 'QuotaExceededError'); });
+  const before = await rawRecords(), original = structuredClone(b);
+  const restore = failWrites();
   await expect(second.saveCopy(b)).rejects.toMatchObject({ name: 'QuotaExceededError' });
-  expect(data.get(key)).toBe(before); expect(b).toEqual(original);
+  expect(await rawRecords()).toEqual(before); expect(b).toEqual(original);
+  restore();
   expect((await second.saveCopy(b)).id).not.toBe(b.id);
 });
 
@@ -134,7 +132,7 @@ it('freezes pending writes before acquiring the browser lock', async () => {
   const pending = first.save(a);
   a.name = 'Later edit'; a.floors[0].walls[0].thickness = 80;
   locks.release(); await pending;
-  const saved = JSON.parse(JSON.parse(data.get(key)!)[a.id]);
+  const saved = JSON.parse((await rawRecords())[a.id]);
   expect(saved.name).toBe('At save time'); expect(saved.floors[0].walls[0].thickness).toBe(15);
   const retry = first.save(a); locks.release(); await retry;
   expect((await first.load(a.id))!.name).toBe('Later edit');
@@ -148,7 +146,7 @@ it('serializes concurrent writes and rereads the full library inside the lock', 
   expect(locks.request.mock.calls.map(([name]) => name)).toEqual(['openplan3d-project-library', 'openplan3d-project-library']);
   locks.release(); await one;
   locks.release(); await two;
-  expect(Object.keys(JSON.parse(data.get(key)!)).sort()).toEqual([a.id, b.id].sort());
+  expect(Object.keys(await rawRecords()).sort()).toEqual([a.id, b.id].sort());
 });
 
 it('rejects the second simultaneous writer to the same project', async () => {
@@ -164,20 +162,20 @@ it('rejects the second simultaneous writer to the same project', async () => {
 
 it('discards a pending save if its project was reopened before the lock arrived', async () => {
   const { first, a } = await twoTabs();
-  const locks = controlledLocks(), before = data.get(key);
+  const locks = controlledLocks(), before = await rawRecords();
   a.name = 'Old pending edit';
   const pending = first.save(a), rejected = expect(pending).rejects.toBeInstanceOf(ProjectConflictError);
   await first.load(a.id);
   locks.release(); await rejected;
-  expect(data.get(key)).toBe(before);
+  expect(await rawRecords()).toEqual(before);
 });
 
 it('does not overwrite a newer project thumbnail from a stale editor', async () => {
   const { first, second, a } = await twoTabs();
   a.name = 'Changed'; await first.save(a);
-  first.saveThumbnail(a.id, 'new thumbnail');
-  second.saveThumbnail(a.id, 'old thumbnail');
-  expect(first.getThumbnail(a.id)).toBe('new thumbnail');
+  await first.saveThumbnail(a.id, 'new thumbnail');
+  await second.saveThumbnail(a.id, 'old thumbnail');
+  expect(await first.getThumbnail(a.id)).toBe('new thumbnail');
 });
 
 it('checks copy IDs against the library while holding the mutation lock', async () => {
@@ -185,6 +183,6 @@ it('checks copy IDs against the library while holding the mutation lock', async 
   const uuid = vi.fn().mockReturnValueOnce(a.id).mockReturnValueOnce('fresh-copy-id');
   vi.stubGlobal('crypto', { randomUUID: uuid });
   const copy = await first.saveCopy(a);
-  expect(copy.id).toBe('fresh-copy-id'); expect(uuid).toHaveBeenCalledTimes(2);
+  expect(copy.id).toBe('fresh-copy-id'); expect(uuid.mock.calls.length).toBeGreaterThanOrEqual(2);
   expect((await first.load(a.id))!.name).toBe(a.name);
 });

--- a/tests/saveStatus.test.ts
+++ b/tests/saveStatus.test.ts
@@ -119,7 +119,7 @@ it('saves immediately but captures a thumbnail only after the canvas redraws', a
     querySelector: () => ({ width: 600, height: 400 }),
     createElement: () => ({ getContext: () => ({ drawImage }), toDataURL: () => renderedPlan }),
   });
-  const preview = vi.spyOn(localStore, 'saveThumbnail').mockImplementation(() => {});
+  const preview = vi.spyOn(localStore, 'saveThumbnail').mockResolvedValue();
   expect(await autoSave()).toBe(true);
   expect(get(saveState)).toBe('saved');
   expect(preview).not.toHaveBeenCalled();
@@ -176,7 +176,7 @@ it('notifies about external project changes without replacing local work and rem
 it('ignores unrelated storage events and other project writes', () => {
   stop();
   const events = new EventTarget(); vi.stubGlobal('window', events);
-  const check = vi.spyOn(localStore, 'assertCurrent').mockImplementation(() => {});
+  const check = vi.spyOn(localStore, 'assertCurrent').mockResolvedValue();
   stop = initAutoSave();
   events.dispatchEvent(Object.assign(new Event('storage'), { key: 'settings' }));
   expect(check).not.toHaveBeenCalled();

--- a/tests/version-history.test.ts
+++ b/tests/version-history.test.ts
@@ -1,3 +1,4 @@
+import { mockStorage, rawRecords, putRaw, failWrites } from './fixtures/indexeddb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { currentProject, loadProject, updateWall, undo, redo, undoHistoryStore } from '$lib/stores/project';
@@ -5,47 +6,74 @@ import { getSnapshots, saveSnapshot, restoreSnapshot, refreshSnapshots, snapshot
 import { roomProject } from './fixtures/project';
 
 let data: Map<string, string>;
-beforeEach(() => {
-  data = new Map();
-  vi.stubGlobal('localStorage', { getItem: (key: string) => data.get(key) ?? null, setItem: (key: string, value: string) => data.set(key, value), removeItem: (key: string) => data.delete(key) });
-  loadProject(roomProject()); refreshSnapshots();
+beforeEach(async () => {
+  data = mockStorage();
+  loadProject(roomProject()); await refreshSnapshots();
 });
 const state = () => JSON.stringify(get(currentProject));
-const key = () => `vh_${get(currentProject)!.id}`;
+const key = () => get(currentProject)!.id;
 
 describe('version restoration safety', () => {
-  it('restores a valid version with dates and keeps retained snapshot data intact', () => {
+  it('restores a valid version with dates and keeps retained snapshot data intact', async () => {
     const before = state(), id = get(currentProject)!.id;
-    saveSnapshot(get(currentProject)!, 'Before edit'); const raw = data.get(key());
+    await saveSnapshot(get(currentProject)!, 'Before edit'); const raw = (await rawRecords('history'))[key()];
     updateWall('a-0', { thickness: 32.5 });
-    expect(restoreSnapshot(id, 0)).toBe(true); expect(state()).toBe(before);
-    expect(get(currentProject)!.createdAt).toBeInstanceOf(Date); expect(data.get(key())).toBe(raw);
+    expect(await restoreSnapshot(id, 0)).toBe(true); expect(state()).toBe(before);
+    expect(get(currentProject)!.createdAt).toBeInstanceOf(Date); expect((await rawRecords('history'))[key()]).toBe(raw);
     expect(get(snapshotError)).toBeNull();
   });
-  it('rejects a malformed snapshot before replacing the plan or clearing redo', () => {
+  it('rejects a malformed snapshot before replacing the plan or clearing redo', async () => {
     const project = get(currentProject)!; updateWall('a-0', { thickness: 32.5 }); undo();
     const before = state(), history = get(undoHistoryStore), damaged: any = JSON.parse(before);
     damaged.floors[0].walls[0].start = null;
-    const raw = JSON.stringify([{ timestamp: 1, description: 'Damaged', data: JSON.stringify(damaged) }]); data.set(key(), raw);
-    expect(restoreSnapshot(project.id, 0)).toBe(false); expect(state()).toBe(before);
-    expect(get(undoHistoryStore)).toEqual(history); expect(data.get(key())).toBe(raw);
+    const raw = JSON.stringify([{ timestamp: 1, description: 'Damaged', data: JSON.stringify(damaged) }]); await putRaw('history', key(), raw);
+    expect(await restoreSnapshot(project.id, 0)).toBe(false); expect(state()).toBe(before);
+    expect(get(undoHistoryStore)).toEqual(history); expect((await rawRecords('history'))[key()]).toBe(raw);
     expect(get(snapshotError)).toContain('walls[0].start');
     redo(); expect(get(currentProject)!.floors[0].walls[0].thickness).toBe(32.5);
   });
-  it('does not restore a version from another project', () => {
+  it('does not restore a version from another project', async () => {
     const before = state(), other = roomProject();
-    data.set(key(), JSON.stringify([{ timestamp: 1, description: 'Wrong project', data: JSON.stringify(other) }]));
-    expect(restoreSnapshot(get(currentProject)!.id, 0)).toBe(false); expect(state()).toBe(before);
+    await putRaw('history', key(), JSON.stringify([{ timestamp: 1, description: 'Wrong project', data: JSON.stringify(other) }]));
+    expect(await restoreSnapshot(get(currentProject)!.id, 0)).toBe(false); expect(state()).toBe(before);
     expect(get(snapshotError)).toContain('different project');
   });
-  it.each(['{broken', 'null', '{}', '[null]', '[{"timestamp":1,"description":{},"data":"{}"}]'])('keeps unreadable history bytes and exposes recovery: %s', raw => {
-    data.set(key(), raw); expect(() => getSnapshots(get(currentProject)!.id)).toThrow('could not be read');
-    refreshSnapshots(); expect(get(snapshotsStore)).toEqual([]); expect(get(snapshotError)).toContain('Download a backup');
-    saveSnapshot(get(currentProject)!, 'Auto-save'); expect(data.get(key())).toBe(raw);
+  it.each(['{broken', 'null', '{}', '[null]', '[{"timestamp":1,"description":{},"data":"{}"}]'])('keeps unreadable history bytes and exposes recovery: %s', async raw => {
+    await putRaw('history', key(), raw); await expect(getSnapshots(get(currentProject)!.id)).rejects.toThrow('could not be read');
+    await refreshSnapshots(); expect(get(snapshotsStore)).toEqual([]); expect(get(snapshotError)).toContain('Download a backup');
+    await saveSnapshot(get(currentProject)!, 'Auto-save'); expect((await rawRecords('history'))[key()]).toBe(raw);
   });
-  it('retains the existing ten-snapshot bound for readable history', () => {
-    for (let i = 0; i < 12; i++) saveSnapshot(get(currentProject)!, `Version ${i}`);
-    const entries = getSnapshots(get(currentProject)!.id);
+  it('retains the existing ten-snapshot bound for readable history', async () => {
+    for (let i = 0; i < 12; i++) await saveSnapshot(get(currentProject)!, `Version ${i}`);
+    const entries = await getSnapshots(get(currentProject)!.id);
     expect(entries).toHaveLength(10); expect(entries[0].description).toBe('Version 2');
   });
+});
+
+
+it('retains all previous versions and the failure message after a quota error, then retries', async () => {
+  const project = get(currentProject)!;
+  for (let i = 0; i < 10; i++) await saveSnapshot(project, `Saved ${i}`);
+  const before = await rawRecords('history'), restore = failWrites('history');
+  expect(await saveSnapshot(project, 'Cannot fit')).toBe(false);
+  expect(await rawRecords('history')).toEqual(before);
+  await refreshSnapshots(); expect(get(snapshotError)).toContain('Browser storage is full');
+  expect(get(snapshotsStore)).toHaveLength(10);
+  restore(); expect(await saveSnapshot(project, 'Retry')).toBe(true);
+  expect(get(snapshotError)).toBeNull(); expect((await getSnapshots(project.id)).at(-1)!.description).toBe('Retry');
+});
+
+it('retains simultaneous history appends in one transaction per update', async () => {
+  const project = get(currentProject)!;
+  await Promise.all([saveSnapshot(project, 'First tab'), saveSnapshot(project, 'Second tab')]);
+  expect((await getSnapshots(project.id)).map(s => s.description).sort()).toEqual(['First tab', 'Second tab']);
+});
+
+it('does not restore an index that shifted after the version panel opened', async () => {
+  const project = get(currentProject)!;
+  for (let i = 0; i < 10; i++) await saveSnapshot(project, `Saved ${i}`);
+  const selected = (await getSnapshots(project.id))[0];
+  await saveSnapshot(project, 'Pushed first version out');
+  expect(await restoreSnapshot(project.id, 0, selected)).toBe(false);
+  expect(get(currentProject)).toBe(project); expect(get(snapshotError)).toContain('This version changed');
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
+    setupFiles: ['tests/fixtures/indexeddb.ts'],
     include: ['tests/**/*.test.ts'],
     restoreMocks: true,
     unstubGlobals: true,


### PR DESCRIPTION
Projects with embedded images or substantial history could exhaust localStorage, and each save rewrote the entire library. Store projects, previews and bounded version history in IndexedDB, updating one project per atomic transaction and showing Saved only after commit.

Migrate existing storage atomically while retaining original bytes for recovery. Preserve late old-release writes as independent recovery copies, retain stale-tab protections, and add full-library backup access. History failures preserve existing versions and remain visible for retry; asynchronous restores protect intervening edits and shifted snapshot selections.

Validation: 404 unit tests, type checking (zero errors, 23 existing warnings), production build and npm audit pass locally. Added migration, rollback/retry, large local project and old-release browser coverage; existing browser persistence assertions and failure injection now exercise IndexedDB. Manual old-build → new-build browser upgrade preserved the project and its pre-upgrade manual/session history. Final PR CI passed all 404 unit and 33 Chromium browser tests: https://github.com/laanlabs/openPlan3D/actions/runs/34061603851. Manual desktop and phone-width checks also passed, including older-release recovery and library backup access; browser logs were empty. Live deployment verified: all 22 existing library entries remained available; saved geometry/history, full-library backup download, and a fresh import/save/reload/3D check passed with empty browser error logs. Main CI also passed: https://github.com/laanlabs/openPlan3D/actions/runs/34061896912. Whole-library restore is tracked in #55.

No Firebase traffic or iPhone/cloud configuration changes. See docs/reviews/2026-09-06-indexeddb-library.md for backup format and remaining scope (whole-library restore UI and image deduplication).

Closes #53.
