### PR TITLE
Keep onboarding hints visible after resizing

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -35,7 +35,8 @@ library backup/restore; two-way local iPhone/web packages; editable item
 notes/photos/costs and pooled attachment history; furniture appearance fixes;
 category continuity; field keyboard editing and browser-engine CI; camera preview
 and 3D resource cleanup; repeatable furnished-home benchmarks and preservation of
-3D views during metadata edits; responsive top-down camera framing. Earlier batches and pause hashes are recorded
+3D views during metadata edits; responsive top-down camera framing; onboarding
+hints that stay within resized viewports. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
 ## 1. Next engineering batch: measured rendering improvements and device coverage
@@ -61,12 +62,14 @@ projection and browser pixel checks cover portrait, desktop and landscape layout
 See [the framing report](docs/reviews/2026-09-07-top-down-framing.md) and PR checks
 for validation and release status.
 
-Next, fix [onboarding hint positioning after resize (#73)](https://github.com/laanlabs/openPlan3D/issues/73).
-The phone QA pass exposed a tip retaining its wider-screen position and wrapping
-into a narrow strip. Track viewport changes and constrain the actual tip bounds,
-while preserving dismissal and seen-tip behavior.
+The [onboarding hint batch (#73)](https://github.com/laanlabs/openPlan3D/issues/73)
+tracks viewport changes and measured hint bounds, keeps the dismissal button
+visible on short screens, and cleans up animation/timer callbacks. Resizing does
+not restart the eight-second timeout; manual and automatic dismissal still retain
+seen-tip behavior. See [the hint report](docs/reviews/2026-09-07-onboarding-hints.md)
+and PR checks for browser validation and release status.
 
-Then measure the same fixtures on representative desktop/phone hardware and agree
+Next, measure the same fixtures on representative desktop/phone hardware and agree
 frame-time and memory targets. Use those results to choose shared geometry,
 object-level visual updates or mobile quality controls. Extend desktop Safari
 checks to actual iPhone/iPad touch devices; the resource batch's native desktop

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -435,3 +435,14 @@ orbit motion and exits walkthrough. Local validation passes 582 unit tests;
 rendered corner pixels are checked across three viewports and all CI engines.
 See [the framing report](2026-09-07-top-down-framing.md). Hardware calibration,
 physical-device coverage and the #30 release/cost gates remain.
+
+
+## Twenty-fourth batch: onboarding hints after viewport changes
+
+Issue #73 fixes hints retaining desktop coordinates after the screen narrows.
+Measured placement keeps the bubble inside the viewport and Got it visible in
+short layouts; animation and dismissal timers have cleanup and resizing preserves
+their deadline. Local validation passes 582 unit tests; two browser workflows add
+viewport, hit-testing, timeout and saved-dismissal checks across all three engines.
+See [the hint report](2026-09-07-onboarding-hints.md). Hardware calibration,
+physical-device coverage and the #30 release/cost gates remain.

--- a/docs/reviews/2026-09-07-onboarding-hints.md
+++ b/docs/reviews/2026-09-07-onboarding-hints.md
@@ -1,0 +1,45 @@
+# Responsive onboarding hints
+
+September 7, 2026 · [Issue #73](https://github.com/laanlabs/openPlan3D/issues/73)
+
+## Reproduction and change
+
+Opening Export at desktop width and shrinking to 280 pixels left the active hint
+at x=300 with a width of only 87.8 pixels. It was outside the visible screen.
+The template read `window.innerWidth` without a reactive resize dependency and
+assumed a fixed hint height when clamping its vertical position.
+
+The component now binds viewport dimensions and measures the rendered hint. It
+uses a normal width up to 280 pixels, an eight-pixel screen margin and the actual
+height to constrain placement. In very short viewports the message can scroll
+while Got it remains visible. The entrance animation only changes opacity so it
+cannot temporarily translate the bubble past the screen edge. The hint has a
+named region for assistive technology.
+
+Each active hint owns its animation callback and eight-second dismissal timer.
+Replacement or unmount cancels them; viewport changes only update placement.
+The existing seen-tip storage behavior is unchanged.
+
+## Validation
+
+Local production build and 582 unit tests passed. Type checking reports zero
+errors and the 23 existing Svelte warnings. Interactive browser QA verified the
+desktop-to-280-pixel resize: the hint moved to x=8 and used 264 pixels of width.
+At the in-app browser's minimum 160-pixel height, the full hint and Got it stayed
+within the screen and dismissal worked. This was viewport QA, not a physical
+iPhone/iPad check.
+
+Two browser workflows exercise the real Export and 3D controls. The first checks
+hint bounds, readable width and hit-testing on Got it through desktop, phone,
+landscape, 280×130 and 200×100 sizes, then verifies dismissal survives reload.
+The second controls time to check replacement deadlines, resize without extending
+the timer, automatic dismissal, and seen/unseen behavior. Screenshots are attached
+to CI reports. The full suite is now 65 workflows per engine (195 across Chromium,
+Firefox and WebKit), plus the six existing rendering benchmarks. See the PR and
+GitHub checks for final results and deployed verification.
+
+## Remaining work and cost
+
+The hardware performance, native-device coverage, release/migration/billing gates,
+catalog fidelity and area agreement follow-ups remain in `NEXT.md`. This change
+does not add Firebase writes, uploads, external assets or dependencies.

--- a/src/lib/components/OnboardingTooltip.svelte
+++ b/src/lib/components/OnboardingTooltip.svelte
@@ -1,46 +1,48 @@
 <script lang="ts">
   import { getActiveTip, dismissTip, TIP_MESSAGES } from '$lib/stores/onboarding.svelte';
 
-  // Reactive binding
   let tip = $derived(getActiveTip());
   let visible = $state(false);
+  let viewportWidth = $state(1200);
+  let viewportHeight = $state(800);
+  let tipWidth = $state(280);
+  let tipHeight = $state(0);
+  const margin = 8;
 
-  let autoTimer: ReturnType<typeof setTimeout> | null = null;
+  let left = $derived(tip ? Math.max(margin, Math.min(tip.x, viewportWidth - tipWidth - margin)) : margin);
+  let top = $derived(tip ? Math.max(margin, Math.min(tip.y, viewportHeight - tipHeight - margin)) : margin);
+
   $effect(() => {
+    visible = false;
     if (tip) {
-      // Small delay for enter animation
-      visible = false;
-      requestAnimationFrame(() => { visible = true; });
-      // Auto-dismiss after 8 seconds
-      if (autoTimer) clearTimeout(autoTimer);
-      autoTimer = setTimeout(() => { dismissTip(); }, 8000);
-    } else {
-      visible = false;
-      if (autoTimer) { clearTimeout(autoTimer); autoTimer = null; }
+      const frame = requestAnimationFrame(() => { visible = true; });
+      const timer = setTimeout(dismissTip, 8000);
+      // Resizing only changes placement; it must not restart the dismissal timer.
+      return () => {
+        cancelAnimationFrame(frame);
+        clearTimeout(timer);
+      };
     }
   });
 </script>
 
+<svelte:window bind:innerWidth={viewportWidth} bind:innerHeight={viewportHeight} />
+
 {#if tip}
-  {@const msg = TIP_MESSAGES[tip.id]}
-  {@const clampedX = Math.min(tip.x, (typeof window !== 'undefined' ? window.innerWidth : 1200) - 320)}
-  {@const clampedY = Math.min(tip.y, (typeof window !== 'undefined' ? window.innerHeight : 800) - 100)}
   <div
-    class="fixed z-[9999] pointer-events-auto"
-    style="left:{clampedX}px;top:{clampedY}px;"
+    role="region"
+    aria-label="Getting started tip"
+    bind:offsetWidth={tipWidth}
+    bind:offsetHeight={tipHeight}
+    class="fixed z-[9999] pointer-events-auto flex flex-col gap-2 bg-slate-800 text-white rounded-xl shadow-2xl px-4 py-3 text-sm leading-relaxed transition-opacity duration-300 ease-out"
+    class:opacity-0={!visible}
+    class:opacity-100={visible}
+    style="left:{left}px;top:{top}px;width:{Math.max(0, Math.min(280, viewportWidth - margin * 2))}px;max-height:{Math.max(0, viewportHeight - margin * 2)}px;"
   >
-    <div
-      class="bg-slate-800 text-white rounded-xl shadow-2xl px-4 py-3 max-w-[280px] text-sm leading-relaxed transition-all duration-300 ease-out"
-      class:opacity-0={!visible}
-      class:translate-y-2={!visible}
-      class:opacity-100={visible}
-      class:translate-y-0={visible}
-    >
-      <p class="mb-2">{msg}</p>
-      <button
-        class="text-xs font-medium px-3 py-1 rounded-lg bg-blue-500 hover:bg-blue-400 transition-colors"
-        onclick={dismissTip}
-      >Got it</button>
-    </div>
+    <p class="min-h-0 overflow-y-auto">{TIP_MESSAGES[tip.id]}</p>
+    <button
+      class="shrink-0 self-start text-xs font-medium px-3 py-1 rounded-lg bg-blue-500 hover:bg-blue-400 transition-colors"
+      onclick={dismissTip}
+    >Got it</button>
   </div>
 {/if}

--- a/tests/browser/onboarding.spec.ts
+++ b/tests/browser/onboarding.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const exportMessage = 'Your plan is ready! Try SVG for vector graphics or PDF for printing.';
+const viewerMessage = 'Orbit with mouse, scroll to zoom. Try walkthrough mode!';
+const tip = (page: Page) => page.getByRole('region', { name: 'Getting started tip', exact: true });
+
+async function openEditorWithClock(page: Page) {
+  await page.clock.install({ time: new Date('2026-09-07T12:00:00Z') });
+  await page.goto('/editor');
+  await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+  await page.clock.pauseAt(new Date('2026-09-07T12:01:00Z'));
+}
+
+test('an open onboarding hint stays readable and dismissible through resizing', async ({ page }, testInfo) => {
+  const errors: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  await openEditorWithClock(page);
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  // Close the menu while leaving its introductory hint open.
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+
+  for (const viewport of [
+    { width: 1440, height: 900 },
+    { width: 390, height: 852 },
+    { width: 280, height: 390 },
+    { width: 844, height: 390 },
+    { width: 280, height: 130 },
+    { width: 200, height: 100 },
+    { width: 1440, height: 900 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.clock.runFor(400);
+    await expect(tip(page)).toContainText(exportMessage);
+    await expect.poll(() => tip(page).evaluate(element => {
+      const bounds = element.getBoundingClientRect();
+      const button = element.querySelector('button')!;
+      const buttonBounds = button.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        buttonBounds.x + buttonBounds.width / 2, buttonBounds.y + buttonBounds.height / 2,
+      );
+      return {
+        inside: bounds.left >= 7 && bounds.top >= 7
+          && bounds.right <= innerWidth - 7 && bounds.bottom <= innerHeight - 7,
+        readableWidth: bounds.width >= Math.min(260, innerWidth - 16),
+        buttonInside: buttonBounds.top >= bounds.top && buttonBounds.bottom <= bounds.bottom,
+        buttonReachable: hit === button || button.contains(hit),
+        opaque: getComputedStyle(element).opacity === '1',
+      };
+    })).toEqual({ inside: true, readableWidth: true, buttonInside: true, buttonReachable: true, opaque: true });
+    await testInfo.attach(`hint-${viewport.width}x${viewport.height}`, {
+      body: await page.screenshot(), contentType: 'image/png',
+    });
+  }
+
+  await tip(page).getByRole('button', { name: 'Got it', exact: true }).click();
+  await expect(tip(page)).not.toBeVisible();
+  await page.reload();
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  await page.clock.runFor(400);
+  await expect(tip(page)).not.toBeVisible();
+  expect(await page.evaluate(() => JSON.parse(localStorage.getItem('o3d_tips_seen')!))).toContain('first-export');
+  expect(errors).toEqual([]);
+});
+
+test('replacement hints get their own timer and resizing does not delay auto-dismissal', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  await openEditorWithClock(page);
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  await page.clock.runFor(6000);
+  await expect(tip(page)).toContainText(exportMessage);
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  await page.clock.runFor(2500);
+  // The first hint's deadline has passed, but the replacement is only 2.5s old.
+  await expect(tip(page)).toContainText(viewerMessage);
+  await page.setViewportSize({ width: 280, height: 390 });
+  await page.clock.runFor(5000);
+  await expect(tip(page)).toContainText(viewerMessage);
+  await page.setViewportSize({ width: 844, height: 390 });
+  await page.clock.runFor(600);
+  await expect(tip(page)).not.toBeVisible();
+  expect(await page.evaluate(() => JSON.parse(localStorage.getItem('o3d_tips_seen')!))).toContain('first-3d');
+
+  await page.getByRole('button', { name: '2D', exact: true }).click();
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  await page.clock.runFor(400);
+  await expect(tip(page)).not.toBeVisible();
+  // Replacing a tip must not mark that unfinished tip as seen.
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  await page.clock.runFor(400);
+  await expect(tip(page)).toContainText(exportMessage);
+  await tip(page).getByRole('button', { name: 'Got it', exact: true }).click();
+  await expect(tip(page)).not.toBeVisible();
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
An onboarding hint opened at desktop width could remain offscreen after resizing to a phone viewport. Hints now respond to viewport dimensions and their rendered size, keep an eight-pixel margin, and retain a visible Got it button in short layouts. Animation/timer cleanup preserves the eight-second deadline through resizing and safely replaces active hints.

Validation: 582 unit tests, 195 browser workflows across Chromium/Firefox/WebKit, and six rendering benchmarks passed in [CI](https://github.com/laanlabs/openPlan3D/actions/runs/34176790450). Production build, audit and type checks pass with the 23 existing Svelte warnings. Interactive browser QA reproduced the offscreen hint before the fix and verified narrow/short layouts and dismissal afterward, including a 200×100 Chrome viewport. Two new browser workflows cover viewport bounds, button hit-testing, replacement/resize deadlines, automatic dismissal and persistence after reload. The Firefox screenshots confirm the hint and dismissal button remain inside the screen.

Updates `NEXT.md` and the batch review. No Firebase writes, uploads, assets or dependencies added.

Fixes #73
