### PR TITLE
Fit top-down views to phone and landscape screens

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -22,7 +22,7 @@ intercepting field editing, and preserves furniture dimensions while replacing
 empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
 and PR checks for final engine results and merge/release status.
 
-Local validation: **562 web unit tests, 53 XCTest tests**, production build and
+Local validation: **582 web unit tests, 53 XCTest tests**, production build and
 audit pass; type checks report zero errors and 23 existing Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
@@ -35,7 +35,7 @@ library backup/restore; two-way local iPhone/web packages; editable item
 notes/photos/costs and pooled attachment history; furniture appearance fixes;
 category continuity; field keyboard editing and browser-engine CI; camera preview
 and 3D resource cleanup; repeatable furnished-home benchmarks and preservation of
-3D views during metadata edits. Earlier batches and pause hashes are recorded
+3D views during metadata edits; responsive top-down camera framing. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
 ## 1. Next engineering batch: measured rendering improvements and device coverage
@@ -54,12 +54,14 @@ item notes/costs/photos. Geometry, finishes, history and area-unit changes still
 refresh. See [the benchmark report](docs/reviews/2026-09-07-rendering-benchmarks.md)
 for results and measurement limits; CI software rendering is not a device budget.
 
-First fix the reproduced [phone top-down framing bug (#71)](https://github.com/laanlabs/openPlan3D/issues/71):
-the large fixture's outer room columns are cropped at 390×900 after clicking
-Top-Down View. Fit the camera to both axes using aspect ratio and field of view,
-with containment tests for single/stacked floors and narrow viewports.
+The [top-down framing batch (#71)](https://github.com/laanlabs/openPlan3D/issues/71)
+fits both screen axes, reserves vertical overlay space, clears pending orbit
+motion and includes distant/stacked geometry in the visible depth range. Corner
+projection and browser pixel checks cover portrait, desktop and landscape layouts.
+See [the framing report](docs/reviews/2026-09-07-top-down-framing.md) and PR checks
+for validation and release status.
 
-Then measure the same fixtures on representative desktop/phone hardware and agree
+Next, measure the same fixtures on representative desktop/phone hardware and agree
 frame-time and memory targets. Use those results to choose shared geometry,
 object-level visual updates or mobile quality controls. Extend desktop Safari
 checks to actual iPhone/iPad touch devices; the resource batch's native desktop

--- a/NEXT.md
+++ b/NEXT.md
@@ -61,7 +61,12 @@ projection and browser pixel checks cover portrait, desktop and landscape layout
 See [the framing report](docs/reviews/2026-09-07-top-down-framing.md) and PR checks
 for validation and release status.
 
-Next, measure the same fixtures on representative desktop/phone hardware and agree
+Next, fix [onboarding hint positioning after resize (#73)](https://github.com/laanlabs/openPlan3D/issues/73).
+The phone QA pass exposed a tip retaining its wider-screen position and wrapping
+into a narrow strip. Track viewport changes and constrain the actual tip bounds,
+while preserving dismissal and seen-tip behavior.
+
+Then measure the same fixtures on representative desktop/phone hardware and agree
 frame-time and memory targets. Use those results to choose shared geometry,
 object-level visual updates or mobile quality controls. Extend desktop Safari
 checks to actual iPhone/iPad touch devices; the resource batch's native desktop

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -424,3 +424,14 @@ finishes, history and area units still refresh. Local validation passes 562 unit
 tests. See [the benchmark report](2026-09-07-rendering-benchmarks.md) for results,
 measurement limits and browser validation. Hardware calibration, further visual
 edit performance, physical-device coverage and the #30 release/cost gates remain.
+
+
+## Twenty-third batch: responsive top-down camera framing
+
+Issue #71 fixes outside rooms being cropped at phone width and corners covered by
+the toolbar in landscape. The shared camera fit now handles a stable top-down
+orientation, overlay clearance and distant/stacked bounds. Top-Down clears pending
+orbit motion and exits walkthrough. Local validation passes 582 unit tests;
+rendered corner pixels are checked across three viewports and all CI engines.
+See [the framing report](2026-09-07-top-down-framing.md). Hardware calibration,
+physical-device coverage and the #30 release/cost gates remain.

--- a/docs/reviews/2026-09-07-top-down-framing.md
+++ b/docs/reviews/2026-09-07-top-down-framing.md
@@ -1,0 +1,59 @@
+# Responsive top-down camera framing
+
+September 7, 2026 · [Issue #71](https://github.com/laanlabs/openPlan3D/issues/71)
+
+## Problem and change
+
+At 390×900, the furnished-home benchmark's outside room columns were cropped after
+clicking **Top-Down View**. The perspective view already fit all bounding-box
+corners using both fields of view; Top-Down instead used a fixed multiple of the
+largest plan dimension. It ignored the narrow viewport's horizontal field of view.
+
+Both views now use the same corner-fitting calculation. Top-Down chooses a stable
+almost-vertical camera direction, fits horizontal and vertical extents, and leaves
+vertical space around the model for the toolbar and lower overlays. This also
+addresses a landscape check where a fitted corner was covered by the toolbar.
+Very long plans can require camera distances beyond the initial far plane, so
+fitting also extends that plane to include the back of the complete floor stack.
+
+An explicit Top-Down action consumes pending orbit/pan damping before setting the
+new camera pose. It exits walkthrough so the next movement frame cannot replace
+that pose. Viewport resizing keeps manual camera positioning; clicking Top-Down
+again refits the current viewport. No project geometry or saved data is changed.
+
+## Regression coverage
+
+The shared camera tests project every bounding-box corner after 60 actual
+`OrbitControls.update()` calls, using ordinary homes, tall stacks with basements,
+and long buildings in portrait, desktop and landscape aspects. Additional cases
+cover changed aspect/zoom, empty floors and vertical overlay clearance.
+
+`tests/fixtures/top-down-framing.openplan.json` is an ordinary local import with
+three floors at -350, 0 and 425.5 cm and magenta columns at the four outside corners.
+The browser test checks rendered pixels in all four quadrants, distance from the
+canvas edges, and overlap with viewer buttons. It exercises active/stacked views
+at 1440×900, 390×900 and 844×390, requesting Top-Down while orbit damping is in
+flight and checking again after more frames. It also checks leaving walkthrough
+when the browser denies mouse capture. Screenshots and measured pixel bounds are
+attached to the normal CI reports; no production debug hooks are added.
+
+Local validation: **582 unit tests passed**, zero type errors with 23 existing
+Svelte warnings, and a successful production build. The production-browser suite
+now has 63 workflows per engine (189 across Chromium, Firefox and WebKit), plus
+the six existing rendering benchmarks. See GitHub checks for their final results
+and merge/release status.
+
+Local interactive QA covers the corner fixture at phone/landscape sizes, stacked
+floors, the originally reported large furnished-home fixture, and empty floors.
+These are browser viewport checks, not physical iPhone/iPad testing. The previous
+native Safari attempt was unavailable while the Mac was locked; hardware/device
+calibration remains follow-up work.
+
+## Follow-up and cost
+
+Use the repeatable furnished-home fixtures to calibrate actual desktop/phone
+performance before choosing shared geometry, object-level updates or mobile
+quality controls. Source/license catalog maintenance, area agreement and native
+release coverage remain in `NEXT.md`. The release/migration/billing gates in #30
+remain open. This camera-only change adds no Firebase writes, media uploads,
+external assets or dependencies.

--- a/docs/reviews/2026-09-07-top-down-framing.md
+++ b/docs/reviews/2026-09-07-top-down-framing.md
@@ -1,6 +1,7 @@
 # Responsive top-down camera framing
 
 September 7, 2026 · [Issue #71](https://github.com/laanlabs/openPlan3D/issues/71)
+· [PR #72](https://github.com/laanlabs/openPlan3D/pull/72)
 
 ## Problem and change
 
@@ -30,7 +31,7 @@ cover changed aspect/zoom, empty floors and vertical overlay clearance.
 
 `tests/fixtures/top-down-framing.openplan.json` is an ordinary local import with
 three floors at -350, 0 and 425.5 cm and magenta columns at the four outside corners.
-The browser test checks rendered pixels in all four quadrants, distance from the
+After acknowledging the first-use hint through its UI, the browser test checks rendered pixels in all four quadrants, distance from the
 canvas edges, and overlap with viewer buttons. It exercises active/stacked views
 at 1440×900, 390×900 and 844×390, requesting Top-Down while orbit damping is in
 flight and checking again after more frames. It also checks leaving walkthrough
@@ -50,6 +51,9 @@ native Safari attempt was unavailable while the Mac was locked; hardware/device
 calibration remains follow-up work.
 
 ## Follow-up and cost
+
+The responsive pass also exposed stale onboarding-tip positioning after a viewport
+resize, tracked separately in [#73](https://github.com/laanlabs/openPlan3D/issues/73).
 
 Use the repeatable furnished-home fixtures to calibrate actual desktop/phone
 performance before choosing shared geometry, object-level updates or mobile

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -1861,16 +1861,17 @@
   }
 
   function viewTopDown() {
-    // Calculate center of the plan
-    const box = new THREE.Box3().setFromObject(wallGroup);
-    const center = box.getCenter(new THREE.Vector3());
-    const size = box.getSize(new THREE.Vector3());
-    const maxDim = Math.max(size.x, size.z, 500);
-
-    // Animate camera to top-down position
-    camera.position.set(center.x, (box.isEmpty() ? 0 : box.max.y) + maxDim * 1.5, center.z);
-    controls.target.copy(center);
+    if (walkthroughMode) exitWalkthroughMode();
+    // Consume pending orbit/pan deltas before setting the requested view. This
+    // public update path clears damping without reaching into control internals.
+    const damping = controls.enableDamping;
+    controls.enableDamping = false;
     controls.update();
+    controls.enableDamping = damping;
+    frameScene(camera, new THREE.Box3().setFromObject(wallGroup), controls.target,
+      { view: 'top-down', verticalInset: Math.min(64 / container.clientHeight, 0.2) });
+    controls.update();
+    markSceneDirty();
   }
 
   function toggleWalkthroughMode() {

--- a/src/lib/utils/frameScene.ts
+++ b/src/lib/utils/frameScene.ts
@@ -1,28 +1,40 @@
 import { Box3, PerspectiveCamera, Vector3 } from 'three';
 
 /** Fit every corner using the camera's horizontal and vertical field of view. */
-export function frameScene(camera: PerspectiveCamera, bounds: Box3, target: Vector3) {
+export function frameScene(camera: PerspectiveCamera, bounds: Box3, target: Vector3,
+  { view = 'perspective', verticalInset = 0 }: { view?: 'perspective' | 'top-down'; verticalInset?: number } = {}) {
   const box = bounds.isEmpty()
     ? new Box3(new Vector3(-200, 0, -200), new Vector3(200, 280, 200))
     : bounds;
   box.getCenter(target);
-  const outward = new Vector3(1.2, 0.8, 1.2).normalize();
+  // Stay just off the pole so camera.up and the viewing direction have a stable
+  // cross product, including after OrbitControls clamps its polar angle.
+  const outward = (view === 'top-down' ? new Vector3(0, 1, 0.00001) : new Vector3(1.2, 0.8, 1.2)).normalize();
   const right = new Vector3().crossVectors(camera.up, outward).normalize();
   const up = new Vector3().crossVectors(outward, right).normalize();
   const tanY = Math.tan(camera.getEffectiveFOV() * Math.PI / 360);
   const tanX = tanY * camera.aspect;
+  // Reserve a fraction of the viewport at both top and bottom for overlay UI.
+  // Horizontal space is independent, so a portrait view still uses its width.
+  const usableTanY = tanY * (1 - 2 * Math.max(0, Math.min(verticalInset, 0.45)));
   let distance = 400;
+  let furthestDepth = 0;
   for (const x of [box.min.x, box.max.x]) {
     for (const y of [box.min.y, box.max.y]) {
       for (const z of [box.min.z, box.max.z]) {
         const corner = new Vector3(x, y, z).sub(target);
         const depth = corner.dot(outward);
+        furthestDepth = Math.max(furthestDepth, -depth);
         distance = Math.max(distance, depth + Math.abs(corner.dot(right)) / tanX,
-          depth + Math.abs(corner.dot(up)) / tanY, depth + camera.near);
+          depth + Math.abs(corner.dot(up)) / usableTanY, depth + camera.near);
       }
     }
   }
   camera.position.copy(target).addScaledVector(outward, distance * 1.15);
+  // A narrow viewport can require a distance beyond the viewer's default far
+  // plane. Include the back of the whole stack instead of clipping the plan.
+  camera.far = Math.max(camera.far, (distance * 1.15 + furthestDepth + camera.near) * 1.1);
+  camera.updateProjectionMatrix();
   camera.lookAt(target);
   camera.updateMatrixWorld(true);
 }

--- a/tests/browser/viewer-framing.spec.ts
+++ b/tests/browser/viewer-framing.spec.ts
@@ -17,6 +17,9 @@ test('top-down fits every corner after orbit, stacking and viewport changes', as
   await (await chooser).setFiles(resolve('tests/fixtures/top-down-framing.openplan.json'));
   await page.getByRole('button', { name: '3D', exact: true }).click();
   await page.waitForLoadState('networkidle');
+  const hint = page.getByRole('button', { name: 'Got it', exact: true });
+  if (await hint.isVisible()) await hint.click();
+  await expect(hint).not.toBeVisible();
   const canvas = page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').last();
   const samples: any[] = [];
   const inspect = () => canvas.evaluate((node: HTMLCanvasElement) => {

--- a/tests/browser/viewer-framing.spec.ts
+++ b/tests/browser/viewer-framing.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { resolve } from 'node:path';
+
+// Four magenta columns mark the outer corners of a wide plan. Inspect rendered
+// pixels, rather than depending on Three/Svelte internals or screenshot goldens.
+test('top-down fits every corner after orbit, stacking and viewport changes', async ({ page }, testInfo) => {
+  test.setTimeout(120_000);
+  const errors: string[] = [], external: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  page.on('request', request => {
+    if (/^https?:/.test(request.url()) && new URL(request.url()).origin !== 'http://127.0.0.1:4188') external.push(request.url());
+  });
+  await page.goto('/editor');
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const chooser = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+  await (await chooser).setFiles(resolve('tests/fixtures/top-down-framing.openplan.json'));
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  await page.waitForLoadState('networkidle');
+  const canvas = page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').last();
+  const samples: any[] = [];
+  const inspect = () => canvas.evaluate((node: HTMLCanvasElement) => {
+    const probe = document.createElement('canvas'); probe.width = node.width; probe.height = node.height;
+    const ctx = probe.getContext('2d')!; ctx.drawImage(node, 0, 0);
+    const { data, width, height } = ctx.getImageData(0, 0, probe.width, probe.height);
+    const canvasBounds = node.getBoundingClientRect();
+    const buttons = [...node.closest('[role="region"]')!.querySelectorAll('button')].map(button => button.getBoundingClientRect()).filter(rect => rect.width && rect.height);
+    const counts = [0, 0, 0, 0]; let minX = width, minY = height, maxX = -1, maxY = -1;
+    let occluded = 0;
+    for (let y = 0; y < height; y++) for (let x = 0; x < width; x++) {
+      const index = (y * width + x) * 4, r = data[index], g = data[index + 1], b = data[index + 2];
+      if (r > 140 && b > 110 && r > g * 1.6 && b > g * 1.6) {
+        counts[(y >= height / 2 ? 2 : 0) + (x >= width / 2 ? 1 : 0)]++;
+        minX = Math.min(minX, x); minY = Math.min(minY, y); maxX = Math.max(maxX, x); maxY = Math.max(maxY, y);
+        const screenX = canvasBounds.x + x / width * canvasBounds.width, screenY = canvasBounds.y + y / height * canvasBounds.height;
+        if (buttons.some(rect => screenX >= rect.left && screenX <= rect.right && screenY >= rect.top && screenY <= rect.bottom)) occluded++;
+      }
+    }
+    return { counts, minX, minY, maxX, maxY, width, height, occluded };
+  });
+  const allCornersFit = async () => {
+    const result = await inspect();
+    return result.occluded === 0 && result.counts.every(count => count > 25) && result.minX > result.width * 0.025 && result.maxX < result.width * 0.975 && result.minY > result.height * 0.025 && result.maxY < result.height * 0.975;
+  };
+  try {
+    for (const viewport of [{ width: 1440, height: 900 }, { width: 390, height: 900 }, { width: 844, height: 390 }]) {
+      await page.setViewportSize(viewport);
+      for (const stacked of [false, true]) {
+        if (stacked) await page.getByRole('button', { name: 'Show All Floors Stacked', exact: true }).click();
+        const bounds = (await canvas.boundingBox())!;
+        // Leave damping in flight before requesting the fitted view.
+        await page.mouse.move(bounds.x + bounds.width * 0.45, bounds.y + bounds.height * 0.6);
+        await page.mouse.down();
+        await page.mouse.move(bounds.x + bounds.width * 0.7, bounds.y + bounds.height * 0.5, { steps: 3 });
+        await page.mouse.up();
+        await page.getByRole('button', { name: 'Top-Down View', exact: true }).click();
+        await expect.poll(allCornersFit).toBe(true);
+        await page.evaluate(() => new Promise<void>(resolve => { let remaining = 20; const frame = () => --remaining ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame); }));
+        expect(await allCornersFit()).toBe(true);
+        samples.push({ viewport, stacked, ...(await inspect()) });
+        await testInfo.attach(`top-down-${viewport.width}-${stacked ? 'stacked' : 'active'}`, { body: await page.screenshot(), contentType: 'image/png' });
+        if (stacked) await page.getByRole('button', { name: 'Active Floor Only', exact: true }).click();
+      }
+    }
+    // Top-Down is also an explicit way out of keyboard walkthrough, including
+    // browsers where mouse capture is denied.
+    await page.evaluate(() => { HTMLCanvasElement.prototype.requestPointerLock = () => Promise.reject(new DOMException('Denied', 'NotAllowedError')); });
+    await page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true }).click();
+    await expect(page.getByText('Walkthrough Controls', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Top-Down View', exact: true }).click();
+    await expect(page.getByText('Walkthrough Controls', { exact: true })).not.toBeVisible();
+    await expect.poll(allCornersFit).toBe(true);
+    expect(errors).toEqual([]); expect(external).toEqual([]);
+  } finally {
+    await testInfo.attach('corner-pixel-bounds', { body: JSON.stringify(samples, null, 2), contentType: 'application/json' });
+  }
+});

--- a/tests/fixtures/top-down-framing.openplan.json
+++ b/tests/fixtures/top-down-framing.openplan.json
@@ -1,0 +1,381 @@
+{
+  "id": "qa-top-down-framing",
+  "name": "QA Top-Down Framing",
+  "floors": [
+    {
+      "id": "framing--1",
+      "name": "Basement",
+      "level": -1,
+      "elevation": -350,
+      "walls": [
+        {
+          "id": "framing--1-wall-0",
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "end": {
+            "x": 1800,
+            "y": 0
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing--1-wall-1",
+          "start": {
+            "x": 1800,
+            "y": 0
+          },
+          "end": {
+            "x": 1800,
+            "y": 1800
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing--1-wall-2",
+          "start": {
+            "x": 1800,
+            "y": 1800
+          },
+          "end": {
+            "x": 0,
+            "y": 1800
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing--1-wall-3",
+          "start": {
+            "x": 0,
+            "y": 1800
+          },
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        }
+      ],
+      "rooms": [],
+      "doors": [],
+      "windows": [],
+      "furniture": [],
+      "stairs": [],
+      "columns": [
+        {
+          "id": "framing--1-corner-0",
+          "position": {
+            "x": -100,
+            "y": -100
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing--1-corner-1",
+          "position": {
+            "x": 1900,
+            "y": -100
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing--1-corner-2",
+          "position": {
+            "x": 1900,
+            "y": 1900
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing--1-corner-3",
+          "position": {
+            "x": -100,
+            "y": 1900
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        }
+      ],
+      "guides": [],
+      "measurements": [],
+      "annotations": [],
+      "textAnnotations": [],
+      "groups": []
+    },
+    {
+      "id": "framing-0",
+      "name": "Ground",
+      "level": 0,
+      "elevation": 0,
+      "walls": [
+        {
+          "id": "framing-0-wall-0",
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "end": {
+            "x": 1800,
+            "y": 0
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing-0-wall-1",
+          "start": {
+            "x": 1800,
+            "y": 0
+          },
+          "end": {
+            "x": 1800,
+            "y": 1800
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing-0-wall-2",
+          "start": {
+            "x": 1800,
+            "y": 1800
+          },
+          "end": {
+            "x": 0,
+            "y": 1800
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing-0-wall-3",
+          "start": {
+            "x": 0,
+            "y": 1800
+          },
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        }
+      ],
+      "rooms": [],
+      "doors": [],
+      "windows": [],
+      "furniture": [],
+      "stairs": [],
+      "columns": [
+        {
+          "id": "framing-0-corner-0",
+          "position": {
+            "x": -100,
+            "y": -100
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing-0-corner-1",
+          "position": {
+            "x": 1900,
+            "y": -100
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing-0-corner-2",
+          "position": {
+            "x": 1900,
+            "y": 1900
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing-0-corner-3",
+          "position": {
+            "x": -100,
+            "y": 1900
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        }
+      ],
+      "guides": [],
+      "measurements": [],
+      "annotations": [],
+      "textAnnotations": [],
+      "groups": []
+    },
+    {
+      "id": "framing-1",
+      "name": "Upper",
+      "level": 1,
+      "elevation": 425.5,
+      "walls": [
+        {
+          "id": "framing-1-wall-0",
+          "start": {
+            "x": 0,
+            "y": 0
+          },
+          "end": {
+            "x": 1800,
+            "y": 0
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing-1-wall-1",
+          "start": {
+            "x": 1800,
+            "y": 0
+          },
+          "end": {
+            "x": 1800,
+            "y": 1800
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing-1-wall-2",
+          "start": {
+            "x": 1800,
+            "y": 1800
+          },
+          "end": {
+            "x": 0,
+            "y": 1800
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        },
+        {
+          "id": "framing-1-wall-3",
+          "start": {
+            "x": 0,
+            "y": 1800
+          },
+          "end": {
+            "x": 0,
+            "y": 0
+          },
+          "thickness": 15,
+          "height": 280,
+          "color": "#778899"
+        }
+      ],
+      "rooms": [],
+      "doors": [],
+      "windows": [],
+      "furniture": [],
+      "stairs": [],
+      "columns": [
+        {
+          "id": "framing-1-corner-0",
+          "position": {
+            "x": -100,
+            "y": -100
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing-1-corner-1",
+          "position": {
+            "x": 1900,
+            "y": -100
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing-1-corner-2",
+          "position": {
+            "x": 1900,
+            "y": 1900
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        },
+        {
+          "id": "framing-1-corner-3",
+          "position": {
+            "x": -100,
+            "y": 1900
+          },
+          "rotation": 0,
+          "diameter": 140,
+          "height": 400,
+          "shape": "round",
+          "color": "#ff00ff"
+        }
+      ],
+      "guides": [],
+      "measurements": [],
+      "annotations": [],
+      "textAnnotations": [],
+      "groups": []
+    }
+  ],
+  "activeFloorId": "framing-1",
+  "createdAt": "2026-09-07T00:00:00Z",
+  "updatedAt": "2026-09-07T00:00:00Z"
+}

--- a/tests/frame-scene.test.ts
+++ b/tests/frame-scene.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from 'vitest';
 import { Box3, PerspectiveCamera, Vector3 } from 'three';
 import { frameScene } from '$lib/utils/frameScene';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 it.each([390 / 852, 640 / 630, 1440 / 852])('fits a tall mixed-floor scene at aspect %s', aspect => {
   const camera = new PerspectiveCamera(60, aspect, 1, 100000);
@@ -28,4 +29,63 @@ it('provides a finite useful camera for empty floors', () => {
   expect(camera.position.toArray().every(Number.isFinite)).toBe(true);
   expect(target.toArray()).toEqual([0, 140, 0]);
   expect(camera.position.distanceTo(target)).toBeGreaterThan(400);
+});
+
+// Use the actual controls' pole clamping and camera update, without a renderer or
+// DOM. A fit must survive that update, not merely look correct before it.
+const scenes = [
+  { name: 'furnished home', min: [-200, 0, -200], max: [2000, 280, 2000] },
+  { name: 'tall stack with basement', min: [-600, -425.5, -150], max: [1900, 2100, 1500] },
+  { name: 'long building beyond the original far plane', min: [-15000, -50, -200], max: [15000, 450, 800] },
+];
+for (const view of ['perspective', 'top-down'] as const) for (const aspect of [390 / 852, 1440 / 852, 844 / 342]) {
+  for (const scene of scenes) it(`${view} fits ${scene.name} at aspect ${aspect} after orbit updates`, () => {
+    const camera = new PerspectiveCamera(50, aspect, 1, 20000);
+    camera.position.set(800, 600, 800);
+    const controls = new OrbitControls(camera);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.maxPolarAngle = Math.PI / 2.05;
+    const bounds = new Box3(new Vector3(...scene.min), new Vector3(...scene.max));
+    frameScene(camera, bounds, controls.target, { view });
+    for (let frame = 0; frame < 60; frame++) controls.update();
+    camera.updateMatrixWorld(true);
+    expect(controls.target.distanceTo(bounds.getCenter(new Vector3()))).toBeLessThan(1e-9);
+    if (view === 'top-down') expect(camera.getWorldDirection(new Vector3()).y).toBeCloseTo(-1, 8);
+    for (const x of [bounds.min.x, bounds.max.x]) for (const y of [bounds.min.y, bounds.max.y]) for (const z of [bounds.min.z, bounds.max.z]) {
+      const projected = new Vector3(x, y, z).project(camera);
+      expect(Math.abs(projected.x)).toBeLessThan(0.99);
+      expect(Math.abs(projected.y)).toBeLessThan(0.99);
+      expect(projected.z).toBeGreaterThan(-1); expect(projected.z).toBeLessThan(1);
+    }
+  });
+}
+
+it('refits top-down after resize and zoom changes, with a useful empty-floor fallback', () => {
+  const camera = new PerspectiveCamera(50, 2, 1, 20000), target = new Vector3();
+  const bounds = new Box3(new Vector3(-1000, -350, -500), new Vector3(1000, 280, 500));
+  frameScene(camera, bounds, target, { view: 'top-down' });
+  const wideDistance = camera.position.distanceTo(target);
+  camera.aspect = 0.35;
+  camera.zoom = 1.5;
+  frameScene(camera, bounds, target, { view: 'top-down' });
+  expect(camera.position.distanceTo(target)).toBeGreaterThan(wideDistance);
+  for (const x of [-1000, 1000]) for (const z of [-500, 500]) {
+    const projected = new Vector3(x, 280, z).project(camera);
+    expect(Math.abs(projected.x)).toBeLessThan(1); expect(Math.abs(projected.y)).toBeLessThan(1);
+  }
+  frameScene(camera, new Box3(), target, { view: 'top-down' });
+  expect(target.toArray()).toEqual([0, 140, 0]);
+  expect(camera.position.toArray().every(Number.isFinite)).toBe(true);
+  expect(camera.position.y).toBeGreaterThan(280);
+});
+
+it('reserves vertical overlay space on a short landscape viewport', () => {
+  const camera = new PerspectiveCamera(50, 844 / 342, 1, 20000), target = new Vector3();
+  const bounds = new Box3(new Vector3(-200, -350, -200), new Vector3(2000, 825.5, 2000));
+  frameScene(camera, bounds, target, { view: 'top-down', verticalInset: 64 / 342 });
+  for (const x of [bounds.min.x, bounds.max.x]) for (const y of [bounds.min.y, bounds.max.y]) for (const z of [bounds.min.z, bounds.max.z]) {
+    const projected = new Vector3(x, y, z).project(camera);
+    expect(Math.abs(projected.y)).toBeLessThan(1 - 2 * 64 / 342);
+  }
 });


### PR DESCRIPTION
At phone width, Top-Down View cropped the outside rooms because its camera distance ignored viewport aspect ratio. It now uses the shared corner-fitting calculation, reserves vertical space for overlay controls, and extends the far plane when a distant/stacked plan needs it. The action clears pending orbit/pan damping and exits walkthrough so the fitted pose remains stable.

Adds camera containment tests after real OrbitControls updates and a browser fixture with four colored corner columns. The browser regression checks all corners remain inside the canvas and clear of buttons after orbit, stacking and desktop/portrait/landscape viewport changes, including denied mouse capture followed by Top-Down. Viewport resize itself preserves manual camera positioning.

Validation: 582 local unit tests; zero type errors (23 existing warnings); production build; interactive phone/landscape checks. Full three-engine CI and six rendering benchmarks run on this PR. `NEXT.md` and the framing report record remaining hardware/device calibration and #30 cost/release gates. No new Firebase writes, uploads, external assets or dependencies.

Fixes #71.
