### PR TITLE
Keep furniture colors and finishes consistent through 3D model loading

### DIFF
--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -372,3 +372,7 @@ A versioned ZIP carries the current edited plan, referenced attachments and reta
 ## Seventeenth batch: local item details and photos
 
 Issue #59 adds web editing for retained item notes, furniture/opening costs, room photos/classification/ceiling metadata and wall construction materials. Local photo import resizes and reuses bytes, with explicit detach/delete behavior and project/history budgets. Saved versions share attachment bytes and retain backup/quota recovery; both old array histories and the new pooled format can be restored. Actual Swift metadata returns, desktop/mobile browser workflows and failure paths verify preservation. See [package and local-storage details](../project-package-v1.md). Catalog/rendering fidelity and native distribution remain further work; Firebase migration/billing gates remain in #30.
+
+## Eighteenth batch: consistent furniture rendering
+
+Issue #61 preserves chosen furniture colors/finishes and translucent placement previews after GLB loading, isolates disposable instance resources, and shares lazy model requests with catalog thumbnails. Late completions cannot revive removed scenes; failed files retain procedural fallbacks without repeated downloads. A fireplace no longer renders as a toaster, and wall transparency leaves furniture finishes intact. See [rendering behavior and verification](2026-09-06-furniture-rendering.md). Broader catalog parity, native rendering/distribution and the cost gates in #30 remain follow-up work.

--- a/docs/reviews/2026-09-06-furniture-rendering.md
+++ b/docs/reviews/2026-09-06-furniture-rendering.md
@@ -1,0 +1,13 @@
+# Furniture appearance and model lifecycle
+
+Issue #61 repairs the asynchronous GLB path used by the web catalog and 3D viewer. Explicit item colors tint the loaded asset while retaining its original texture and contrasting details. The existing material choices now adjust roughness, metalness and, for Glass, opacity. The unset choice is shown as **Original materials**; unknown stored choices remain retained. Reset to defaults clears overrides. This does not introduce physically accurate material simulation or a native rendering change.
+
+Placement ghosts keep their blue translucent appearance before and after a model loads. Each thumbnail and placed instance owns cloned geometry, materials and textures; removing a thumbnail, rebuilding a floor, cancelling placement or leaving 3D disposes the instance without damaging the cached template or another item. Late model completions cannot revive disposed containers. Invalid model dimensions and failed loads leave the original procedural fallback intact.
+
+Thumbnails and placed furniture use one catalog mapping and share in-flight/template loads for each bundled file. Nothing is fetched before it is needed. Templates are retained for the browser page session; failures also remain cached until reload to avoid repeated requests on every edit. Existing content-hashed, immutable asset URLs remain in use. The fireplace uses its procedural fireplace rather than the unrelated toaster GLB. No asset files, external model service, production dependency or Firebase upload is added.
+
+Wall transparency now affects active-floor wall bodies. Furniture finishes, glass openings, floor surfaces and the already-translucent reference floors keep their own settings. The wall setting is reapplied when the scene rebuilds.
+
+Validation covers independent cached instances, shared textures, single-request reuse, fractional model bounds, tint/finish preservation, delayed disposal, invalid models and failed-request suppression. Production-browser CI exercises desktop/390px rendering using actual pixel colors, editing and persisted finishes, catalog reuse, repeated 2D/3D transitions, and completion after 3D closes. The PR records final test counts and live release verification.
+
+Native furniture categories/rendering and broader catalog parity remain subsequent work. Issue #30 still tracks native distribution, physical-device transfer and Firebase migration/billing gates.

--- a/src/lib/components/sidebar/PropertiesPanel.svelte
+++ b/src/lib/components/sidebar/PropertiesPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { furnitureFinishes } from '$lib/utils/furnitureFinishes';
   import { onDestroy } from 'svelte';
   import ItemDetailsPanel from './ItemDetailsPanel.svelte';
   import type { DetailTarget } from '$lib/models/types';
@@ -173,7 +174,7 @@
   }
   function onFurnitureMaterial(e: Event) {
     if (!selectedFurniture) return;
-    updateFurniture(selectedFurniture.id, { material: (e.target as HTMLSelectElement).value });
+    updateFurniture(selectedFurniture.id, { material: (e.target as HTMLSelectElement).value || undefined });
   }
   function onFurnitureRotation(e: Event) {
     if (!selectedFurniture) return;
@@ -664,20 +665,19 @@
       <label class="block">
         <span class="text-xs text-gray-500">Material</span>
         <select 
-          value={selectedFurniture.material ?? 'Wood'} 
+          value={selectedFurniture.material ?? ''}
           onchange={onFurnitureMaterial} 
           class="w-full px-2 py-1 border border-gray-200 rounded text-sm"
         >
-          <option value="Wood">Wood</option>
-          <option value="Metal">Metal</option>
-          <option value="Fabric">Fabric</option>
-          <option value="Leather">Leather</option>
-          <option value="Glass">Glass</option>
-          <option value="Plastic">Plastic</option>
-          <option value="Stone">Stone</option>
-          <option value="Ceramic">Ceramic</option>
+          <option value="">Original materials</option>
+          {#if selectedFurniture.material && !Object.hasOwn(furnitureFinishes, selectedFurniture.material)}
+            <option value={selectedFurniture.material}>{selectedFurniture.material} (retained)</option>
+          {/if}
+          {#each Object.keys(furnitureFinishes) as finish}<option value={finish}>{finish}</option>{/each}
         </select>
       </label>
+
+      <p class="text-xs text-gray-500">Color tints the 3D model; materials adjust its finish. Reset to defaults restores the original appearance.</p>
       
       <!-- Rotation -->
       <label class="block">

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -20,7 +20,7 @@
   import MaterialPicker from './MaterialPicker.svelte';
   import { getCatalogItem, furnitureCatalog, furnitureCategories } from '$lib/utils/furnitureCatalog';
   import type { FurnitureDef } from '$lib/utils/furnitureCatalog';
-  import { createFurnitureModel } from '$lib/utils/furnitureModels3d';
+  import { disposeModel } from '$lib/utils/furnitureModelResources';
   import { createFurnitureModelWithGLB } from '$lib/utils/furnitureModelLoader';
   import { addFurniture } from '$lib/stores/project';
   import { detectRooms, resolveRooms, getRoomPolygon, roomCentroid } from '$lib/utils/roomDetection';
@@ -952,33 +952,7 @@
     if (!cat || cat.symbol) return;
     const model = createFurnitureModelWithGLB(catalogId, cat, () => {
       if (renderer && scene && camera) renderer.render(scene, camera);
-    });
-    // Make semi-transparent
-    model.traverse((child: any) => {
-      if (child instanceof THREE.Mesh) {
-        if (Array.isArray(child.material)) {
-          child.material = child.material.map((m: THREE.Material) => {
-            const c = m.clone();
-            if (c instanceof THREE.MeshStandardMaterial) {
-              c.transparent = true;
-              c.opacity = 0.5;
-              c.emissive = new THREE.Color(0x4488ff);
-              c.emissiveIntensity = 0.3;
-            }
-            return c;
-          });
-        } else {
-          const c = child.material.clone();
-          if (c instanceof THREE.MeshStandardMaterial) {
-            c.transparent = true;
-            c.opacity = 0.5;
-            c.emissive = new THREE.Color(0x4488ff);
-            c.emissiveIntensity = 0.3;
-          }
-          child.material = c;
-        }
-      }
-    });
+    }, { ghost: true });
     model.visible = false;
     ghostGroup = model;
     scene.add(ghostGroup);
@@ -987,13 +961,7 @@
   function removeGhostPreview() {
     if (ghostGroup) {
       scene.remove(ghostGroup);
-      ghostGroup.traverse((obj: any) => {
-        if (obj.geometry) obj.geometry.dispose();
-        if (obj.material) {
-          if (Array.isArray(obj.material)) obj.material.forEach((m: any) => m.dispose());
-          else obj.material.dispose();
-        }
-      });
+      disposeModel(ghostGroup);
       ghostGroup = null;
     }
   }
@@ -1165,16 +1133,10 @@
     }
   }
 
-  function clearGroup(group: THREE.Group) {
+  function clearGroup(group: THREE.Object3D) {
     while (group.children.length) {
       const child = group.children[0];
-      child.traverse((obj: any) => {
-        if (obj.geometry) obj.geometry.dispose();
-        if (obj.material) {
-          if (Array.isArray(obj.material)) obj.material.forEach((m: any) => m.dispose());
-          else obj.material.dispose();
-        }
-      });
+      disposeModel(child);
       group.remove(child);
     }
   }
@@ -1524,7 +1486,7 @@
       const model = createFurnitureModelWithGLB(fi.catalogId, furnitureDef, () => {
         // Re-render when GLB model finishes loading
         if (renderer && scene && camera) renderer.render(scene, camera);
-      });
+      }, { color: fi.color, material: fi.material });
       model.position.set(fi.position.x, 1.5, fi.position.y);
       model.rotation.y = -(fi.rotation * Math.PI) / 180;
       // Note: fi.scale is 2D editor scale — don't override 3D model scaling from scaleToFit
@@ -1667,6 +1629,7 @@
     // Columns
     buildColumns(floor);
 
+    applyWallTransparency();
     autoCenterCamera();
   }
 
@@ -1829,15 +1792,21 @@
     markSceneDirty();
   }
 
+  function applyWallTransparency() {
+    // Only active-floor wall bodies belong to this control; furniture finishes,
+    // glass openings and reference-floor opacity keep their own settings.
+    for (const child of wallMeshMap.keys()) if (child instanceof THREE.Mesh) {
+      for (const material of Array.isArray(child.material) ? child.material : [child.material]) {
+        material.transparent = wallsTransparent;
+        material.opacity = wallsTransparent ? 0.15 : 1;
+        material.needsUpdate = true;
+      }
+    }
+  }
+
   function toggleWallTransparency() {
     wallsTransparent = !wallsTransparent;
-    wallGroup.traverse((child) => {
-      if (child instanceof THREE.Mesh && child.material instanceof THREE.MeshStandardMaterial) {
-        child.material.transparent = wallsTransparent;
-        child.material.opacity = wallsTransparent ? 0.15 : 1.0;
-        child.material.needsUpdate = true;
-      }
-    });
+    applyWallTransparency();
     markSceneDirty();
   }
 
@@ -2061,6 +2030,8 @@
       cancelAnimationFrame(animId);
       document.removeEventListener('keydown', onKeyDown, false);
       document.removeEventListener('keyup', onKeyUp, false);
+      removeGhostPreview();
+      clearGroup(scene);
       pointerControls.dispose();
       controls.dispose();
       renderer.dispose();

--- a/src/lib/utils/furnitureFinishes.ts
+++ b/src/lib/utils/furnitureFinishes.ts
@@ -1,0 +1,11 @@
+/** Lightweight catalog finish choices; importing the properties UI must not load Three.js. */
+export const furnitureFinishes: Record<string, { roughness: number; metalness: number; opacity?: number }> = {
+  Wood: { roughness: 0.75, metalness: 0 },
+  Metal: { roughness: 0.25, metalness: 0.85 },
+  Fabric: { roughness: 1, metalness: 0 },
+  Leather: { roughness: 0.55, metalness: 0 },
+  Glass: { roughness: 0.1, metalness: 0, opacity: 0.35 },
+  Plastic: { roughness: 0.35, metalness: 0 },
+  Stone: { roughness: 0.9, metalness: 0 },
+  Ceramic: { roughness: 0.2, metalness: 0 },
+};

--- a/src/lib/utils/furnitureModelFiles.ts
+++ b/src/lib/utils/furnitureModelFiles.ts
@@ -6,7 +6,7 @@ const MODEL_FILES: Record<string, string> = {
   tv_stand: 'cabinetTelevision',
   bookshelf: 'bookcaseOpen',
   side_table: 'sideTable',
-  fireplace: 'toaster',
+  // Fireplace uses its procedural fireplace; no matching bundled GLB.
   television: 'televisionModern',
   storage: 'bookcaseClosed',
   table: 'tableCross',
@@ -115,5 +115,5 @@ const MODEL_FILES: Record<string, string> = {
 };
 
 export function getModelFile(catalogId: string): string | null {
-  return MODEL_FILES[catalogId] ?? null;
+  return Object.hasOwn(MODEL_FILES, catalogId) ? MODEL_FILES[catalogId] : null;
 }

--- a/src/lib/utils/furnitureModelLoader.ts
+++ b/src/lib/utils/furnitureModelLoader.ts
@@ -1,307 +1,75 @@
-import { catalogAssetUrl } from '$lib/utils/catalogAssetUrl';
-/**
- * Furniture Model Loader
- * Loads GLB models from /models/ for furniture items, with procedural fallback.
- * Models sourced from Kenney Furniture Kit (CC0).
- */
+/** Lazy GLB furniture with an immediate procedural fallback. */
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { createFurnitureModel } from './furnitureModels3d';
 import type { FurnitureDef } from './furnitureCatalog';
+import { getModelFile } from './furnitureModelFiles';
+import { furnitureFinishes } from './furnitureFinishes';
+import { disposeModel, isModelDisposed, loadCatalogModel } from './furnitureModelResources';
 
-const loader = new GLTFLoader();
-const modelCache = new Map<string, THREE.Group>();
-const loadingPromises = new Map<string, Promise<THREE.Group | null>>();
+export interface FurnitureAppearance { color?: string; material?: string; ghost?: boolean }
 
-/**
- * Map our catalog IDs to Kenney GLB filenames (without extension).
- * Each entry can also specify scale/rotation adjustments.
- */
-interface ModelMapping {
-  file: string;
-  scale?: number;       // uniform scale multiplier
-  rotateY?: number;     // additional Y rotation in radians
-  offsetY?: number;     // vertical offset
-}
-
-const MODEL_MAP: Record<string, ModelMapping> = {
-  // Living Room
-  sofa:           { file: 'loungeDesignSofa', scale: 110 },
-  loveseat:       { file: 'loungeDesignSofa', scale: 100 },
-  chair:          { file: 'loungeChair', scale: 95 },
-  coffee_table:   { file: 'tableCoffee', scale: 100 },
-  tv_stand:       { file: 'cabinetTelevision', scale: 100 },
-  bookshelf:      { file: 'bookcaseOpen', scale: 100 },
-  side_table:     { file: 'sideTable', scale: 80 },
-  fireplace:      { file: 'toaster', scale: 100 }, // placeholder
-  television:     { file: 'televisionModern', scale: 100 },
-  storage:        { file: 'bookcaseClosed', scale: 100 },
-  table:          { file: 'tableCross', scale: 100 },
-
-  // Bedroom
-  bed_queen:      { file: 'bedDouble', scale: 110 },
-  bed_twin:       { file: 'bedSingle', scale: 100 },
-  nightstand:     { file: 'cabinetBedDrawerTable', scale: 80 },
-  dresser:        { file: 'cabinetBedDrawer', scale: 100 },
-  wardrobe:       { file: 'bookcaseClosedDoors', scale: 110 },
-
-  // Kitchen
-  stove:          { file: 'kitchenStove', scale: 100 },
-  fridge:         { file: 'kitchenFridgeLarge', scale: 100 },
-  sink_k:         { file: 'kitchenSink', scale: 100 },
-  counter:        { file: 'kitchenCabinet', scale: 100 },
-  dishwasher:     { file: 'kitchenCabinetDrawer', scale: 100 },
-  oven:           { file: 'kitchenStoveElectric', scale: 100 },
-
-  // Bathroom
-  toilet:         { file: 'toilet', scale: 100 },
-  bathtub:        { file: 'bathtub', scale: 100 },
-  shower:         { file: 'shower', scale: 100 },
-  sink_b:         { file: 'bathroomSink', scale: 100 },
-  washer_dryer:   { file: 'washerDryerStacked', scale: 100 },
-
-  // Office
-  desk:           { file: 'tableCross', scale: 110 },
-  office_chair:   { file: 'chairDesk', scale: 90 },
-
-  // Dining
-  dining_table:   { file: 'tableCross', scale: 100 },
-  dining_chair:   { file: 'chair', scale: 90 },
-
-  // Decor
-  potted_plant:   { file: 'pottedPlant', scale: 80 },
-  floor_plant:    { file: 'plantSmall1', scale: 100 },
-
-  // Outdoor Furniture
-  fire_pit:       { file: 'outdoor_campfire_stones', scale: 100 },
-  campfire:       { file: 'outdoor_campfire_logs', scale: 100 },
-  tent:           { file: 'outdoor_tent_detailedOpen', scale: 100 },
-  outdoor_sign:   { file: 'outdoor_sign', scale: 100 },
-  outdoor_pot_large: { file: 'outdoor_pot_large', scale: 100 },
-  outdoor_pot_small: { file: 'outdoor_pot_small', scale: 100 },
-
-  // Landscaping — Trees
-  tree_oak:       { file: 'outdoor_tree_oak', scale: 100 },
-  tree_default:   { file: 'outdoor_tree_default', scale: 100 },
-  tree_detailed:  { file: 'outdoor_tree_detailed', scale: 100 },
-  tree_pine:      { file: 'outdoor_tree_pineRoundA', scale: 100 },
-  tree_pine_tall: { file: 'outdoor_tree_pineTallA_detailed', scale: 100 },
-  tree_palm:      { file: 'outdoor_tree_palm', scale: 100 },
-  tree_palm_bend: { file: 'outdoor_tree_palmBend', scale: 100 },
-  tree_palm_tall: { file: 'outdoor_tree_palmTall', scale: 100 },
-  tree_fat:       { file: 'outdoor_tree_fat', scale: 100 },
-  tree_simple:    { file: 'outdoor_tree_simple', scale: 100 },
-  tree_thin:      { file: 'outdoor_tree_thin', scale: 100 },
-  tree_tall:      { file: 'outdoor_tree_tall', scale: 100 },
-  tree_cone:      { file: 'outdoor_tree_cone', scale: 100 },
-  tree_blocky:    { file: 'outdoor_tree_blocks', scale: 100 },
-  tree_small:     { file: 'outdoor_tree_small', scale: 100 },
-
-  // Landscaping — Bushes & Plants
-  bush:           { file: 'outdoor_plant_bush', scale: 100 },
-  bush_detailed:  { file: 'outdoor_plant_bushDetailed', scale: 100 },
-  bush_large:     { file: 'outdoor_plant_bushLarge', scale: 100 },
-  bush_large_triangle: { file: 'outdoor_plant_bushLargeTriangle', scale: 100 },
-  bush_small:     { file: 'outdoor_plant_bushSmall', scale: 100 },
-  bush_triangle:  { file: 'outdoor_plant_bushTriangle', scale: 100 },
-  cactus_short:   { file: 'outdoor_cactus_short', scale: 100 },
-  cactus_tall:    { file: 'outdoor_cactus_tall', scale: 100 },
-  hanging_moss:   { file: 'outdoor_hanging_moss', scale: 100 },
-
-  // Landscaping — Flowers
-  flower_purple:  { file: 'outdoor_flower_purpleA', scale: 100 },
-  flower_red:     { file: 'outdoor_flower_redA', scale: 100 },
-  flower_yellow:  { file: 'outdoor_flower_yellowA', scale: 100 },
-  flower_purple_b: { file: 'outdoor_flower_purpleB', scale: 100 },
-  flower_red_b:   { file: 'outdoor_flower_redB', scale: 100 },
-  flower_yellow_b: { file: 'outdoor_flower_yellowB', scale: 100 },
-  lily:           { file: 'outdoor_lily_large', scale: 100 },
-
-  // Landscaping — Grass
-  grass_tuft:     { file: 'outdoor_grass', scale: 100 },
-  grass_large:    { file: 'outdoor_grass_large', scale: 100 },
-  grass_leafs:    { file: 'outdoor_grass_leafs', scale: 100 },
-  grass_leafs_large: { file: 'outdoor_grass_leafsLarge', scale: 100 },
-
-  // Landscaping — Rocks & Stones
-  rock_large:     { file: 'outdoor_rock_largeA', scale: 100 },
-  rock_large_b:   { file: 'outdoor_rock_largeB', scale: 100 },
-  rock_tall:      { file: 'outdoor_rock_tallA', scale: 100 },
-  rock_small:     { file: 'outdoor_rock_smallA', scale: 100 },
-  rock_small_b:   { file: 'outdoor_rock_smallB', scale: 100 },
-  stone_large:    { file: 'outdoor_stone_largeA', scale: 100 },
-  stone_tall:     { file: 'outdoor_stone_tallA', scale: 100 },
-
-  // Landscaping — Misc
-  mushroom_red:   { file: 'outdoor_mushroom_red', scale: 100 },
-  mushroom_group: { file: 'outdoor_mushroom_redGroup', scale: 100 },
-  mushroom_tan:   { file: 'outdoor_mushroom_tan', scale: 100 },
-  log_single:     { file: 'outdoor_log', scale: 100 },
-  log_large:      { file: 'outdoor_log_large', scale: 100 },
-  log_stack:      { file: 'outdoor_log_stack', scale: 100 },
-  stump_old:      { file: 'outdoor_stump_old', scale: 100 },
-  stump_round:    { file: 'outdoor_stump_round', scale: 100 },
-  corn:           { file: 'outdoor_crops_cornStageD', scale: 100 },
-  pumpkin:        { file: 'outdoor_crop_pumpkin', scale: 100 },
-  statue_column:  { file: 'outdoor_statue_column', scale: 100 },
-  obelisk:        { file: 'outdoor_statue_obelisk', scale: 100 },
-
-  // Fencing
-  fence_simple:   { file: 'outdoor_fence_simple', scale: 100 },
-  fence_planks:   { file: 'outdoor_fence_planks', scale: 100 },
-  fence_gate:     { file: 'outdoor_fence_gate', scale: 100 },
-  fence_corner:   { file: 'outdoor_fence_corner', scale: 100 },
-};
-
-/**
- * Load a GLB model for the given catalog ID.
- * Returns a clone from cache if available, or loads async.
- * Returns null if no GLB mapping exists.
- */
-function loadGLBModel(catalogId: string): Promise<THREE.Group | null> {
-  const mapping = MODEL_MAP[catalogId];
-  if (!mapping) return Promise.resolve(null);
-
-  const cacheKey = mapping.file;
-
-  // Return cached clone
-  if (modelCache.has(cacheKey)) {
-    return Promise.resolve(modelCache.get(cacheKey)!.clone());
-  }
-
-  // Return existing loading promise — clone from cache (not from resolved value, which may be mutated)
-  if (loadingPromises.has(cacheKey)) {
-    return loadingPromises.get(cacheKey)!.then(() => modelCache.has(cacheKey) ? modelCache.get(cacheKey)!.clone() : null);
-  }
-
-  const promise = new Promise<THREE.Group | null>((resolve) => {
-    loader.load(
-      catalogAssetUrl(`/models/${mapping.file}.glb`),
-      (gltf) => {
-        const group = new THREE.Group();
-        // Clone the scene into our group
-        gltf.scene.traverse((child) => {
-          if (child instanceof THREE.Mesh) {
-            child.castShadow = true;
-            child.receiveShadow = true;
-          }
-        });
-        group.add(gltf.scene);
-        modelCache.set(cacheKey, group);
-        loadingPromises.delete(cacheKey);
-        resolve(group.clone());
-      },
-      undefined,
-      () => {
-        // Load failed — fall back
-        loadingPromises.delete(cacheKey);
-        resolve(null);
+function applyAppearance(model: THREE.Group, appearance: FurnitureAppearance, tint: boolean) {
+  const seen = new Set<THREE.Material>();
+  model.traverse(child => {
+    if (!(child instanceof THREE.Mesh)) return;
+    for (const material of Array.isArray(child.material) ? child.material : [child.material]) {
+      if (seen.has(material)) continue;
+      seen.add(material);
+      if (!(material instanceof THREE.MeshStandardMaterial)) continue;
+      // A tint keeps the source model's texture and contrasting material detail.
+      if (tint && appearance.color) material.color.multiply(new THREE.Color(appearance.color));
+      const finish = appearance.material && Object.hasOwn(furnitureFinishes, appearance.material) ? furnitureFinishes[appearance.material] : undefined;
+      if (finish) {
+        material.roughness = finish.roughness; material.metalness = finish.metalness;
+        if (finish.opacity !== undefined) {
+          material.opacity *= finish.opacity; material.transparent = true; material.depthWrite = false;
+        }
       }
-    );
+      if (appearance.ghost) {
+        material.transparent = true; material.opacity *= 0.5; material.depthWrite = false;
+        material.emissive.set(0x4488ff); material.emissiveIntensity = 0.3;
+      }
+    }
   });
-
-  loadingPromises.set(cacheKey, promise);
-  return promise;
 }
 
-/**
- * Scale a GLB model to match our catalog dimensions.
- * Kenney models are unit-scale (~1m tall). We need to match our cm dimensions.
- */
-function scaleToFit(model: THREE.Group, def: FurnitureDef, mapping: ModelMapping): void {
-  // Compute the model's bounding box
-  const box = new THREE.Box3().setFromObject(model);
-  const size = new THREE.Vector3();
-  box.getSize(size);
-
-  const EPSILON = 0.001;
-  if (size.x < EPSILON || size.y < EPSILON || size.z < EPSILON) return;
-
-  // Detect Z-up orientation: only rotate if Y is near-zero (truly flat/degenerate)
-  // Don't rotate models that are just naturally short (like beds, tables)
-  if (size.y < 0.01 && size.z > size.y * 10) {
-    model.rotation.x = -Math.PI / 2;
-    model.updateMatrixWorld(true);
-    // Recompute bounding box after rotation
-    box.setFromObject(model);
-    box.getSize(size);
+/** Match the complete model's footprint, center it, and place its bottom at zero. */
+export function fitFurnitureModel(model: THREE.Group, def: FurnitureDef) {
+  const bounds = new THREE.Box3().setFromObject(model), size = bounds.getSize(new THREE.Vector3());
+  if ([size.x, size.y, size.z, def.width, def.height, def.depth].some(value => !Number.isFinite(value) || value <= 0)) {
+    throw new Error('Furniture model has invalid dimensions.');
   }
-
-  // Scale to match our catalog dimensions (in cm) — non-uniform to fill exact footprint
-  // Our convention: width=X, height=Y, depth=Z
-  const scaleX = def.width / size.x;
-  const scaleY = def.height / size.y;
-  const scaleZ = def.depth / size.z;
-
-  model.scale.set(scaleX, scaleY, scaleZ);
-
-  // Re-center at origin after scaling
-  const scaledBox = new THREE.Box3().setFromObject(model);
-  const center = new THREE.Vector3();
-  scaledBox.getCenter(center);
-  model.position.sub(center);
-  // Put bottom on ground plane
-  model.position.y -= scaledBox.min.y;
-
-  // Recompute after repositioning
-  const finalBox = new THREE.Box3().setFromObject(model);
-  model.position.y -= finalBox.min.y;
+  model.scale.multiply(new THREE.Vector3(def.width / size.x, def.height / size.y, def.depth / size.z));
+  model.updateMatrixWorld(true);
+  bounds.setFromObject(model);
+  const center = bounds.getCenter(new THREE.Vector3());
+  model.position.sub(new THREE.Vector3(center.x, bounds.min.y, center.z));
+  model.updateMatrixWorld(true);
 }
 
-/**
- * Create a furniture model — tries GLB first, falls back to procedural.
- * Returns immediately with procedural model, then replaces with GLB when loaded.
- */
 export function createFurnitureModelWithGLB(
-  catalogId: string,
-  def: FurnitureDef,
-  onLoaded?: (model: THREE.Group) => void
+  catalogId: string, def: FurnitureDef, onLoaded?: (model: THREE.Group) => void,
+  appearance: FurnitureAppearance = {},
 ): THREE.Group {
   const container = new THREE.Group();
   container.name = `furniture_${catalogId}`;
-
-  // Start with procedural model immediately
   const procedural = createFurnitureModel(catalogId, def);
+  applyAppearance(procedural, appearance, false);
   container.add(procedural);
-
-  // Try to load GLB async
-  const mapping = MODEL_MAP[catalogId];
-  if (mapping) {
-    loadGLBModel(catalogId).then((glbModel) => {
-      if (glbModel) {
-        try {
-          // Remove procedural and dispose its resources, then add GLB
-          container.remove(procedural);
-          procedural.traverse((obj: any) => {
-            if (obj.geometry) obj.geometry.dispose();
-            if (obj.material) {
-              if (Array.isArray(obj.material)) obj.material.forEach((m: any) => m.dispose());
-              else obj.material.dispose();
-            }
-          });
-          scaleToFit(glbModel, def, mapping);
-          container.add(glbModel);
-          onLoaded?.(container);
-        } catch (err) {
-          // scaleToFit or GLB add failed — fall back to procedural
-          console.warn(`[FurnitureLoader] GLB error for ${catalogId}:`, err);
-          container.add(procedural);
-        }
-      }
-    });
-  }
-
+  const file = getModelFile(catalogId);
+  if (file) void loadCatalogModel(file).then(model => {
+    if (!model) return;
+    if (isModelDisposed(container)) { disposeModel(model); return; }
+    try {
+      fitFurnitureModel(model, def);
+      applyAppearance(model, appearance, true);
+    } catch {
+      disposeModel(model);
+      return; // The original fallback remains intact and usable.
+    }
+    container.remove(procedural); disposeModel(procedural);
+    container.add(model);
+    onLoaded?.(container);
+  }).catch(error => { console.warn(`[FurnitureLoader] Model unavailable for ${catalogId}:`, error); });
   return container;
-}
-
-/** Check if a catalog item has a GLB model available */
-export function hasGLBModel(catalogId: string): boolean {
-  return catalogId in MODEL_MAP;
-}
-
-/** Preload all mapped models */
-export function preloadModels(): void {
-  for (const catalogId of Object.keys(MODEL_MAP)) {
-    loadGLBModel(catalogId);
-  }
 }

--- a/src/lib/utils/furnitureModelResources.ts
+++ b/src/lib/utils/furnitureModelResources.ts
@@ -1,0 +1,66 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { catalogAssetUrl } from './catalogAssetUrl';
+
+const loader = new GLTFLoader();
+// Only bundled catalog filenames reach this cache. Templates live for the page session;
+// thumbnails and placed instances own their disposable geometry, materials and textures.
+const sources = new Map<string, Promise<THREE.Group | null>>();
+const disposed = new WeakSet<THREE.Object3D>();
+const ownedTextures = new WeakSet<THREE.Texture>();
+
+export function cloneModel(source: THREE.Group): THREE.Group {
+  const clone = source.clone(true);
+  const geometries = new Map<THREE.BufferGeometry, THREE.BufferGeometry>();
+  const materials = new Map<THREE.Material, THREE.Material>();
+  const textures = new Map<THREE.Texture, THREE.Texture>();
+  const material = (original: THREE.Material) => {
+    if (materials.has(original)) return materials.get(original)!;
+    const result = original.clone();
+    for (const [key, value] of Object.entries(result)) if (value instanceof THREE.Texture) {
+      if (!textures.has(value)) { const copy = value.clone(); textures.set(value, copy); ownedTextures.add(copy); }
+      (result as any)[key] = textures.get(value);
+    }
+    materials.set(original, result);
+    return result;
+  };
+  clone.traverse(child => {
+    if (!(child instanceof THREE.Mesh)) return;
+    const original = child.geometry;
+    if (!geometries.has(original)) geometries.set(original, original.clone());
+    child.geometry = geometries.get(original)!;
+    child.material = Array.isArray(child.material) ? child.material.map(material) : material(child.material);
+    child.castShadow = true; child.receiveShadow = true;
+  });
+  return clone;
+}
+
+/** A failed file stays a procedural fallback until reload, avoiding retries on every edit. */
+export async function loadCatalogModel(file: string): Promise<THREE.Group | null> {
+  if (!sources.has(file)) sources.set(file, loader.loadAsync(catalogAssetUrl(`/models/${file}.glb`))
+    .then(gltf => gltf.scene).catch(() => null));
+  const source = await sources.get(file)!;
+  return source ? cloneModel(source) : null;
+}
+
+export function isModelDisposed(root: THREE.Object3D) { return disposed.has(root); }
+
+/** Also marks pending furniture containers so late model loads cannot revive them.
+ * Global wall/floor texture caches retain ownership of their textures. */
+export function disposeModel(root: THREE.Object3D) {
+  const geometries = new Set<THREE.BufferGeometry>(), materials = new Set<THREE.Material>();
+  const textures = new Set<THREE.Texture>();
+  root.traverse(child => {
+    if (disposed.has(child)) return;
+    disposed.add(child);
+    const renderable = child as THREE.Mesh;
+    if (renderable.geometry) geometries.add(renderable.geometry);
+    if (renderable.material) for (const material of Array.isArray(renderable.material) ? renderable.material : [renderable.material]) {
+      materials.add(material);
+      for (const value of Object.values(material)) if (value instanceof THREE.Texture && ownedTextures.has(value)) textures.add(value);
+    }
+  });
+  for (const geometry of geometries) geometry.dispose();
+  for (const material of materials) material.dispose();
+  for (const texture of textures) texture.dispose();
+}

--- a/src/lib/utils/furnitureThumbnails.ts
+++ b/src/lib/utils/furnitureThumbnails.ts
@@ -4,8 +4,7 @@
  * Cached as data URLs after first render.
  */
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-import { catalogAssetUrl } from './catalogAssetUrl';
+import { disposeModel, loadCatalogModel } from './furnitureModelResources';
 
 const SIZE = 128;
 const cache = new Map<string, string>();
@@ -37,19 +36,6 @@ function ensureRenderer() {
   camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.01, 100);
 }
 
-const loader = new GLTFLoader();
-
-function loadModel(file: string): Promise<THREE.Group> {
-  return new Promise((resolve, reject) => {
-    loader.load(
-      catalogAssetUrl(`/models/${file}.glb`),
-      (gltf) => resolve(gltf.scene),
-      undefined,
-      reject
-    );
-  });
-}
-
 export function getThumbnail(file: string): string | null {
   return cache.get(file) ?? null;
 }
@@ -59,9 +45,11 @@ export async function generateThumbnail(file: string): Promise<string | null> {
   if (pending.has(file)) return pending.get(file)!;
 
   const promise = (async () => {
+    let model: THREE.Group | null = null;
     try {
       ensureRenderer();
-      const model = await loadModel(file);
+      model = await loadCatalogModel(file);
+      if (!model) return null;
 
       // Clear scene of previous models (keep lights)
       const toRemove: THREE.Object3D[] = [];
@@ -104,16 +92,15 @@ export async function generateThumbnail(file: string): Promise<string | null> {
 
       scene!.remove(model);
       cache.set(file, dataUrl);
-      pending.delete(file);
       return dataUrl;
     } catch {
-      pending.delete(file);
       return null;
+    } finally {
+      if (model) { scene?.remove(model); disposeModel(model); }
+      pending.delete(file);
     }
   })();
 
   pending.set(file, promise);
   return promise;
 }
-
-/** Get the GLB filename for a catalog ID (mirrors MODEL_MAP keys) */

--- a/tests/browser/furniture-fidelity.spec.ts
+++ b/tests/browser/furniture-fidelity.spec.ts
@@ -32,7 +32,9 @@ async function colors(page: Page) {
       const [r, g, b] = [pixels[i], pixels[i + 1], pixels[i + 2]];
       if (r > 50 && r > g * 1.5 && r > b * 1.5) result.red++;
       if (g > 50 && g > r * 1.5 && g > b * 1.5) result.green++;
-      if (b > 50 && b > r * 1.5 && b > g * 1.5) result.blue++;
+      // The selected navy (#191970) remains dark under scene lighting. Require
+      // a clear blue hue above the shadow floor, rather than bright blue pixels.
+      if (b > 20 && b > r * 1.5 && b > g * 1.5) result.blue++;
     }
     return result;
   });
@@ -48,6 +50,7 @@ for (const width of [1440, 390]) test(`furniture tint, finish and resource reuse
   await openFixture(page); await open3D(page);
   await expect.poll(async () => (await colors(page)).green).toBeGreaterThan(50);
   expect((await colors(page)).red).toBeGreaterThan(50);
+  expect((await colors(page)).blue).toBeLessThan(25);
   expect(observed.models.filter(url => chairURL.test(url))).toHaveLength(1);
   await page.getByRole('button', { name: 'Make Walls Transparent', exact: true }).click();
   await expect.poll(async () => (await colors(page)).green).toBeGreaterThan(50);

--- a/tests/browser/furniture-fidelity.spec.ts
+++ b/tests/browser/furniture-fidelity.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, type Page } from '@playwright/test';
+import { resolve } from 'node:path';
+import { savedProjects } from './storage';
+
+const fixture = resolve('tests/fixtures/furniture-fidelity.openplan.json');
+const chairURL = /\/loungeChair\.[\w-]+\.glb$/;
+function observe(page: Page) {
+  const errors: string[] = [], external: string[] = [], models: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  page.on('request', request => {
+    if (/^https?:/.test(request.url()) && new URL(request.url()).origin !== 'http://127.0.0.1:4188') external.push(request.url());
+    if (/\.glb$/.test(request.url())) models.push(request.url());
+  });
+  return { models, check() { expect(errors).toEqual([]); expect(external).toEqual([]); expect(models.some(url => /toaster/.test(url))).toBe(false); } };
+}
+async function openFixture(page: Page) {
+  await page.goto('/editor');
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const pending = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+  await (await pending).setFiles(fixture);
+  await expect(page.getByRole('button', { name: 'QA Furniture Fidelity', exact: true })).toBeVisible();
+}
+async function colors(page: Page) {
+  // Inspect actual rendered pixels, without relying on private Three.js scene state.
+  return page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first().evaluate((source: HTMLCanvasElement) => {
+    const canvas = document.createElement('canvas'); canvas.width = 256; canvas.height = 256;
+    const context = canvas.getContext('2d')!; context.drawImage(source, 0, 0, 256, 256);
+    const pixels = context.getImageData(0, 0, 256, 256).data;
+    const result = { red: 0, green: 0, blue: 0 };
+    for (let i = 0; i < pixels.length; i += 4) {
+      const [r, g, b] = [pixels[i], pixels[i + 1], pixels[i + 2]];
+      if (r > 50 && r > g * 1.5 && r > b * 1.5) result.red++;
+      if (g > 50 && g > r * 1.5 && g > b * 1.5) result.green++;
+      if (b > 50 && b > r * 1.5 && b > g * 1.5) result.blue++;
+    }
+    return result;
+  });
+}
+async function open3D(page: Page) {
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  await expect(page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
+  await page.waitForLoadState('networkidle');
+}
+
+for (const width of [1440, 390]) test(`furniture tint, finish and resource reuse survive 3D rebuilds at ${width}px`, async ({ page }, testInfo) => {
+  const observed = observe(page); await page.setViewportSize({ width, height: 900 });
+  await openFixture(page); await open3D(page);
+  await expect.poll(async () => (await colors(page)).green).toBeGreaterThan(50);
+  expect((await colors(page)).red).toBeGreaterThan(50);
+  expect(observed.models.filter(url => chairURL.test(url))).toHaveLength(1);
+  await page.getByRole('button', { name: 'Make Walls Transparent', exact: true }).click();
+  await expect.poll(async () => (await colors(page)).green).toBeGreaterThan(50);
+  await page.getByRole('button', { name: 'Show Solid Walls', exact: true }).click();
+  await page.getByRole('button', { name: '2D', exact: true }).click();
+  await page.getByRole('button', { name: 'Save', exact: true }).press('l');
+  await page.getByRole('button', { name: '💺 Armchair', exact: true }).first().click();
+  await expect(page.getByRole('combobox', { name: 'Material', exact: true })).toHaveValue('');
+  await page.getByRole('button', { name: 'Color: #191970', exact: true }).click();
+  await page.getByRole('combobox', { name: 'Material', exact: true }).selectOption('Fabric');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(async () => Object.values(await savedProjects(page)).some(project => project.floors[0].furniture.some((item: any) => item.id === 'chair-red' && item.color === '#191970' && item.material === 'Fabric'))).toBe(true);
+  await open3D(page);
+  await expect.poll(async () => (await colors(page)).blue).toBeGreaterThan(50);
+  expect((await colors(page)).green).toBeGreaterThan(50);
+  expect(observed.models.filter(url => chairURL.test(url))).toHaveLength(1);
+  await testInfo.attach(`furniture-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+
+  if (width === 1440) {
+    await page.getByRole('button', { name: '2D', exact: true }).click();
+    await page.getByRole('button', { name: 'Objects', exact: true }).click();
+    await page.getByPlaceholder('Search furniture...').fill('Armchair');
+    await expect(page.getByRole('img', { name: 'Armchair', exact: true })).toBeVisible();
+    expect(observed.models.filter(url => chairURL.test(url))).toHaveLength(1);
+  }
+  await page.reload();
+  await page.getByRole('button', { name: 'Save', exact: true }).press('l');
+  await page.getByRole('button', { name: '💺 Armchair', exact: true }).first().click();
+  await expect(page.getByRole('combobox', { name: 'Material', exact: true })).toHaveValue('Fabric');
+  await open3D(page);
+  await expect.poll(async () => (await colors(page)).blue).toBeGreaterThan(50);
+  expect((await colors(page)).green).toBeGreaterThan(50);
+  observed.check();
+});
+
+test('a model completing after 3D closes stays reusable without another download', async ({ page }) => {
+  const observed = observe(page);
+  let release!: () => void, arrived!: () => void;
+  const hold = new Promise<void>(resolve => { release = resolve; }), requested = new Promise<void>(resolve => { arrived = resolve; });
+  await page.route(chairURL, async route => { arrived(); await hold; await route.continue(); });
+  await openFixture(page);
+  await page.getByRole('button', { name: '3D', exact: true }).click(); await requested;
+  await page.getByRole('button', { name: '2D', exact: true }).click(); release();
+  await page.waitForLoadState('networkidle'); await open3D(page);
+  await expect.poll(async () => (await colors(page)).green).toBeGreaterThan(50);
+  expect(observed.models.filter(url => chairURL.test(url))).toHaveLength(1);
+  observed.check();
+});

--- a/tests/fixtures/furniture-fidelity.openplan.json
+++ b/tests/fixtures/furniture-fidelity.openplan.json
@@ -1,0 +1,77 @@
+{
+  "id": "qa-furniture-fidelity",
+  "name": "QA Furniture Fidelity",
+  "floors": [
+    {
+      "id": "dimensions-floor",
+      "name": "Showroom",
+      "level": 0,
+      "walls": [],
+      "rooms": [],
+      "doors": [],
+      "windows": [],
+      "furniture": [
+        {
+          "id": "chair-red",
+          "catalogId": "chair",
+          "position": {
+            "x": -140,
+            "y": 0
+          },
+          "rotation": 0,
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "color": "#ff0000",
+          "width": 100,
+          "depth": 100,
+          "height": 110
+        },
+        {
+          "id": "chair-green",
+          "catalogId": "chair",
+          "position": {
+            "x": 140,
+            "y": 0
+          },
+          "rotation": 0,
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          },
+          "color": "#00ff00",
+          "width": 100,
+          "depth": 100,
+          "height": 110
+        },
+        {
+          "id": "fireplace",
+          "catalogId": "fireplace",
+          "position": {
+            "x": 0,
+            "y": -230
+          },
+          "rotation": 0,
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      ],
+      "stairs": [],
+      "columns": [],
+      "guides": [],
+      "measurements": [],
+      "annotations": [],
+      "textAnnotations": [],
+      "groups": []
+    }
+  ],
+  "activeFloorId": "dimensions-floor",
+  "createdAt": "2026-09-05T00:00:00.000Z",
+  "updatedAt": "2026-09-05T00:00:00.000Z"
+}

--- a/tests/furniture-models.test.ts
+++ b/tests/furniture-models.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { existsSync } from 'node:fs';
+import { furnitureCatalog, getCatalogItem } from '$lib/utils/furnitureCatalog';
+import { getModelFile } from '$lib/utils/furnitureModelFiles';
+
+beforeEach(() => vi.resetModules());
+const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+function template() {
+  const group = new THREE.Group();
+  const texture = new THREE.Texture();
+  const material = new THREE.MeshStandardMaterial({ color: '#dddddd', map: texture, roughness: 0.8 });
+  const geometry = new THREE.BoxGeometry(2, 3, 4);
+  const first = new THREE.Mesh(geometry, [material, material]); first.position.set(5, 8, -4);
+  const second = new THREE.Mesh(geometry, material); second.position.set(-2, 4, 3);
+  group.add(first, second);
+  return { group, texture, material, geometry };
+}
+const firstMesh = (root: THREE.Object3D) => { let result: THREE.Mesh | undefined; root.traverse(child => { if (!result && child instanceof THREE.Mesh) result = child; }); return result!; };
+const firstMaterial = (root: THREE.Object3D) => { const mat = firstMesh(root).material; return (Array.isArray(mat) ? mat[0] : mat) as THREE.MeshStandardMaterial; };
+
+it('shares one lazy request while isolating geometry, materials and textures for every consumer', async () => {
+  const source = template();
+  const load = vi.spyOn(GLTFLoader.prototype, 'loadAsync').mockResolvedValue({ scene: source.group } as any);
+  const { loadCatalogModel, disposeModel } = await import('$lib/utils/furnitureModelResources');
+  expect(load).not.toHaveBeenCalled();
+  const [thumbnail, placed] = await Promise.all([loadCatalogModel('loungeChair'), loadCatalogModel('loungeChair')]);
+  expect(load).toHaveBeenCalledTimes(1);
+  expect(firstMesh(thumbnail!).geometry).not.toBe(firstMesh(placed!).geometry);
+  expect(firstMaterial(thumbnail!)).not.toBe(firstMaterial(placed!));
+  expect(firstMaterial(thumbnail!).map).not.toBe(firstMaterial(placed!).map);
+  firstMaterial(thumbnail!).color.set('#ff0000');
+  expect(firstMaterial(placed!).color.getHexString()).toBe('dddddd');
+  const sharedMaterial = firstMaterial(thumbnail!), sharedGeometry = firstMesh(thumbnail!).geometry;
+  const materialDisposed = vi.spyOn(sharedMaterial, 'dispose'), geometryDisposed = vi.spyOn(sharedGeometry, 'dispose');
+  const textureDisposed = vi.spyOn(sharedMaterial.map!, 'dispose'), sourceDisposed = vi.spyOn(source.geometry, 'dispose');
+  disposeModel(thumbnail!); disposeModel(thumbnail!);
+  expect(materialDisposed).toHaveBeenCalledTimes(1); expect(geometryDisposed).toHaveBeenCalledTimes(1); expect(textureDisposed).toHaveBeenCalledTimes(1);
+  expect(sourceDisposed).not.toHaveBeenCalled();
+  const later = await loadCatalogModel('loungeChair');
+  expect(firstMaterial(later!).color.getHexString()).toBe('dddddd');
+  expect(load).toHaveBeenCalledTimes(1);
+  disposeModel(placed!); disposeModel(later!);
+});
+
+it('fits off-center nested models to fractional dimensions without changing the cached source', async () => {
+  const { fitFurnitureModel } = await import('$lib/utils/furnitureModelLoader');
+  const { cloneModel } = await import('$lib/utils/furnitureModelResources');
+  const source = template().group, model = cloneModel(source);
+  const before = new THREE.Box3().setFromObject(source);
+  const def = { ...getCatalogItem('chair')!, width: 87.125, depth: 123.75, height: 95.5 };
+  fitFurnitureModel(model, def);
+  const bounds = new THREE.Box3().setFromObject(model), size = bounds.getSize(new THREE.Vector3()), center = bounds.getCenter(new THREE.Vector3());
+  expect(size.x).toBeCloseTo(def.width); expect(size.y).toBeCloseTo(def.height); expect(size.z).toBeCloseTo(def.depth);
+  expect(center.x).toBeCloseTo(0); expect(center.z).toBeCloseTo(0); expect(bounds.min.y).toBeCloseTo(0);
+  expect(new THREE.Box3().setFromObject(source)).toEqual(before);
+});
+
+it('retains tint and finish after GLB load without changing another instance or its original materials', async () => {
+  const source = template(); vi.spyOn(GLTFLoader.prototype, 'loadAsync').mockResolvedValue({ scene: source.group } as any);
+  const { createFurnitureModelWithGLB } = await import('$lib/utils/furnitureModelLoader');
+  const def = getCatalogItem('chair')!, loaded = vi.fn();
+  const tinted = createFurnitureModelWithGLB('chair', { ...def, color: '#00ff00' }, loaded, { color: '#00ff00', material: 'Metal' });
+  const original = createFurnitureModelWithGLB('chair', def);
+  await settle();
+  expect(loaded).toHaveBeenCalledTimes(1);
+  expect(firstMaterial(tinted).color.getHexString()).toBe('00dd00');
+  expect(firstMaterial(tinted).metalness).toBe(0.85); expect(firstMaterial(tinted).roughness).toBe(0.25);
+  expect(firstMaterial(original).color.getHexString()).toBe('dddddd'); expect(firstMaterial(original).metalness).toBe(0);
+  expect(source.material.color.getHexString()).toBe('dddddd');
+});
+
+it('keeps ghost and glass opacity through async replacement and for later cached instances', async () => {
+  const source = template(); vi.spyOn(GLTFLoader.prototype, 'loadAsync').mockResolvedValue({ scene: source.group } as any);
+  const { createFurnitureModelWithGLB } = await import('$lib/utils/furnitureModelLoader');
+  const ghost = createFurnitureModelWithGLB('chair', getCatalogItem('chair')!, undefined, { ghost: true, material: 'Glass' });
+  expect(firstMaterial(ghost).opacity).toBeCloseTo(0.175);
+  await settle();
+  expect(firstMaterial(ghost).opacity).toBeCloseTo(0.175); expect(firstMaterial(ghost).depthWrite).toBe(false);
+  expect(firstMaterial(ghost).emissive.getHexString()).toBe('4488ff');
+  const normal = createFurnitureModelWithGLB('chair', getCatalogItem('chair')!);
+  await settle(); expect(firstMaterial(normal).opacity).toBe(1); expect(firstMaterial(normal).transparent).toBe(false);
+});
+
+it('cannot revive a disposed scene when a shared model request finishes late', async () => {
+  let finish!: (value: any) => void;
+  vi.spyOn(GLTFLoader.prototype, 'loadAsync').mockImplementation(() => new Promise(resolve => { finish = resolve; }));
+  const { createFurnitureModelWithGLB } = await import('$lib/utils/furnitureModelLoader');
+  const { disposeModel } = await import('$lib/utils/furnitureModelResources');
+  const callback = vi.fn(), model = createFurnitureModelWithGLB('chair', getCatalogItem('chair')!, callback);
+  const fallback = model.children[0], dispose = vi.spyOn(firstMesh(fallback).geometry, 'dispose');
+  const scene = new THREE.Group(); scene.add(model); disposeModel(scene);
+  finish({ scene: template().group }); await settle();
+  expect(model.children).toEqual([fallback]); expect(callback).not.toHaveBeenCalled(); expect(dispose).toHaveBeenCalledTimes(1);
+  const current = createFurnitureModelWithGLB('chair', getCatalogItem('chair')!, callback);
+  await settle(); expect(callback).toHaveBeenCalledExactlyOnceWith(current);
+});
+
+it('keeps a valid fallback when a downloaded model has no usable dimensions', async () => {
+  vi.spyOn(GLTFLoader.prototype, 'loadAsync').mockResolvedValue({ scene: new THREE.Group() } as any);
+  const { createFurnitureModelWithGLB } = await import('$lib/utils/furnitureModelLoader');
+  const callback = vi.fn(), model = createFurnitureModelWithGLB('chair', getCatalogItem('chair')!, callback);
+  const fallback = model.children[0], dispose = vi.spyOn(firstMesh(fallback).geometry, 'dispose');
+  await settle(); expect(model.children).toEqual([fallback]); expect(dispose).not.toHaveBeenCalled(); expect(callback).not.toHaveBeenCalled();
+});
+
+it('does not retry failed assets on every scene edit', async () => {
+  const load = vi.spyOn(GLTFLoader.prototype, 'loadAsync').mockRejectedValue(new Error('offline'));
+  const { createFurnitureModelWithGLB } = await import('$lib/utils/furnitureModelLoader');
+  for (let i = 0; i < 3; i++) { const model = createFurnitureModelWithGLB('chair', getCatalogItem('chair')!); await settle(); expect(model.children).toHaveLength(1); }
+  expect(load).toHaveBeenCalledTimes(1);
+});
+
+it('uses existing shared catalog mappings and a procedural fireplace instead of a toaster', async () => {
+  for (const item of furnitureCatalog) { const file = getModelFile(item.id); if (file) expect(existsSync(`static/models/${file}.glb`), item.id).toBe(true); }
+  expect(getModelFile('toString')).toBeNull(); expect(getModelFile('fireplace')).toBeNull();
+  const load = vi.spyOn(GLTFLoader.prototype, 'loadAsync');
+  const { createFurnitureModelWithGLB } = await import('$lib/utils/furnitureModelLoader');
+  const model = createFurnitureModelWithGLB('fireplace', getCatalogItem('fireplace')!);
+  await settle(); expect(load).not.toHaveBeenCalled(); expect(model.children[0].children.length).toBeGreaterThan(1);
+});


### PR DESCRIPTION
Downloaded furniture models could overwrite chosen colors, ignore material choices, and become opaque after replacing a placement ghost. Cached clones shared disposable geometry/materials, and late loads could revive removed previews. Preserve explicit color tints and finish settings through GLB replacement, retain original materials when unset, and dispose each instance without modifying another item or the template. Cancelled scenes reject late completions; failed/invalid models keep the procedural fallback.

Catalog thumbnails and placed furniture now share one lazy model mapping and request/template cache. Remove the incorrect fireplace-to-toaster mapping in favor of the existing procedural fireplace. Wall transparency affects active-floor wall bodies and preserves furniture finishes, opening glass and reference-floor opacity. No new catalog assets, production dependencies, Firebase uploads or external services.

Validation: 482 unit tests pass, including independent resources, tint/finish preservation, ghost opacity, fractional bounds, failed-request suppression and late disposal. Type checking has zero errors / 23 existing warnings; the production build passes. Added browser regressions check actual rendered colors at desktop/390px, saved finishes, model reuse for thumbnails and repeated 3D transitions, and delayed completion after leaving 3D. All 53 browser tests pass on final head `5c629fb`: [full CI run](https://github.com/laanlabs/openPlan3D/actions/runs/34074100614). Local manual desktop/mobile checks confirm separate chair colors, persisted finishes, glass opacity through wall toggles and the procedural fireplace, without console errors. Live desktop/mobile verification passes for separate colors, the correct fireplace, persisted navy/Glass edits, wall-opacity independence and unchanged catalog thumbnails, without browser warnings/errors. The QA import preserved all 26 original project links; the final library has 27 projects. [Merged-main CI](https://github.com/laanlabs/openPlan3D/actions/runs/34074484516) also passes all 482 unit and 53 browser tests. The next cross-platform furniture-category task is #63.

Details and limits are in `docs/reviews/2026-09-06-furniture-rendering.md`. Native catalog/rendering parity remains follow-up work; native distribution and Firebase migration/billing gates remain in #30.

Closes #61.
