### PR TITLE
Fix field keyboard editing and verify all three browser engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -28,14 +28,60 @@ jobs:
       - run: npm run check
       - run: npm test
       - run: npm run build
-      - run: npx playwright install --with-deps chromium
-      - run: npm run test:browser
+      - name: Production build for all browser engines
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: browser-build
+          path: build/
+          if-no-files-found: error
+          retention-days: 1
+
+  browser:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+        env:
+          NODE_ENV: production
+          NPM_CONFIG_INCLUDE: dev
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: browser-build
+          path: build/
+      - run: npx playwright install --with-deps ${{ matrix.browser }}
+      - run: npm run test:browser -- --project=${{ matrix.browser }}
       - name: Browser report and failure traces
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: browser-checks
+          name: browser-checks-${{ matrix.browser }}
           path: |
             playwright-report/
             test-results/
           retention-days: 7
+
+  # Keep the existing check name as an aggregate gate: success includes every
+  # engine, and a failed/skipped dependency must not silently pass this job.
+  check:
+    if: ${{ always() }}
+    needs: [build, browser]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Require build and all browser checks
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          BROWSER_RESULT: ${{ needs.browser.result }}
+        run: test "$BUILD_RESULT" = success && test "$BROWSER_RESULT" = success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,14 @@ jobs:
           name: browser-build
           path: build/
       - run: npx playwright install --with-deps ${{ matrix.browser }}
-      - run: npm run test:browser -- --project=${{ matrix.browser }}
+      - name: Chromium and WebKit regressions
+        if: matrix.browser != 'firefox'
+        run: npm run test:browser -- --project=${{ matrix.browser }}
+      - name: Firefox regressions with a virtual display for WebGL
+        if: matrix.browser == 'firefox'
+        run: xvfb-run -a npm run test:browser -- --project=firefox --headed
+        env:
+          LIBGL_ALWAYS_SOFTWARE: '1'
       - name: Browser report and failure traces
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/NEXT.md
+++ b/NEXT.md
@@ -16,7 +16,13 @@ IDs, fractional dimensions and metadata survive actual native return packages.
 See [the batch report](docs/reviews/2026-09-07-furniture-categories.md) and GitHub
 PR checks for merge/release status and final browser CI results.
 
-Local validation: **537 web unit tests, 53 XCTest tests**, production build and
+The browser compatibility batch for [#65](https://github.com/laanlabs/openPlan3D/issues/65)
+adds the full CI suite to Chromium, Firefox and WebKit, fixes canvas shortcuts
+intercepting field editing, and preserves furniture dimensions while replacing
+empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
+and PR checks for final engine results and merge/release status.
+
+Local validation: **541 web unit tests, 53 XCTest tests**, production build and
 audit pass; type checks report zero errors and 23 existing Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
@@ -27,15 +33,15 @@ floor elevations and sloped walls; direct AI provider configuration; safe import
 and project switching; local tab conflict recovery; IndexedDB migration; full
 library backup/restore; two-way local iPhone/web packages; editable item
 notes/photos/costs and pooled attachment history; furniture appearance fixes;
-category continuity. The earlier eighteen batches and pause hashes are recorded
+category continuity; field keyboard editing and browser-engine CI. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
-## 1. Next engineering batch: browser coverage and 3D resource review
+## 1. Next engineering batch: measured 3D resource review
 
-Expand meaningful import/edit/save/reload/export coverage beyond Chromium to
-Firefox and WebKit, then perform actual touch-device checks. Investigate the
-selected-wall material and camera-preview renderer teardown observations below
-with measured reproductions before deciding their fixes. Keep category contract
+Investigate the selected-wall material and camera-preview renderer teardown
+observations below with measured reproductions before deciding their fixes.
+Extend the desktop Safari interactive pass to actual touch-device checks.
+Keep category contract
 fixtures in both repositories synchronized when extending the catalog.
 
 Legacy saved package projects with chair fallbacks are protected on export and
@@ -80,9 +86,9 @@ quotas. See the [cost audit](docs/reviews/2026-09-05-firebase-cost-audit.md) and
 
 These are follow-up work areas, not claims that every item is a reproduced bug.
 
-- **Browser and device coverage:** expand the Chromium CI suite to Firefox and
-  WebKit; test actual iPhone/iPad touch, gestures, downloads/share sheets,
-  storage/quota recovery and desktop Safari. Exercise native denied camera access,
+- **Browser and device coverage:** keep all three CI engines passing; broaden
+  the bounded desktop Safari pass and test actual iPhone/iPad touch, gestures,
+  downloads/share sheets and storage/quota recovery. Exercise native denied camera access,
   interruption/backgrounding, long scans, multi-floor work and attachment-heavy
   saves. Run a first-room usability session with unfamiliar desktop/iPhone users.
 - **3D resource/performance audit:** investigate selected-wall highlight material
@@ -141,8 +147,7 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
   fixture-oriented issue/PR templates and a release checklist. Historical review
   findings and original package metadata are not authoritative current status.
 - Reduce the 23 existing Svelte warnings with focused accessibility/component
-  changes. Review the CI artifact-upload action's Node 20 deprecation warning and
-  update its pinned supported version; current checks pass. Continue dependency
+  changes. The CI artifact actions now use pinned Node 24 releases. Continue dependency
   auditing rather than treating the original resolved advisories as still open.
 - Decide whether to publish/license the currently private iOS repository, add a
   root contributor README, and clarify the two native targets/release branding.
@@ -153,8 +158,8 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
 
 1. Fetch both repositories and confirm clean `main` against `origin/main`; reread
    open GitHub issues and #30 for release updates. Start a focused `codex/…` branch
-   from current main after checking the category batch merge status.
-2. Start with browser coverage and measured resource checks. Preserve unknown fields,
+   from current main after checking the browser batch merge status.
+2. Start with measured resource checks. Preserve unknown fields,
    explicit clears, independent import copies, fractional transforms and pooled
    local attachments. Do not rely on temporary QA directories as source artifacts.
 3. Web baseline: Node 24/npm; run `NODE_ENV=production npm run check`,

--- a/README.md
+++ b/README.md
@@ -102,18 +102,25 @@ Open [http://localhost:5173](http://localhost:5173) in your browser.
 npm test
 npm run check
 npm run build
-npx playwright install --with-deps chromium
+npx playwright install --with-deps chromium firefox webkit
 npm run test:browser
 ```
 
 GitHub Actions runs these checks for pull requests and pushes to `main`.
 The regression suite covers local storage failures, autosave status, room metadata
 and exports, and keyboard tools. Use `npm run test:watch` while working on a fix.
-Production-browser CI covers import/edit/undo/save/reload/export, damaged-file
-recovery, catalog loading, 3D and cold/warm asset transfers. It starts an isolated
-Node server with analytics and cloud uploads disabled. Failure screenshots/traces
-and the HTML report are retained for seven days. Drawing and touch gestures still
-need separate interactive/device checks.
+Production-browser CI runs the same regression suite in Chromium, Firefox and
+WebKit, covering import/edit/undo/save/reload/export, damaged-file recovery,
+iPhone project packages, photos, catalog loading, 3D and cold/warm asset transfers.
+Each engine runs in a separate job against the same production build, with an
+isolated Node server and analytics/cloud uploads disabled. The final `check` job
+requires the build and every browser job to pass. Engine-specific failure
+screenshots/traces and HTML reports are retained for seven days; the shared build
+expires after one day. To run one engine, use
+`npm run test:browser -- --project=firefox` (or `chromium` / `webkit`).
+Linux WebKit is engine coverage, not a substitute for shipping Safari or physical
+iPhone/iPad checks. Drawing, touch gestures and native share sheets still need
+separate interactive/device checks.
 
 ### Production Build
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ requires the build and every browser job to pass. Engine-specific failure
 screenshots/traces and HTML reports are retained for seven days; the shared build
 expires after one day. To run one engine, use
 `npm run test:browser -- --project=firefox` (or `chromium` / `webkit`).
+Firefox's Linux CI job uses a virtual display and software OpenGL for real 3D
+rendering (`xvfb-run -a npm run test:browser -- --project=firefox --headed`).
 Linux WebKit is engine coverage, not a substitute for shipping Safari or physical
 iPhone/iPad checks. Drawing, touch gestures and native share sheets still need
 separate interactive/device checks.

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -391,3 +391,14 @@ legacy chair fallbacks remain protected on export. Local validation passes 537
 web unit tests and 53 XCTest tests. See [the category report](2026-09-07-furniture-categories.md)
 for compatibility details and PR verification. Browser coverage, native release
 and Firebase cost gates remain the next priorities.
+
+## Twentieth batch: browser coverage and field keyboard editing
+
+Issue #65 adds full production-browser CI for Chromium, Firefox and WebKit with
+one shared build and an aggregate status gate. Interactive Safari QA reproduced
+canvas shortcuts stealing text-field input; keyboard regressions also exposed
+empty furniture dimensions being committed as 1 cm. Both editing paths are
+repaired, with fractional values, text clipboard/undo and local recovery retained.
+See [the browser report](2026-09-07-cross-browser-editing.md) for validation and
+remaining device coverage. Measured 3D resource work is the next engineering batch;
+native distribution and the Firebase release/billing gates remain in #30.

--- a/docs/reviews/2026-09-07-cross-browser-editing.md
+++ b/docs/reviews/2026-09-07-cross-browser-editing.md
@@ -1,0 +1,67 @@
+# Cross-browser editing and project exchange
+
+Issue [#65](https://github.com/laanlabs/openPlan3D/issues/65), PR
+[#66](https://github.com/laanlabs/openPlan3D/pull/66).
+
+## Behavior and coverage
+
+The full production browser suite now runs in Chromium, Firefox and WebKit.
+Each engine has its own Linux CI job and isolated profile/server. All jobs use
+one production build; unit tests, type checks, audit and build run once. The
+existing `check` status is an aggregate gate that fails if the build or any
+browser job fails or is skipped. Reports and failure traces have distinct engine
+names and seven-day retention; the shared build expires after one day. Artifact
+actions are pinned to Node 24 releases.
+
+Coverage includes numeric editing, undo/redo, persistence, multi-floor views,
+local storage migration/conflicts/quota recovery, library backups, JSON and native
+project-package exchange, item photos/metadata, furniture rendering, and lazy,
+cacheable assets. Desktop and phone-width cases remain part of the same suite.
+Cloud uploads and analytics are disabled. This adds no Firebase service, storage
+writes, schema changes or account requirement.
+
+## Keyboard defect reproduced in Safari
+
+Selecting a wall, focusing Thickness, pressing Cmd+A and typing `33.75` previously
+selected all plan objects and appended digits to the old dimension. The window
+canvas listener ran before the field guard in the shared shortcut handler. It
+also intercepted Space, clipboard commands and selected-annotation deletion
+while editing fields.
+
+The canvas now returns before those actions for input, textarea, select and
+content-editable targets. Save remains available; native text selection,
+clipboard and undo/redo stay with the focused field. Plan undo/redo continues to
+work outside fields and through toolbar buttons. Browser regressions use real
+keyboard events to replace a fractional furniture width, type spaced notes,
+copy/paste/undo text with an already populated plan clipboard, save and reload.
+They compare the complete floor geometry and settings to the expected changes.
+
+Those keyboard tests also reproduced a furniture-field defect: clearing a width
+immediately committed 1 cm, so subsequent digits could produce `178.125` instead
+of `78.125`. Width, depth and height now keep geometry unchanged for empty or
+invalid drafts, restore the prior value on blur, accept fractional input and use
+the same 1 cm minimum in metric/imperial display units.
+
+## Verification
+
+Local Node 24 checks: **541 unit tests**, type checks with **zero errors and 23
+existing warnings**, and production build pass. Final engine results are recorded
+in the PR checks and completion comment.
+
+Interactive desktop Safari QA used a separate localhost project imported from
+`native-project-package.zip`. Verified the three-floor preview, corrected Cmd+A
+numeric editing, spaces and native copy/paste/undo in notes, 3D and stacked floors.
+The actual Safari-downloaded ZIP was decoded: wall thickness `0.3375` metres,
+new note, retained item price and both original attachment byte arrays matched.
+Reopening the saved Safari project retained the dimension and note.
+
+## Limits and follow-up
+
+[Playwright's WebKit](https://playwright.dev/docs/browsers) is engine coverage;
+Linux CI does not establish shipping Safari or physical iPhone/iPad compatibility.
+The bounded desktop Safari pass above does not cover all workflows. Physical
+touch/gesture/share-sheet tests and native release validation remain required.
+
+The selected-wall highlight materials and separate camera-preview renderer
+resource observations remain a separate measured audit. No claim of complete
+Planner 5D parity or completed Firebase cost gates is made; see `NEXT.md` and #30.

--- a/docs/reviews/2026-09-07-cross-browser-editing.md
+++ b/docs/reviews/2026-09-07-cross-browser-editing.md
@@ -8,6 +8,9 @@ Issue [#65](https://github.com/laanlabs/openPlan3D/issues/65), PR
 The full production browser suite now runs in Chromium, Firefox and WebKit.
 Each engine has its own Linux CI job and isolated profile/server. All jobs use
 one production build; unit tests, type checks, audit and build run once. The
+Firefox job uses a virtual display and software OpenGL to exercise real WebGL
+rendering. Tests finish before the job deadline and stop after five failures so
+reports remain available even when the runner cannot support a workflow. The
 existing `check` status is an aggregate gate that fails if the build or any
 browser job fails or is skipped. Reports and failure traces have distinct engine
 names and seven-day retention; the shared build expires after one day. Artifact
@@ -19,6 +22,12 @@ project-package exchange, item photos/metadata, furniture rendering, and lazy,
 cacheable assets. Desktop and phone-width cases remain part of the same suite.
 Cloud uploads and analytics are disabled. This adds no Firebase service, storage
 writes, schema changes or account requirement.
+
+The cache regression records timing metadata but does not depend on every engine
+reporting a cached image's encoded size or even creating another timing entry.
+It opens the warmed 3D view offline and compares decoded texture dimensions and
+pixel hashes with the cold load, while retaining byte limits, cache-header checks
+and zero startup model-download assertions.
 
 ## Keyboard defect reproduced in Safari
 
@@ -54,6 +63,8 @@ numeric editing, spaces and native copy/paste/undo in notes, 3D and stacked floo
 The actual Safari-downloaded ZIP was decoded: wall thickness `0.3375` metres,
 new note, retained item price and both original attachment byte arrays matched.
 Reopening the saved Safari project retained the dimension and note.
+Interactive in-app browser checks also verified empty/zero/negative furniture
+draft recovery and imperial editing/persistence at desktop and phone widths.
 
 ## Limits and follow-up
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,15 @@ export default defineConfig({
     screenshot: 'only-on-failure',
   },
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 }, launchOptions: { args: ['--use-angle=swiftshader', '--enable-unsafe-swiftshader'] } } },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 },
+        launchOptions: { args: ['--use-angle=swiftshader', '--enable-unsafe-swiftshader'] },
+      },
+    },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'], viewport: { width: 1440, height: 900 } } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'], viewport: { width: 1440, height: 900 } } },
   ],
   webServer: {
     command: 'node build/index.js',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
+  // Finish with reports before the job's 15-minute limit, even if a runner
+  // cannot provide graphics or many workflows fail for the same reason.
+  globalTimeout: process.env.CI ? 12 * 60_000 : undefined,
+  maxFailures: process.env.CI ? 5 : undefined,
   timeout: 60_000,
   expect: { timeout: 10_000 },
   reporter: [['list'], ['html', { open: 'never' }]],

--- a/src/lib/components/editor/FloorPlanCanvas.svelte
+++ b/src/lib/components/editor/FloorPlanCanvas.svelte
@@ -12,7 +12,7 @@
   import { snapFurnitureToWalls } from '$lib/utils/furnitureGeometry';
   import { getCatalogItem, getFurnitureSize, type FurnitureDef } from '$lib/utils/furnitureCatalog';
   import { drawFurnitureIcon } from '$lib/utils/furnitureIcons';
-  import { handleGlobalShortcut } from '$lib/utils/shortcuts';
+  import { handleGlobalShortcut, isEditingField } from '$lib/utils/shortcuts';
   import ContextMenu from './ContextMenu.svelte';
   import { roomPresets, placePreset } from '$lib/utils/roomPresets';
   import { getWallTextureCanvas, getFloorTextureCanvas, setTextureLoadCallback } from '$lib/utils/textureGenerator';
@@ -3112,14 +3112,19 @@
   }
 
   function onKeyDown(e: KeyboardEvent) {
+    // This listener is on window, so field keystrokes reach it too. Keep every
+    // canvas action (including Space, select/copy/paste and annotation deletion)
+    // out of focused inputs; only the explicit Save shortcut is global there.
+    if (isEditingField(e.target)) {
+      handleGlobalShortcut(e);
+      return;
+    }
     shiftDown = e.shiftKey;
     if (e.code === 'Space') { spaceDown = true; e.preventDefault(); return; }
 
     // Exact-length entry while drawing a wall (issue #6):
     // type a number, then Enter places the wall at exactly that length.
-    const keyTargetTag = (e.target as HTMLElement)?.tagName;
-    const inFormField = keyTargetTag === 'INPUT' || keyTargetTag === 'TEXTAREA' || keyTargetTag === 'SELECT';
-    if (currentTool === 'wall' && wallStart && !editingTextAnnotationId && !inFormField && !e.metaKey && !e.ctrlKey) {
+    if (currentTool === 'wall' && wallStart && !editingTextAnnotationId && !e.metaKey && !e.ctrlKey) {
       if (/^[0-9.]$/.test(e.key)) {
         typedWallLength += e.key;
         markDirty();

--- a/src/lib/components/sidebar/PropertiesPanel.svelte
+++ b/src/lib/components/sidebar/PropertiesPanel.svelte
@@ -159,18 +159,18 @@
   }
   function onFurnitureWidth(e: Event) {
     if (!selectedFurniture) return;
-    const v = Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1);
-    updateFurniture(selectedFurniture.id, { width: v });
+    dimensionInput(e, selectedFurniture.width ?? getCatalogItem(selectedFurniture.catalogId)?.width ?? 100,
+      value => updateFurniture(selectedFurniture!.id, { width: value }));
   }
   function onFurnitureDepth(e: Event) {
     if (!selectedFurniture) return;
-    const v = Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1);
-    updateFurniture(selectedFurniture.id, { depth: v });
+    dimensionInput(e, selectedFurniture.depth ?? getCatalogItem(selectedFurniture.catalogId)?.depth ?? 80,
+      value => updateFurniture(selectedFurniture!.id, { depth: value }));
   }
   function onFurnitureHeight(e: Event) {
     if (!selectedFurniture) return;
-    const v = Math.max(1, inputToCm(Number((e.target as HTMLInputElement).value)) || 1);
-    updateFurniture(selectedFurniture.id, { height: v });
+    dimensionInput(e, selectedFurniture.height ?? getCatalogItem(selectedFurniture.catalogId)?.height ?? 80,
+      value => updateFurniture(selectedFurniture!.id, { height: value }));
   }
   function onFurnitureMaterial(e: Event) {
     if (!selectedFurniture) return;
@@ -643,7 +643,7 @@
         <input 
           type="number" 
           value={displayValue(selectedFurniture.width ?? getCatalogItem(selectedFurniture.catalogId)?.width ?? 100)} 
-          oninput={onFurnitureWidth} min="1"
+          oninput={onFurnitureWidth} onblur={onFurnitureWidth} min={settings.units === 'imperial' ? 1 / 2.54 : 1} step="any"
           class="w-full px-2 py-1 border border-gray-200 rounded text-sm" 
         />
       </label>
@@ -652,7 +652,7 @@
         <input 
           type="number" 
           value={displayValue(selectedFurniture.depth ?? getCatalogItem(selectedFurniture.catalogId)?.depth ?? 80)} 
-          oninput={onFurnitureDepth} min="1"
+          oninput={onFurnitureDepth} onblur={onFurnitureDepth} min={settings.units === 'imperial' ? 1 / 2.54 : 1} step="any"
           class="w-full px-2 py-1 border border-gray-200 rounded text-sm" 
         />
       </label>
@@ -661,7 +661,7 @@
         <input 
           type="number" 
           value={displayValue(selectedFurniture.height ?? getCatalogItem(selectedFurniture.catalogId)?.height ?? 80)} 
-          oninput={onFurnitureHeight} min="1"
+          oninput={onFurnitureHeight} onblur={onFurnitureHeight} min={settings.units === 'imperial' ? 1 / 2.54 : 1} step="any"
           class="w-full px-2 py-1 border border-gray-200 rounded text-sm" 
         />
       </label>

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -7,8 +7,23 @@ export interface ShortcutContext {
   save?: () => void;
 }
 
+export function isEditingField(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  return !!element && (['INPUT', 'TEXTAREA', 'SELECT'].includes(element.tagName) || element.isContentEditable === true);
+}
+
 export function handleGlobalShortcut(e: KeyboardEvent, ctx: ShortcutContext = {}): boolean {
   const mod = e.metaKey || e.ctrlKey;
+
+  // Save remains available while editing. Text selection, clipboard and undo
+  // belong to the focused field, not the plan's selection/history.
+  if (mod && e.key === 's') {
+    e.preventDefault();
+    if (ctx.save) ctx.save();
+    else void manualSave();
+    return true;
+  }
+  if (isEditingField(e.target)) return false;
 
   // Ctrl+Z undo
   if (mod && e.key === 'z' && !e.shiftKey) {
@@ -22,18 +37,7 @@ export function handleGlobalShortcut(e: KeyboardEvent, ctx: ShortcutContext = {}
     redo();
     return true;
   }
-  // Ctrl+S save
-  if (mod && e.key === 's') {
-    e.preventDefault();
-    if (ctx.save) ctx.save();
-    else void manualSave();
-    return true;
-  }
-
-  // Don't handle single-key shortcuts if user is typing in an input
-  const tag = (e.target as HTMLElement)?.tagName;
-  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return false;
-  if ((e.target as HTMLElement)?.isContentEditable || mod || e.altKey) return false;
+  if (mod || e.altKey) return false;
 
   if (e.key.toLowerCase() === 'm' || e.key.toLowerCase() === 'n') {
     const tool = e.key.toLowerCase() === 'm' ? 'measure' : 'annotate';

--- a/tests/browser/editor.spec.ts
+++ b/tests/browser/editor.spec.ts
@@ -140,6 +140,20 @@ test('catalog and 3D use bounded, cacheable assets with zero startup model downl
   expect(oak).toBeTruthy();
   expect(oak!.bytes).toBeLessThan(120_000);
   for (const asset of assets) expect(asset.cacheControl).toContain('immutable');
+  // Decode through the same browser image cache used by Three's ImageLoader.
+  // Comparing pixels also proves the warm asset is complete and usable.
+  const decodedOak = () => page.evaluate(async url => {
+    const image = new Image(); image.src = url; await image.decode();
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth; canvas.height = image.naturalHeight;
+    const ctx = canvas.getContext('2d')!; ctx.drawImage(image, 0, 0);
+    const bytes = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    const hash = await crypto.subtle.digest('SHA-256', bytes);
+    return { width: canvas.width, height: canvas.height, hash: Array.from(new Uint8Array(hash)) };
+  }, oak!.url);
+  const coldPixels = await decodedOak();
+  expect(coldPixels.width).toBeGreaterThan(0);
+  expect(coldPixels.height).toBeGreaterThan(0);
 
   const cold = await page.evaluate(() => performance.getEntriesByType('resource').map(entry => {
     const resource = entry as PerformanceResourceTiming;
@@ -148,26 +162,25 @@ test('catalog and 3D use bounded, cacheable assets with zero startup model downl
   await page.getByRole('button', { name: '2D', exact: true }).click();
   await page.getByRole('button', { name: 'Save', exact: true }).click();
   await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
-  const warmAssetStart = assets.length;
   await page.reload();
   await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
   // Prove the previously loaded 3D assets remain usable without network access.
-  // WebKit's cached-image encodedBodySize can be zero; timing alone is not
-  // reliable evidence that the full image came from cache in every engine.
+  // WebKit can report zero cached encodedBodySize, and Firefox can reuse an
+  // image without a new timing entry. Decode/hash offline instead of relying
+  // on those engine-specific timing fields as the cache proof.
   await context.setOffline(true);
   await page.getByRole('button', { name: '3D', exact: true }).click();
   await expect(page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
   await page.waitForLoadState('networkidle');
   await Promise.all(pending);
+  const warmPixels = await decodedOak();
+  expect(warmPixels).toEqual(coldPixels);
   const warm = await page.evaluate(() => performance.getEntriesByType('resource').map(entry => {
     const resource = entry as PerformanceResourceTiming;
     return { url: resource.name, transferBytes: resource.transferSize, encodedBytes: resource.encodedBodySize };
   }));
-  const warmOak = warm.find(x => x.url === oak!.url);
-  expect(warmOak).toBeTruthy();
-  expect(warmOak!.transferBytes).toBe(0);
-  expect(assets.slice(warmAssetStart).find(asset => asset.url === oak!.url)?.bytes).toBe(oak!.bytes);
-  await testInfo.attach('asset-transfers', { body: JSON.stringify({ startup, catalogModels, cold, warm }, null, 2), contentType: 'application/json' });
+  for (const entry of warm.filter(x => /\.(glb|webp)(?:\?|$)/.test(x.url))) expect(entry.transferBytes).toBe(0);
+  await testInfo.attach('asset-transfers', { body: JSON.stringify({ startup, catalogModels, cold, warm, coldPixels, warmPixels }, null, 2), contentType: 'application/json' });
   await context.setOffline(false);
   await page.getByRole('button', { name: '2D', exact: true }).click();
   expect(errors).toEqual([]);

--- a/tests/browser/editor.spec.ts
+++ b/tests/browser/editor.spec.ts
@@ -96,7 +96,7 @@ test('import, numeric edit, undo/redo, save/reload and export preserve a multi-f
   expect(externalRequests).toEqual([]);
 });
 
-test('catalog and 3D use bounded, cacheable assets with zero startup model downloads', async ({ page }, testInfo) => {
+test('catalog and 3D use bounded, cacheable assets with zero startup model downloads', async ({ page, context }, testInfo) => {
   const errors: string[] = [];
   const assets: { url: string; cacheControl: string | undefined; bytes: number }[] = [];
   page.on('pageerror', error => errors.push(error.message));
@@ -148,11 +148,17 @@ test('catalog and 3D use bounded, cacheable assets with zero startup model downl
   await page.getByRole('button', { name: '2D', exact: true }).click();
   await page.getByRole('button', { name: 'Save', exact: true }).click();
   await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
+  const warmAssetStart = assets.length;
   await page.reload();
   await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+  // Prove the previously loaded 3D assets remain usable without network access.
+  // WebKit's cached-image encodedBodySize can be zero; timing alone is not
+  // reliable evidence that the full image came from cache in every engine.
+  await context.setOffline(true);
   await page.getByRole('button', { name: '3D', exact: true }).click();
   await expect(page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').first()).toBeVisible();
   await page.waitForLoadState('networkidle');
+  await Promise.all(pending);
   const warm = await page.evaluate(() => performance.getEntriesByType('resource').map(entry => {
     const resource = entry as PerformanceResourceTiming;
     return { url: resource.name, transferBytes: resource.transferSize, encodedBytes: resource.encodedBodySize };
@@ -160,8 +166,9 @@ test('catalog and 3D use bounded, cacheable assets with zero startup model downl
   const warmOak = warm.find(x => x.url === oak!.url);
   expect(warmOak).toBeTruthy();
   expect(warmOak!.transferBytes).toBe(0);
-  expect(warmOak!.encodedBytes).toBe(oak!.bytes);
+  expect(assets.slice(warmAssetStart).find(asset => asset.url === oak!.url)?.bytes).toBe(oak!.bytes);
   await testInfo.attach('asset-transfers', { body: JSON.stringify({ startup, catalogModels, cold, warm }, null, 2), contentType: 'application/json' });
+  await context.setOffline(false);
   await page.getByRole('button', { name: '2D', exact: true }).click();
   expect(errors).toEqual([]);
 });

--- a/tests/browser/item-details.spec.ts
+++ b/tests/browser/item-details.spec.ts
@@ -60,6 +60,14 @@ for (const width of [1440, 390]) test(`field keyboard editing cannot select or p
   await itemWidth.pressSequentially('78.125');
   await itemWidth.press('Tab');
   await expect(itemWidth).toHaveValue('78.125');
+  for (const dimension of ['Width (cm)', 'Depth (cm)', 'Height (cm)']) {
+    const input = page.getByRole('spinbutton', { name: dimension, exact: true });
+    const value = await input.inputValue();
+    for (const draft of ['', '0', '-1']) {
+      await input.fill(draft); await input.press('Tab');
+      await expect(input).toHaveValue(value);
+    }
+  }
   // Seed the canvas clipboard with furniture before using the text clipboard.
   await page.getByRole('button', { name: 'Save', exact: true }).press('ControlOrMeta+c');
   const notes = page.getByRole('textbox', { name: 'Item notes', exact: true });

--- a/tests/browser/item-details.spec.ts
+++ b/tests/browser/item-details.spec.ts
@@ -49,6 +49,45 @@ async function addPhoto(page: Page, path = resolve('tests/fixtures/large-item-ph
   await expect(page.getByRole('button', { name: 'Add photo', exact: true })).toBeEnabled();
 }
 
+for (const width of [1440, 390]) test(`field keyboard editing cannot select or paste plan objects at ${width}px`, async ({ page }) => {
+  const check = observe(page); await page.setViewportSize({ width, height: 900 });
+  const original = await openPackage(page); await selectFurniture(page);
+  const itemWidth = page.getByRole('spinbutton', { name: 'Width (cm)', exact: true });
+  // Use actual key events: fill() bypasses the canvas listener that used to
+  // swallow select-all and leave the old number in front of the typed value.
+  await itemWidth.press('ControlOrMeta+a');
+  await itemWidth.press('Backspace');
+  await itemWidth.pressSequentially('78.125');
+  await itemWidth.press('Tab');
+  await expect(itemWidth).toHaveValue('78.125');
+  // Seed the canvas clipboard with furniture before using the text clipboard.
+  await page.getByRole('button', { name: 'Save', exact: true }).press('ControlOrMeta+c');
+  const notes = page.getByRole('textbox', { name: 'Item notes', exact: true });
+  await notes.press('ControlOrMeta+a');
+  await notes.pressSequentially('Soft green fabric chair');
+  await expect(notes).toHaveValue('Soft green fabric chair');
+  await notes.press('ControlOrMeta+a'); await notes.press('ControlOrMeta+c');
+  await notes.press('ArrowRight'); await notes.press('Enter'); await notes.press('ControlOrMeta+v');
+  await expect(notes).toHaveValue('Soft green fabric chair\nSoft green fabric chair');
+  await notes.press('ControlOrMeta+z');
+  await expect(notes).toHaveValue('Soft green fabric chair\n');
+  await expect(itemWidth).toHaveValue('78.125');
+  await notes.press('ControlOrMeta+a'); await notes.press('Backspace');
+  await notes.pressSequentially('Soft green fabric chair');
+  await notes.press('Tab');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await page.reload(); await selectFurniture(page);
+  await expect(notes).toHaveValue('Soft green fabric chair');
+  await expect(itemWidth).toHaveValue('78.125');
+  const saved = (await savedProjects(page))[original.id];
+  const expected = structuredClone(original);
+  expected.floors[0].furniture[0].width = 78.125;
+  expected.floors[0].furniture[0].details.note = 'Soft green fabric chair';
+  expect(saved.floors).toEqual(expected.floors);
+  expect(saved.settings).toEqual(original.settings);
+  check();
+});
+
 for (const width of [1440, 390]) test(`item metadata and optimized photos survive undo, save and exports at ${width}px`, async ({ page }, testInfo) => {
   const check = observe(page); await page.setViewportSize({ width, height: 900 });
   const original = await openPackage(page); await selectFurniture(page);

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -45,3 +45,18 @@ it('routes Cmd/Ctrl+S through the same save status and error handling as the Sav
   handleGlobalShortcut(keyEvent('s', { ctrlKey: true }));
   expect(manualSave).toHaveBeenCalledTimes(2);
 });
+
+it.each([
+  { tagName: 'INPUT' }, { tagName: 'TEXTAREA' }, { tagName: 'SELECT' },
+  { tagName: 'SPAN', isContentEditable: true },
+])('leaves field editing to the browser but keeps save available: %j', target => {
+  for (const modifier of ['metaKey', 'ctrlKey']) {
+    for (const key of ['z', 'y', 'a', 'c', 'v', ' ', 'Backspace']) {
+      const event = keyEvent(key, { target, [modifier]: true });
+      expect(handleGlobalShortcut(event)).toBe(false);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    }
+    expect(handleGlobalShortcut(keyEvent('s', { target, [modifier]: true }))).toBe(true);
+  }
+  expect(manualSave).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
Editing a dimension with Cmd/Ctrl+A could select the entire plan instead of replacing the field text, and typing notes could trigger canvas shortcuts. Clearing a furniture dimension also immediately committed 1 cm, so typing `78.125` could produce `178.125`.

Keep canvas selection/clipboard/space/deletion shortcuts out of focused fields, leave text undo/redo to the browser, and preserve Cmd/Ctrl+S. Furniture width/depth/height retain their geometry through empty or invalid drafts and restore the prior value on blur, with fractional input and the same physical minimum in both unit systems.

Run the complete production browser suite in Chromium, Firefox and WebKit against one shared build. Firefox uses a virtual display/software OpenGL for 3D; the existing `check` status requires every engine and the build to pass. Retain separate engine reports, update artifact actions to pinned Node 24 releases, and verify cached 3D assets offline using decoded texture pixels. Cloud uploads and analytics remain disabled.

Validation: 541 unit tests, type checks (0 errors; 23 existing warnings), audit and production build pass. Interactive Safari verified import, field editing, text clipboard/undo, reload, 3D/stacked floors, and an actual downloaded ZIP with the expected dimension, note, retained price and attachment bytes. Local interactive checks also verified empty/invalid furniture drafts and imperial persistence. Final CI passed all 174 browser tests (58 each in Chromium, Firefox and WebKit), with no skipped tests or retries: https://github.com/laanlabs/openPlan3D/actions/runs/34162995601.

Linux WebKit and the bounded Safari pass do not replace physical iPhone/iPad touch, gestures, share sheets or native release validation. NEXT.md and the batch report record the remaining work.

Closes #65.
