### PR TITLE
Fix camera previews and release replaced 3D resources

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -22,7 +22,7 @@ intercepting field editing, and preserves furniture dimensions while replacing
 empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
 and PR checks for final engine results and merge/release status.
 
-Local validation: **541 web unit tests, 53 XCTest tests**, production build and
+Local validation: **544 web unit tests, 53 XCTest tests**, production build and
 audit pass; type checks report zero errors and 23 existing Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
@@ -33,15 +33,24 @@ floor elevations and sloped walls; direct AI provider configuration; safe import
 and project switching; local tab conflict recovery; IndexedDB migration; full
 library backup/restore; two-way local iPhone/web packages; editable item
 notes/photos/costs and pooled attachment history; furniture appearance fixes;
-category continuity; field keyboard editing and browser-engine CI. Earlier batches and pause hashes are recorded
+category continuity; field keyboard editing and browser-engine CI; camera preview
+and 3D resource cleanup. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
-## 1. Next engineering batch: measured 3D resource review
+## 1. Next engineering batch: rendering benchmarks and device coverage
 
-Investigate the selected-wall material and camera-preview renderer teardown
-observations below with measured reproductions before deciding their fixes.
-Extend the desktop Safari interactive pass to actual touch-device checks.
-Keep category contract
+The measured resource batch for [#67](https://github.com/laanlabs/openPlan3D/issues/67)
+repairs blank reopened camera previews, releases renderer contexts and replaced
+scene textures, and disposes/reapplies wall highlights through rebuilds. The
+pre-fix browser measurements confirmed retained contexts and texture growth. See
+[the resource report](docs/reviews/2026-09-07-viewer-resources.md) and PR checks for
+final validation and merge/release status.
+
+Next, establish repeatable small/medium/large-home benchmarks and agreed frame-time
+and memory targets on representative desktop/phone hardware. Measure before
+changing mobile quality or replacing whole-scene rebuilds. Extend desktop Safari
+checks to actual iPhone/iPad touch devices; the resource batch's native desktop
+Safari attempt was unavailable while the Mac was locked. Keep category contract
 fixtures in both repositories synchronized when extending the catalog.
 
 Legacy saved package projects with chair fallbacks are protected on export and
@@ -91,13 +100,11 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
   downloads/share sheets and storage/quota recovery. Exercise native denied camera access,
   interruption/backgrounding, long scans, multi-floor work and attachment-heavy
   saves. Run a first-room usability session with unfamiliar desktop/iPhone users.
-- **3D resource/performance audit:** investigate selected-wall highlight material
-  clones being replaced without explicit disposal, and the separate camera-preview
-  renderer lacking explicit teardown in `ThreeViewer.svelte`. These are source
-  observations; quantify memory/context growth before calling them confirmed user
-  failures. Add a repeatable small/medium/large-home benchmark, agreed desktop and
-  phone frame-time/memory targets, and measured mobile quality settings. Consider
-  updating changed objects instead of rebuilding whole scenes.
+- **3D performance:** keep the measured preview-context and scene-allocation
+  regressions passing. The confirmed cleanup defects are addressed in #67/#68.
+  Add small/medium/large-home benchmarks, agreed desktop and phone frame-time/memory
+  targets, and measured mobile quality settings. Consider updating changed objects
+  instead of rebuilding whole scenes only after measuring the benefit.
 - **Area/geometry agreement:** define whether area is measured at interior wall
   faces or another boundary, reconcile native raster-based areas with web polygons,
   and test room split/merge identity and schedules. Matching area totals are not

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -402,3 +402,14 @@ repaired, with fractional values, text clipboard/undo and local recovery retaine
 See [the browser report](2026-09-07-cross-browser-editing.md) for validation and
 remaining device coverage. Measured 3D resource work is the next engineering batch;
 native distribution and the Firebase release/billing gates remain in #30.
+
+
+## Twenty-first batch: camera previews and measured 3D resource cleanup
+
+Issue #67 reproduces blank reopened previews, retained WebGL contexts and texture
+allocation growth across scene rebuilds. Camera canvases and renderers now share a
+lifecycle; scene-generated textures have explicit ownership, and wall highlights
+restore/dispose their materials before rebuilds and reapply the selection. Local
+validation passes 544 unit tests. See [the resource report](2026-09-07-viewer-resources.md)
+for measurements, browser checks and their limits. Broader hardware performance
+benchmarks, physical-device coverage and the release/cost gates in #30 remain.

--- a/docs/reviews/2026-09-07-viewer-resources.md
+++ b/docs/reviews/2026-09-07-viewer-resources.md
@@ -26,6 +26,11 @@ collection cannot hide missing teardown. In Firefox:
   on these measured expectations. The retained counts are allocations, not GPU
   byte estimates, JavaScript heap measurements or frame-time benchmarks.
 
+The first post-fix Firefox run (all 61 tests passed) kept the same scene at **13
+textures** through every measured rebuild. Closing a preview retained only the
+main context, whose buffers/programs returned to 10/3 each time; leaving 3D left
+zero live measured contexts. Final three-engine results are attached to PR #68.
+
 ## Changes
 
 - The preview renderer follows its canvas lifetime. Closing, repositioning,
@@ -45,6 +50,10 @@ collection cannot hide missing teardown. In Firefox:
   dirty so the new highlight is rendered promptly.
 
 ## Validation
+
+The full suite also exposed an existing save-retry test reloading the page while
+its IndexedDB transaction was still pending. It now waits for the visible
+`Saved ✓` confirmation before checking persistence after reload.
 
 Local validation: **544 unit tests**, zero type errors, 23 existing Svelte
 warnings and production build pass. The ownership tests exercise 100 repeated

--- a/docs/reviews/2026-09-07-viewer-resources.md
+++ b/docs/reviews/2026-09-07-viewer-resources.md
@@ -1,0 +1,77 @@
+# Interior camera and 3D resource lifetimes
+
+September 7, 2026. Tracks [#67](https://github.com/laanlabs/openPlan3D/issues/67)
+and [PR #68](https://github.com/laanlabs/openPlan3D/pull/68).
+
+## Reproduction and measurements
+
+On main `49149e6`, an interior-camera preview drew normally the first time, then
+remained blank after closing and placing another camera. The renderer still
+referenced the removed canvas. Closing during the first placement step also left
+placement mode active. Both were reproduced interactively in the in-app browser.
+
+The pre-fix [CI measurement run](https://github.com/laanlabs/openPlan3D/actions/runs/34166158517)
+uses the production build and instruments the browser's public WebGL API, with no
+application debug hooks. It deliberately retains context references so garbage
+collection cannot hide missing teardown. In Firefox:
+
+- Closing the preview left **two live contexts**, including the disconnected
+  preview canvas. Its context still held 10 buffers, 11 textures, 3 programs,
+  10 framebuffers and 6 renderbuffers.
+- For the one-room textured fixture, after warming both floor-display modes,
+  retained texture allocations rose **23 → 28 → 33 → 38 → 43** across four
+  stack/unstack cycles (eight rebuilds). Buffers (132), programs (8), framebuffers
+  (10) and renderbuffers (6) stayed constant.
+- The existing 58 Firefox browser tests passed; the two new resource tests failed
+  on these measured expectations. The retained counts are allocations, not GPU
+  byte estimates, JavaScript heap measurements or frame-time benchmarks.
+
+## Changes
+
+- The preview renderer follows its canvas lifetime. Closing, repositioning,
+  changing floors or leaving 3D cancels pending preview frames and releases the
+  old context. A new panel gets a renderer for its new canvas.
+- Closing also removes and disposes the camera marker and clears placement state.
+  Main-view and temporary photo/AI-capture renderers explicitly release their
+  contexts. Photo capture restores temporary scene visibility and releases its
+  renderer in `finally`, including rendering/encoding failures.
+- Scene-generated texture wrappers (floors, walls, labels and ground) register
+  ownership with the existing resource disposer. Rebuilds dispose replaced
+  wrappers; shared decoded canvases and cached model templates remain available.
+  Sky and shadow-map resources have explicit viewer teardown.
+- Wall highlighting restores original materials before rebuilding or disposing a
+  scene, disposes its cloned materials, and reapplies the selected wall afterward.
+  Shared textures are borrowed by highlights. Selection changes mark the view
+  dirty so the new highlight is rendered promptly.
+
+## Validation
+
+Local validation: **544 unit tests**, zero type errors, 23 existing Svelte
+warnings and production build pass. The ownership tests exercise 100 repeated
+selections, rebuilt highlighted scenes, and owned versus borrowed textures.
+
+The new production-browser tests measure preview contexts at desktop and
+390-pixel widths, repeated closing/reopening, repositioning, two 1920×1080 PNG
+captures, 2D/3D remounts and textured scene rebuilds. They retain JSON allocation
+samples in the CI report. The complete suite runs in Chromium, Firefox and
+WebKit; see PR checks and the completion comment for final results and rollout
+status.
+
+Interactive local checks verify repaired previews at desktop and phone widths,
+repositioning, viewer remounts, and a selected wall remaining highlighted after
+stack/unstack rebuilds. No console errors or warnings were observed in those
+checks. Native desktop Safari could not be repeated because the Mac was locked;
+WebKit CI is separate from physical Safari/iPhone validation.
+
+No Firebase Storage writes, server routes, quotas, rules or cloud retention
+settings are added or changed. Ordinary editing, textures and photos retain the
+local/cached asset design. The iPhone repository and package format are unchanged.
+
+## Remaining work
+
+Keep the resource regression fixtures passing. Broader performance work still
+needs repeatable small/medium/large homes, measured frame-time and memory budgets
+on actual desktop/phone hardware, and evidence before adjusting mobile quality
+or replacing whole-scene rebuilds. Touch gestures, downloads/share sheets and
+physical native device coverage remain open. See [NEXT.md](../../NEXT.md) and
+[#30](https://github.com/laanlabs/openPlan3D/issues/30) for release and cost gates.

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -20,7 +20,8 @@
   import MaterialPicker from './MaterialPicker.svelte';
   import { getCatalogItem, furnitureCatalog, furnitureCategories } from '$lib/utils/furnitureCatalog';
   import type { FurnitureDef } from '$lib/utils/furnitureCatalog';
-  import { disposeModel } from '$lib/utils/furnitureModelResources';
+  import { createWallHighlight } from '$lib/utils/wallHighlight';
+  import { disposeModel, ownTexture } from '$lib/utils/furnitureModelResources';
   import { createFurnitureModelWithGLB } from '$lib/utils/furnitureModelLoader';
   import { addFurniture } from '$lib/stores/project';
   import { detectRooms, resolveRooms, getRoomPolygon, roomCentroid } from '$lib/utils/roomDetection';
@@ -46,7 +47,7 @@
   const mouse = new THREE.Vector2();
   const wallMeshMap = new Map<THREE.Object3D, string>(); // mesh → wallId
   let selectedWallId3D: string | null = null;
-  const originalEmissive = new Map<THREE.Object3D, THREE.Color>();
+  const wallHighlight = createWallHighlight();
 
   // 3D Edit mode — enables click-to-select
   let editMode = $state(false);
@@ -108,6 +109,7 @@
   let cameraPreviewOpen = $state(false);
   let cameraPreviewCanvas = $state<HTMLCanvasElement | null>(null);
   let cameraPreviewRenderer: THREE.WebGLRenderer | null = null;
+  let previewAnimId: number | undefined;
   let cameraPlaced = $state(false);
   let cameraDragMode = $state<'position' | 'lookat' | null>(null);
   let cameraYaw = $state(0);   // degrees, 0 = initial direction
@@ -171,16 +173,13 @@
     offRenderer.shadowMap.enabled = true;
     offRenderer.shadowMap.type = THREE.PCFSoftShadowMap;
     offRenderer.toneMapping = THREE.ACESFilmicToneMapping;
-    const helperVisible = cameraHelper?.visible ?? true;
     try {
-      if (cameraHelper) cameraHelper.visible = false;
-      setSpritesVisible(false);
-      offRenderer.render(scene!, interiorCamera!);
-      return offRenderer.domElement.toDataURL('image/png');
+      return withInteriorScene(() => {
+        offRenderer.render(scene, interiorCamera!);
+        return offRenderer.domElement.toDataURL('image/png');
+      }, false);
     } finally {
-      if (cameraHelper) cameraHelper.visible = helperVisible;
-      setSpritesVisible(true);
-      offRenderer.dispose();
+      releaseRenderer(offRenderer);
     }
   }
 
@@ -412,14 +411,6 @@
     }
   }
 
-  /** Hide/show all label sprites in the scene (room names, etc.) */
-  function setSpritesVisible(visible: boolean) {
-    if (!scene) return;
-    scene.traverse((obj) => {
-      if (obj instanceof THREE.Sprite) obj.visible = visible;
-    });
-  }
-
   function captureInteriorPhoto() {
     if (!scene || !interiorCamera) return;
     updateInteriorCamera();
@@ -435,19 +426,15 @@
     offRenderer.toneMapping = THREE.ACESFilmicToneMapping;
     offRenderer.toneMappingExposure = 1.0;
 
-    // Hide camera marker and room labels during capture
-    if (cameraHelper) cameraHelper.visible = false;
-    setSpritesVisible(false);
-    if (cameraXrayWalls) setWallsXray(true);
-
-    offRenderer.render(scene, interiorCamera);
-
-    if (cameraHelper) cameraHelper.visible = true;
-    setSpritesVisible(true);
-    if (cameraXrayWalls) setWallsXray(false);
-
-    const dataUrl = offRenderer.domElement.toDataURL('image/png');
-    offRenderer.dispose();
+    let dataUrl: string;
+    try {
+      dataUrl = withInteriorScene(() => {
+        offRenderer.render(scene, interiorCamera!);
+        return offRenderer.domElement.toDataURL('image/png');
+      });
+    } finally {
+      releaseRenderer(offRenderer);
+    }
 
     // Download
     const link = document.createElement('a');
@@ -455,6 +442,62 @@
     link.download = `${projectName}-interior-photo.png`;
     link.href = dataUrl;
     link.click();
+  }
+
+  function releaseRenderer(target: THREE.WebGLRenderer) {
+    try { target.dispose(); }
+    finally { target.forceContextLoss(); }
+  }
+
+  function releaseCameraPreview() {
+    if (previewAnimId !== undefined) cancelAnimationFrame(previewAnimId);
+    previewAnimId = undefined;
+    if (cameraPreviewRenderer) {
+      releaseRenderer(cameraPreviewRenderer);
+      cameraPreviewRenderer = null;
+    }
+  }
+
+  function attachCameraPreview(canvas: HTMLCanvasElement) {
+    cameraPreviewCanvas = canvas;
+    cameraPreviewDirty = true;
+    return { destroy() {
+      releaseCameraPreview();
+      cameraPreviewCanvas = null;
+    } };
+  }
+
+  function closeCamera() {
+    cancelAIRender();
+    releaseCameraPreview();
+    cameraPreviewOpen = cameraPlaced = cameraPlacementMode = false;
+    previewDragStart = null;
+    if (cameraHelper) {
+      clearGroup(cameraHelper);
+      cameraHelper.removeFromParent();
+      cameraHelper = null;
+    }
+    interiorCamera = null;
+    aiRenderOpen = false; aiRenderResult = null; aiRenderError = null;
+    markSceneDirty();
+  }
+
+  /** All temporary presentation changes are restored even if rendering fails. */
+  function withInteriorScene<T>(render: () => T, xray = cameraXrayWalls): T {
+    const helperVisible = cameraHelper?.visible ?? true;
+    const sprites = new Map<THREE.Sprite, boolean>();
+    scene.traverse(obj => {
+      if (obj instanceof THREE.Sprite) { sprites.set(obj, obj.visible); obj.visible = false; }
+    });
+    try {
+      if (cameraHelper) cameraHelper.visible = false;
+      if (xray) setWallsXray(true);
+      return render();
+    } finally {
+      if (xray) setWallsXray(false);
+      if (cameraHelper) cameraHelper.visible = helperVisible;
+      for (const [sprite, visible] of sprites) sprite.visible = visible;
+    }
   }
 
   function renderCameraPreview() {
@@ -468,27 +511,25 @@
       cameraPreviewRenderer.shadowMap.type = THREE.PCFSoftShadowMap;
       cameraPreviewRenderer.toneMapping = THREE.ACESFilmicToneMapping;
       cameraPreviewRenderer.toneMappingExposure = 1.0;
+      cameraPreviewRenderer.setSize(384, 216);
+      cameraPreviewRenderer.setPixelRatio(1);
     }
-    cameraPreviewRenderer.setSize(384, 216);
-    cameraPreviewRenderer.setPixelRatio(1);
-
-    if (cameraHelper) cameraHelper.visible = false;
-    setSpritesVisible(false);
-    if (cameraXrayWalls) setWallsXray(true);
-    cameraPreviewRenderer.render(scene, interiorCamera);
-    if (cameraHelper) cameraHelper.visible = true;
-    setSpritesVisible(true);
-    if (cameraXrayWalls) setWallsXray(false);
+    withInteriorScene(() => cameraPreviewRenderer!.render(scene, interiorCamera!));
     cameraPreviewDirty = false;
   }
 
-  // Auto-render preview + update 3D marker when dirty flag is set
+  // Cancel pending callbacks when the panel disappears or another update wins.
   $effect(() => {
     if (cameraPreviewDirty && cameraPreviewCanvas && cameraPlaced) {
-      requestAnimationFrame(() => {
+      previewAnimId = requestAnimationFrame(() => {
+        previewAnimId = undefined;
         updateCameraMarkerFromState();
         renderCameraPreview();
       });
+      return () => {
+        if (previewAnimId !== undefined) cancelAnimationFrame(previewAnimId);
+        previewAnimId = undefined;
+      };
     }
   });
 
@@ -584,7 +625,7 @@
         cx.strokeRect(x + offset, y, 62, 30);
       }
     }
-    const tex = new THREE.CanvasTexture(c);
+    const tex = ownTexture(new THREE.CanvasTexture(c));
     tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
     tex.repeat.set(10, 10);
     return tex;
@@ -673,7 +714,7 @@
     grad.addColorStop(1.0, '#b8b0a0');
     cx.fillStyle = grad;
     cx.fillRect(0, 0, 4, 512);
-    skyTexture = new THREE.CanvasTexture(skyCanvas);
+    skyTexture = ownTexture(new THREE.CanvasTexture(skyCanvas));
     // Use as scene background (maps onto equirectangular projection)
     skyTexture.mapping = THREE.EquirectangularReflectionMapping;
     scene.background = skyTexture;
@@ -715,7 +756,7 @@
     for (let y = 0; y <= 1024; y += gridStep * 4) {
       gctx.beginPath(); gctx.moveTo(0, y); gctx.lineTo(1024, y); gctx.stroke();
     }
-    const groundTex = new THREE.CanvasTexture(groundCanvas);
+    const groundTex = ownTexture(new THREE.CanvasTexture(groundCanvas));
     groundTex.wrapS = groundTex.wrapT = THREE.RepeatWrapping;
     groundTex.repeat.set(groundSize / 4000, groundSize / 4000);
     const groundMat = new THREE.MeshStandardMaterial({
@@ -980,11 +1021,11 @@
       const cx = c.getContext('2d')!;
       cx.fillStyle = color;
       cx.fillRect(0, 0, 64, 64);
-      const tex = new THREE.CanvasTexture(c);
+      const tex = ownTexture(new THREE.CanvasTexture(c));
       tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
       return tex;
     }
-    const tex = new THREE.CanvasTexture(canvas);
+    const tex = ownTexture(new THREE.CanvasTexture(canvas));
     tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
     // Each texture tile covers ~200cm of real wall
     const tileSizeCm = 200;
@@ -1134,11 +1175,8 @@
   }
 
   function clearGroup(group: THREE.Object3D) {
-    while (group.children.length) {
-      const child = group.children[0];
-      disposeModel(child);
-      group.remove(child);
-    }
+    disposeModel(group);
+    group.clear();
   }
 
   function addOpeningFrame(wall: Wall, position: number, width: number, bottom: number, height: number, depth: number, material: THREE.Material) {
@@ -1155,7 +1193,9 @@
   }
 
   function buildWalls(floor: Floor) {
+    wallHighlight.clear();
     clearGroup(wallGroup);
+    cameraHelper = null;
     wallMeshMap.clear();
 
     const defaultInteriorMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.9, polygonOffset: true, polygonOffsetFactor: 1, polygonOffsetUnits: 1 });
@@ -1546,7 +1586,7 @@
         const floorMat = getMaterial(room.floorTexture);
         const floorCanvas = getFloorTextureCanvas(room.floorTexture);
         if (floorCanvas) {
-          const tex = new THREE.CanvasTexture(floorCanvas);
+          const tex = ownTexture(new THREE.CanvasTexture(floorCanvas));
           tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
           // Tile every 200cm — now UVs are 0-1, so repeat = room size / tile size
           const tileSizeCm = 200;
@@ -1599,7 +1639,7 @@
       ctx2.fillStyle = '#d1d5db';
       ctx2.fillText(formatArea(room.area, get(projectSettings).units), 128, 50);
 
-      const tex = new THREE.CanvasTexture(canvas);
+      const tex = ownTexture(new THREE.CanvasTexture(canvas));
       const spriteMat = new THREE.SpriteMaterial({ map: tex, transparent: true });
       const sprite = new THREE.Sprite(spriteMat);
       sprite.position.set(centroid.x, 30, centroid.y);
@@ -1669,7 +1709,7 @@
     ctx.textAlign = 'center';
     ctx.fillText(name, 128, 32);
 
-    const tex = new THREE.CanvasTexture(canvas);
+    const tex = ownTexture(new THREE.CanvasTexture(canvas));
     const spriteMat = new THREE.SpriteMaterial({ map: tex, transparent: true });
     const sprite = new THREE.Sprite(spriteMat);
 
@@ -1779,6 +1819,7 @@
       sceneGround.position.y = -1;
       buildWalls(currentFloor);
     }
+    wallHighlight.apply(wallMeshMap, selectedWallId3D);
     if (walkingPosition && walkingRotation) {
       camera.position.copy(walkingPosition);
       camera.position.y = activeFloorElevation + eyeHeight;
@@ -1806,7 +1847,9 @@
 
   function toggleWallTransparency() {
     wallsTransparent = !wallsTransparent;
+    wallHighlight.clear();
     applyWallTransparency();
+    wallHighlight.apply(wallMeshMap, selectedWallId3D);
     markSceneDirty();
   }
 
@@ -1971,53 +2014,18 @@
 
     const unsub = activeFloor.subscribe((f) => {
       if (currentFloor?.id !== f?.id) {
-        cancelAIRender();
+        closeCamera();
         if (walkthroughMode) exitWalkthroughMode();
-        cameraPlaced = false;
-        cameraPreviewOpen = false;
-        cameraPlacementMode = false;
       }
       currentFloor = f;
       if (f) rebuildScene();
     });
 
 
-    // Highlight selected wall in 3D
-    // Store original materials so we can restore them (shared materials must not be mutated)
-    const originalMaterials = new Map<THREE.Mesh, THREE.Material | THREE.Material[]>();
     const unsubSel = selectedElementId.subscribe((id) => {
-      // Restore previously highlighted meshes to their original materials
-      for (const [mesh, origMat] of originalMaterials) {
-        mesh.material = origMat;
-      }
-      originalMaterials.clear();
-      originalEmissive.clear();
       selectedWallId3D = id;
-      if (!id) return;
-      // Highlight matching wall meshes by cloning their materials
-      for (const [mesh, wallId] of wallMeshMap) {
-        if (wallId === id && mesh instanceof THREE.Mesh) {
-          originalMaterials.set(mesh, mesh.material);
-          // Clone materials so we don't mutate shared instances
-          if (Array.isArray(mesh.material)) {
-            mesh.material = mesh.material.map((m: THREE.Material) => {
-              const cloned = m.clone();
-              if (cloned instanceof THREE.MeshStandardMaterial) {
-                cloned.emissive.set(0x3388ff);
-                cloned.emissiveIntensity = 0.3;
-              }
-              return cloned;
-            });
-          } else {
-            const cloned = mesh.material.clone();
-            if (cloned instanceof THREE.MeshStandardMaterial) {
-              cloned.emissive.set(0x3388ff);
-              cloned.emissiveIntensity = 0.3;
-            }
-            mesh.material = cloned;
-          }
-        }
-      }
+      wallHighlight.apply(wallMeshMap, id);
+      markSceneDirty();
     });
 
     return () => {
@@ -2030,11 +2038,16 @@
       cancelAnimationFrame(animId);
       document.removeEventListener('keydown', onKeyDown, false);
       document.removeEventListener('keyup', onKeyUp, false);
+      releaseCameraPreview();
+      wallHighlight.clear();
       removeGhostPreview();
+      skyTexture.dispose();
+      sunLight.shadow.dispose();
       clearGroup(scene);
+      wallMeshMap.clear();
       pointerControls.dispose();
       controls.dispose();
-      renderer.dispose();
+      releaseRenderer(renderer);
     };
   });
 </script>
@@ -2185,7 +2198,7 @@
           <button class="text-xs text-blue-400 hover:text-blue-300" onclick={() => { cancelAIRender(); aiRenderOpen = !aiRenderOpen; }}>
             {aiRenderOpen ? 'Hide AI' : '✨ AI Render'}
           </button>
-          <button class="text-gray-400 hover:text-white text-lg leading-none" onclick={() => { cancelAIRender(); cameraPreviewOpen = false; if (cameraHelper) { wallGroup.remove(cameraHelper); cameraHelper = null; } cameraPlaced = false; aiRenderOpen = false; aiRenderResult = null; aiRenderError = null; }} aria-label="Close camera">✕</button>
+          <button class="text-gray-400 hover:text-white text-lg leading-none" onclick={closeCamera} aria-label="Close camera">✕</button>
         </div>
       </div>
       <!-- Preview canvas with drag-to-rotate -->
@@ -2195,7 +2208,7 @@
         onpointermove={(e) => { if (!previewDragStart) return; const dx = e.clientX - previewDragStart.x; const dy = e.clientY - previewDragStart.y; cameraYaw = previewDragStart.yaw + dx * 0.5; cameraPitch = Math.max(-45, Math.min(45, previewDragStart.pitch - dy * 0.3)); cameraPreviewDirty = true; }}
         onpointerup={() => { previewDragStart = null; }}
       >
-        <canvas bind:this={cameraPreviewCanvas} width="384" height="216" class="w-full pointer-events-none"></canvas>
+        <canvas use:attachCameraPreview aria-label="Interior camera preview" width="384" height="216" class="w-full pointer-events-none"></canvas>
         <div class="absolute bottom-1 left-1 text-[10px] text-white/50 pointer-events-none">Drag to look around</div>
       </div>
 

--- a/src/lib/utils/furnitureModelResources.ts
+++ b/src/lib/utils/furnitureModelResources.ts
@@ -9,6 +9,13 @@ const sources = new Map<string, Promise<THREE.Group | null>>();
 const disposed = new WeakSet<THREE.Object3D>();
 const ownedTextures = new WeakSet<THREE.Texture>();
 
+/** Register an instance-owned texture wrapper. Its image/canvas may still be
+ * shared; disposing a THREE.Texture releases GPU state without destroying it. */
+export function ownTexture<T extends THREE.Texture>(texture: T): T {
+  ownedTextures.add(texture);
+  return texture;
+}
+
 export function cloneModel(source: THREE.Group): THREE.Group {
   const clone = source.clone(true);
   const geometries = new Map<THREE.BufferGeometry, THREE.BufferGeometry>();
@@ -18,7 +25,7 @@ export function cloneModel(source: THREE.Group): THREE.Group {
     if (materials.has(original)) return materials.get(original)!;
     const result = original.clone();
     for (const [key, value] of Object.entries(result)) if (value instanceof THREE.Texture) {
-      if (!textures.has(value)) { const copy = value.clone(); textures.set(value, copy); ownedTextures.add(copy); }
+      if (!textures.has(value)) { const copy = ownTexture(value.clone()); textures.set(value, copy); }
       (result as any)[key] = textures.get(value);
     }
     materials.set(original, result);
@@ -46,7 +53,7 @@ export async function loadCatalogModel(file: string): Promise<THREE.Group | null
 export function isModelDisposed(root: THREE.Object3D) { return disposed.has(root); }
 
 /** Also marks pending furniture containers so late model loads cannot revive them.
- * Global wall/floor texture caches retain ownership of their textures. */
+ * Unregistered shared textures retain their original owner. */
 export function disposeModel(root: THREE.Object3D) {
   const geometries = new Set<THREE.BufferGeometry>(), materials = new Set<THREE.Material>();
   const textures = new Set<THREE.Texture>();
@@ -62,5 +69,5 @@ export function disposeModel(root: THREE.Object3D) {
   });
   for (const geometry of geometries) geometry.dispose();
   for (const material of materials) material.dispose();
-  for (const texture of textures) texture.dispose();
+  for (const texture of textures) { ownedTextures.delete(texture); texture.dispose(); }
 }

--- a/src/lib/utils/wallHighlight.ts
+++ b/src/lib/utils/wallHighlight.ts
@@ -1,0 +1,36 @@
+import * as THREE from 'three';
+
+/** Highlights borrow textures and own only their material clones. Restore the
+ * originals before scene disposal so neither set of materials is orphaned. */
+export function createWallHighlight() {
+  const originals = new Map<THREE.Mesh, THREE.Material | THREE.Material[]>();
+  const clones = new Map<THREE.Material, THREE.Material>();
+  function clear() {
+    for (const [mesh, material] of originals) mesh.material = material;
+    originals.clear();
+    for (const material of clones.values()) material.dispose();
+    clones.clear();
+  }
+  function clone(material: THREE.Material) {
+    if (!clones.has(material)) {
+      const highlighted = material.clone();
+      if (highlighted instanceof THREE.MeshStandardMaterial) {
+        highlighted.emissive.set(0x3388ff);
+        highlighted.emissiveIntensity = 0.3;
+      }
+      clones.set(material, highlighted);
+    }
+    return clones.get(material)!;
+  }
+  return {
+    clear,
+    apply(meshes: ReadonlyMap<THREE.Object3D, string>, id: string | null) {
+      clear();
+      if (!id) return;
+      for (const [mesh, wallId] of meshes) if (wallId === id && mesh instanceof THREE.Mesh) {
+        originals.set(mesh, mesh.material);
+        mesh.material = Array.isArray(mesh.material) ? mesh.material.map(clone) : clone(mesh.material);
+      }
+    }
+  };
+}

--- a/tests/browser/project-opening.spec.ts
+++ b/tests/browser/project-opening.spec.ts
@@ -116,6 +116,9 @@ test('a failed candidate save keeps the import in memory and its original safe i
   expect((await library(page))[source.id]).toEqual(source);
   await page.evaluate(() => { (window as any).failProjectWrites = false; });
   await page.getByRole('button', { name: 'Retry save', exact: true }).click();
+  // A click starts asynchronous IndexedDB work; wait for the committed save
+  // before navigating away, as the user-facing status instructs.
+  await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
   await page.reload(); expect((await exportJSON(page)).id).toBe(copy.id);
   check();
 });

--- a/tests/browser/viewer-resources.spec.ts
+++ b/tests/browser/viewer-resources.spec.ts
@@ -54,13 +54,17 @@ for (const width of [1440, 390]) test(`camera previews release resources across 
   try {
     await page.goto('/editor');
     await page.getByRole('button', { name: '3D', exact: true }).click();
+    let closedResources: unknown;
     for (let cycle = 0; cycle < 3; cycle++) {
       await placeCamera(page);
       await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost && item.width === 384 && item.height === 216 && item.connected && item.draws > 0).length).toBe(1);
       samples.push({ phase: `open-${cycle}`, contexts: await gpu(page) });
       await page.getByRole('button', { name: 'Close camera', exact: true }).click();
-      samples.push({ phase: `close-${cycle}`, contexts: await gpu(page) });
       await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost).length).toBe(1);
+      const closed = await gpu(page);
+      samples.push({ phase: `close-${cycle}`, contexts: closed });
+      if (cycle === 0) closedResources = closed[0].live;
+      else expect(closed[0].live).toEqual(closedResources); // removed markers do not accumulate on the main renderer
     }
     await placeCamera(page);
     await page.getByRole('button', { name: 'Reposition', exact: true }).click();
@@ -107,6 +111,7 @@ test('textured scene rebuilds retain a bounded number of GPU resources', async (
     await page.getByRole('button', { name: '─ Wall 1', exact: true }).click();
     await page.getByRole('button', { name: '3D', exact: true }).click();
     await page.waitForLoadState('networkidle');
+    await expect.poll(async () => (await gpu(page))[0]?.draws ?? 0).toBeGreaterThan(0);
     await page.getByRole('button', { name: 'Edit Mode', exact: true }).click();
     const canvas = page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').last();
     const bounds = await canvas.boundingBox();

--- a/tests/browser/viewer-resources.spec.ts
+++ b/tests/browser/viewer-resources.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { resolve } from 'node:path';
 
 // CI-only instrumentation of the browser's WebGL API. No app internals or debug
 // hooks: retain contexts deliberately so GC cannot disguise missing teardown.
@@ -7,7 +8,7 @@ async function observeGPU(page: Page) {
     const contexts: any[] = [];
     (window as any).__gpuAudit = contexts;
     const getContext = HTMLCanvasElement.prototype.getContext;
-    HTMLCanvasElement.prototype.getContext = function (...args: any[]) {
+    HTMLCanvasElement.prototype.getContext = function (this: HTMLCanvasElement, ...args: any[]) {
       const context = (getContext as any).apply(this, args);
       if (!context || !String(args[0]).startsWith('webgl') || contexts.some(item => item.gl === context)) return context;
       const entry: any = { gl: context, canvas: this, draws: 0, live: {} };
@@ -63,5 +64,38 @@ test('camera previews release their WebGL context and render on every reopen', a
   } finally {
     samples.push({ phase: 'final', contexts: await gpu(page) });
     await testInfo.attach('webgl-resource-counts', { body: JSON.stringify(samples, null, 2), contentType: 'application/json' });
+  }
+});
+
+
+test('textured scene rebuilds retain a bounded number of GPU resources', async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await observeGPU(page);
+  const samples: any[] = [];
+  try {
+    await page.goto('/editor');
+    await page.getByRole('button', { name: 'Export', exact: true }).click();
+    const chooser = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+    await (await chooser).setFiles(resolve('tests/fixtures/connected-dimensions.openplan.json'));
+    await page.getByRole('button', { name: 'Save', exact: true }).press('l');
+    await page.getByRole('button', { name: '─ Wall 1', exact: true }).click();
+    await page.getByRole('button', { name: '3D', exact: true }).click();
+    await page.waitForLoadState('networkidle');
+    const cycle = async () => {
+      for (const name of ['Show All Floors Stacked', 'Active Floor Only']) {
+        const before = (await gpu(page))[0].draws;
+        await page.getByRole('button', { name, exact: true }).click();
+        await expect.poll(async () => (await gpu(page))[0].draws).toBeGreaterThan(before);
+      }
+      return (await gpu(page))[0].live;
+    };
+    await cycle(); // warm both presentation modes and lazily loaded textures
+    const baseline = await cycle();
+    samples.push({ phase: 'warmed', live: baseline });
+    for (let index = 0; index < 4; index++) samples.push({ phase: `rebuild-${index}`, live: await cycle() });
+    expect(samples.at(-1).live).toEqual(baseline);
+  } finally {
+    await testInfo.attach('scene-resource-counts', { body: JSON.stringify(samples, null, 2), contentType: 'application/json' });
   }
 });

--- a/tests/browser/viewer-resources.spec.ts
+++ b/tests/browser/viewer-resources.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { resolve } from 'node:path';
+import { readFile } from 'node:fs/promises';
 
 // CI-only instrumentation of the browser's WebGL API. No app internals or debug
 // hooks: retain contexts deliberately so GC cannot disguise missing teardown.
@@ -42,9 +43,13 @@ async function placeCamera(page: Page) {
   await expect(page.getByRole('button', { name: 'Close camera', exact: true })).toBeVisible();
 }
 
-test('camera previews release their WebGL context and render on every reopen', async ({ page }, testInfo) => {
+for (const width of [1440, 390]) test(`camera previews release resources across reopen, reposition and capture at ${width}px`, async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  await page.setViewportSize({ width, height: 900 });
   await observeGPU(page);
-  const errors: string[] = []; page.on('pageerror', error => errors.push(error.message));
+  const errors: string[] = [], external: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  page.on('request', request => { if (/^https?:/.test(request.url()) && new URL(request.url()).origin !== 'http://127.0.0.1:4188') external.push(request.url()); });
   const samples: any[] = [];
   try {
     await page.goto('/editor');
@@ -58,9 +63,29 @@ test('camera previews release their WebGL context and render on every reopen', a
       await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost).length).toBe(1);
     }
     await placeCamera(page);
+    await page.getByRole('button', { name: 'Reposition', exact: true }).click();
+    await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost).length).toBe(1);
+    const main = page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').last();
+    const bounds = await main.boundingBox();
+    await main.click({ position: { x: bounds!.width * 0.45, y: bounds!.height * 0.5 } });
+    await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost && item.width === 384 && item.draws > 0).length).toBe(1);
+    for (let photo = 0; photo < 2; photo++) {
+      const pending = page.waitForEvent('download');
+      await page.getByRole('button', { name: '📸 Capture 1920×1080', exact: true }).click();
+      const bytes = await readFile((await (await pending).path())!);
+      expect(bytes.subarray(1, 4).toString()).toBe('PNG');
+      expect(bytes.readUInt32BE(16)).toBe(1920); expect(bytes.readUInt32BE(20)).toBe(1080);
+      await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost).length).toBe(2);
+      samples.push({ phase: `photo-${photo}`, contexts: await gpu(page) });
+    }
     await page.getByRole('button', { name: '2D', exact: true }).click();
     await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost).length).toBe(0);
-    expect(errors).toEqual([]);
+    await page.getByRole('button', { name: '3D', exact: true }).click();
+    await placeCamera(page);
+    await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost && item.draws > 0).length).toBe(2);
+    await page.getByRole('button', { name: '2D', exact: true }).click();
+    await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost).length).toBe(0);
+    expect(errors).toEqual([]); expect(external).toEqual([]);
   } finally {
     samples.push({ phase: 'final', contexts: await gpu(page) });
     await testInfo.attach('webgl-resource-counts', { body: JSON.stringify(samples, null, 2), contentType: 'application/json' });
@@ -82,6 +107,11 @@ test('textured scene rebuilds retain a bounded number of GPU resources', async (
     await page.getByRole('button', { name: '─ Wall 1', exact: true }).click();
     await page.getByRole('button', { name: '3D', exact: true }).click();
     await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Edit Mode', exact: true }).click();
+    const canvas = page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').last();
+    const bounds = await canvas.boundingBox();
+    await canvas.click({ position: { x: bounds!.width * 0.4, y: bounds!.height * 0.6 } });
+    await expect(page.getByRole('spinbutton', { name: 'Thickness (cm)', exact: true })).toBeVisible();
     const cycle = async () => {
       for (const name of ['Show All Floors Stacked', 'Active Floor Only']) {
         const before = (await gpu(page))[0].draws;

--- a/tests/browser/viewer-resources.spec.ts
+++ b/tests/browser/viewer-resources.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// CI-only instrumentation of the browser's WebGL API. No app internals or debug
+// hooks: retain contexts deliberately so GC cannot disguise missing teardown.
+async function observeGPU(page: Page) {
+  await page.addInitScript(() => {
+    const contexts: any[] = [];
+    (window as any).__gpuAudit = contexts;
+    const getContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (...args: any[]) {
+      const context = (getContext as any).apply(this, args);
+      if (!context || !String(args[0]).startsWith('webgl') || contexts.some(item => item.gl === context)) return context;
+      const entry: any = { gl: context, canvas: this, draws: 0, live: {} };
+      contexts.push(entry);
+      for (const kind of ['Buffer', 'Texture', 'Program', 'Framebuffer', 'Renderbuffer']) {
+        const objects = new Set(); entry.live[kind] = objects;
+        const create = context[`create${kind}`].bind(context), remove = context[`delete${kind}`].bind(context);
+        context[`create${kind}`] = (...args: any[]) => { const object = create(...args); if (object) objects.add(object); return object; };
+        context[`delete${kind}`] = (object: any) => { objects.delete(object); return remove(object); };
+      }
+      for (const name of ['drawElements', 'drawArrays', 'drawElementsInstanced', 'drawArraysInstanced']) {
+        const draw = context[name]?.bind(context);
+        if (draw) context[name] = (...args: any[]) => { entry.draws++; return draw(...args); };
+      }
+      return context;
+    } as typeof getContext;
+  });
+}
+async function gpu(page: Page) {
+  return page.evaluate(() => (window as any).__gpuAudit.map((item: any) => ({
+    connected: item.canvas.isConnected, lost: item.gl.isContextLost(), draws: item.draws,
+    width: item.canvas.width, height: item.canvas.height,
+    live: Object.fromEntries(Object.entries(item.live).map(([key, objects]: [string, any]) => [key, objects.size]))
+  })));
+}
+async function placeCamera(page: Page) {
+  await page.getByRole('button', { name: 'Place Interior Camera', exact: true }).click();
+  const canvas = page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').last();
+  const bounds = await canvas.boundingBox();
+  await canvas.click({ position: { x: bounds!.width * 0.45, y: bounds!.height * 0.5 } });
+  await expect(page.getByRole('button', { name: 'Close camera', exact: true })).toBeVisible();
+}
+
+test('camera previews release their WebGL context and render on every reopen', async ({ page }, testInfo) => {
+  await observeGPU(page);
+  const errors: string[] = []; page.on('pageerror', error => errors.push(error.message));
+  const samples: any[] = [];
+  try {
+    await page.goto('/editor');
+    await page.getByRole('button', { name: '3D', exact: true }).click();
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await placeCamera(page);
+      await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost && item.width === 384 && item.height === 216 && item.connected && item.draws > 0).length).toBe(1);
+      samples.push({ phase: `open-${cycle}`, contexts: await gpu(page) });
+      await page.getByRole('button', { name: 'Close camera', exact: true }).click();
+      samples.push({ phase: `close-${cycle}`, contexts: await gpu(page) });
+      await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost).length).toBe(1);
+    }
+    await placeCamera(page);
+    await page.getByRole('button', { name: '2D', exact: true }).click();
+    await expect.poll(async () => (await gpu(page)).filter((item: any) => !item.lost).length).toBe(0);
+    expect(errors).toEqual([]);
+  } finally {
+    samples.push({ phase: 'final', contexts: await gpu(page) });
+    await testInfo.attach('webgl-resource-counts', { body: JSON.stringify(samples, null, 2), contentType: 'application/json' });
+  }
+});

--- a/tests/wall-highlight.test.ts
+++ b/tests/wall-highlight.test.ts
@@ -1,0 +1,60 @@
+import { expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { createWallHighlight } from '$lib/utils/wallHighlight';
+import { disposeModel, ownTexture } from '$lib/utils/furnitureModelResources';
+
+it('repeated wall selections dispose every clone without changing shared originals or textures', () => {
+  const texture = ownTexture(new THREE.Texture());
+  const original = new THREE.MeshStandardMaterial({ map: texture });
+  const materialDisposed = vi.spyOn(original, 'dispose'), textureDisposed = vi.spyOn(texture, 'dispose');
+  const selected = new THREE.Mesh(new THREE.BoxGeometry(), [original, original]);
+  const shared = new THREE.Mesh(selected.geometry, original);
+  const meshes = new Map<THREE.Object3D, string>([[selected, 'a'], [shared, 'b']]);
+  const highlight = createWallHighlight();
+  const disposals: ReturnType<typeof vi.fn>[] = [];
+  for (let i = 0; i < 100; i++) {
+    highlight.apply(meshes, 'a');
+    const materials = selected.material as THREE.MeshStandardMaterial[];
+    expect(materials[0]).toBe(materials[1]);
+    expect(materials[0].emissive.getHexString()).toBe('3388ff');
+    expect(materials[0].map).toBe(texture);
+    expect(shared.material).toBe(original);
+    expect(original.emissive.getHexString()).toBe('000000');
+    const disposed = vi.fn(); materials[0].addEventListener('dispose', disposed); disposals.push(disposed);
+    highlight.apply(meshes, null);
+    expect(selected.material).toEqual([original, original]);
+  }
+  highlight.clear();
+  expect(disposals).toHaveLength(100);
+  for (const disposed of disposals) expect(disposed).toHaveBeenCalledTimes(1);
+  expect(materialDisposed).not.toHaveBeenCalled(); expect(textureDisposed).not.toHaveBeenCalled();
+  const scene = new THREE.Group(); scene.add(selected, shared); disposeModel(scene);
+  expect(materialDisposed).toHaveBeenCalledTimes(1); expect(textureDisposed).toHaveBeenCalledTimes(1);
+});
+
+it('restores originals before scene disposal and highlights replacements after a rebuild', () => {
+  const highlight = createWallHighlight();
+  for (let rebuild = 0; rebuild < 10; rebuild++) {
+    const original = new THREE.MeshStandardMaterial();
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(), original);
+    const scene = new THREE.Group(); scene.add(mesh);
+    const disposed = vi.spyOn(original, 'dispose');
+    highlight.apply(new Map([[mesh, 'a']]), 'a');
+    const cloneDisposed = vi.spyOn(mesh.material, 'dispose');
+    highlight.clear(); disposeModel(scene);
+    expect(cloneDisposed).toHaveBeenCalledTimes(1);
+    expect(disposed).toHaveBeenCalledTimes(1);
+  }
+});
+
+it('owns scene texture wrappers while retaining borrowed texture images and templates', () => {
+  const canvas = { width: 256, height: 64 }; // shared decoded/cached image source
+  const owned = ownTexture(new THREE.Texture(canvas)), borrowed = new THREE.Texture(canvas);
+  const ownedDisposed = vi.spyOn(owned, 'dispose'), borrowedDisposed = vi.spyOn(borrowed, 'dispose');
+  const scene = new THREE.Group();
+  scene.add(new THREE.Sprite(new THREE.SpriteMaterial({ map: owned })));
+  scene.add(new THREE.Mesh(new THREE.BoxGeometry(), new THREE.MeshStandardMaterial({ map: borrowed })));
+  disposeModel(scene); disposeModel(scene);
+  expect(ownedDisposed).toHaveBeenCalledTimes(1); expect(borrowedDisposed).not.toHaveBeenCalled();
+  expect(owned.image).toBe(canvas); expect(borrowed.image).toBe(canvas);
+});


### PR DESCRIPTION
Closing and reopening the interior camera left the new preview blank, and ordinary scene rebuilds retained GPU textures. The preview now releases its renderer with its canvas, closes placement cleanly, and disposes its marker. Scene-owned textures and selected-wall material clones are released when replaced; selection survives rebuilding. Main-view and photo/AI-capture contexts also have explicit teardown.

Measured on the production build in Firefox: the old implementation retained two contexts after closing a preview and grew from 23 to 43 textures over eight rebuilds. With the fix, closing leaves only the main context; leaving 3D leaves zero. Rebuilds stay at 13 textures with stable buffer/program/framebuffer/renderbuffer counts. Browser tests retain allocation samples and verify repeated reopening, repositioning and actual 1920×1080 PNG downloads at desktop and phone widths.

Validation: 544 local unit tests, zero type errors (23 existing warnings), production build and dependency audit pass. Interactive browser checks verify preview rendering and highlight persistence. All 183 browser tests (61 each in Chromium, Firefox and WebKit) passed without retries on the final PR and merged main. Live deployment version `1788820936979` passed preview reopen/reposition, viewer remount, selected-wall rebuild and phone-width checks without console errors or warnings. Native Safari could not be repeated while the Mac was locked.

No Firebase Storage operations, cloud configuration, package schema or iPhone changes. NEXT.md and the [resource report](https://github.com/laanlabs/openPlan3D/blob/main/docs/reviews/2026-09-07-viewer-resources.md) record findings and the remaining hardware benchmark/device work.

Closes #67.
