### PR TITLE
Pause idle 3D animation and restore access to lighting controls

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -76,7 +76,8 @@ Native Safari on M4 Max recorded 1,500 idle callbacks before the change and zero
 after it in matched 25-second intervals; a post-orbit repeat also returned to zero.
 See [the report and sanitized metrics](docs/reviews/2026-09-07-idle-rendering.md).
 The regression checks controls, scene changes, placement previews and teardown in
-all three engines. These results establish idle behavior, not general FPS or
+all three engines. It also fixes the desktop Help button covering Lighting Controls.
+These results establish idle behavior, not general FPS or
 battery-life targets.
 
 The next focused fix is [frame-rate-independent walkthrough motion (#77)](https://github.com/laanlabs/openPlan3D/issues/77).

--- a/NEXT.md
+++ b/NEXT.md
@@ -22,7 +22,7 @@ intercepting field editing, and preserves furniture dimensions while replacing
 empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
 and PR checks for final engine results and merge/release status.
 
-Local validation: **582 web unit tests, 53 XCTest tests**, production build and
+Local validation: **591 web unit tests, 53 XCTest tests**, production build and
 audit pass; type checks report zero errors and 23 existing Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
@@ -36,7 +36,8 @@ notes/photos/costs and pooled attachment history; furniture appearance fixes;
 category continuity; field keyboard editing and browser-engine CI; camera preview
 and 3D resource cleanup; repeatable furnished-home benchmarks and preservation of
 3D views during metadata edits; responsive top-down camera framing; onboarding
-hints that stay within resized viewports. Earlier batches and pause hashes are recorded
+hints that stay within resized viewports; idle 3D animation cleanup measured in
+native Safari. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
 ## 1. Next engineering batch: measured rendering improvements and device coverage
@@ -69,11 +70,25 @@ not restart the eight-second timeout; manual and automatic dismissal still retai
 seen-tip behavior. See [the hint report](docs/reviews/2026-09-07-onboarding-hints.md)
 and PR checks for browser validation and release status.
 
-Next, measure the same fixtures on representative desktop/phone hardware and agree
+The [idle-rendering batch (#75)](https://github.com/laanlabs/openPlan3D/issues/75)
+replaces continuous orbit polling with requested frames that stop after damping.
+Native Safari on M4 Max recorded 1,500 idle callbacks before the change and zero
+after it in matched 25-second intervals; a post-orbit repeat also returned to zero.
+See [the report and sanitized metrics](docs/reviews/2026-09-07-idle-rendering.md).
+The regression checks controls, scene changes, placement previews and teardown in
+all three engines. These results establish idle behavior, not general FPS or
+battery-life targets.
+
+The next focused fix is [frame-rate-independent walkthrough motion (#77)](https://github.com/laanlabs/openPlan3D/issues/77).
+Movement currently uses a fixed 16 ms step per callback, so its speed changes with
+frame cadence. Integrate elapsed time with bounded pause recovery and test equal
+elapsed input at 30/60/120 Hz, key-state cleanup and pointer-lock denial.
+
+Then measure the same fixtures on representative desktop/phone hardware and agree
 frame-time and memory targets. Use those results to choose shared geometry,
 object-level visual updates or mobile quality controls. Extend desktop Safari
-checks to actual iPhone/iPad touch devices; the resource batch's native desktop
-Safari attempt was unavailable while the Mac was locked. Keep category contract
+checks to actual iPhone/iPad touch devices. The initial small-home native Safari
+calibration is complete; medium/large homes and physical phones remain. Keep category contract
 fixtures in both repositories synchronized when extending the catalog.
 
 Legacy saved package projects with chair fallbacks are protected on export and
@@ -190,11 +205,12 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
 1. Fetch both repositories and confirm clean `main` against `origin/main`; reread
    open GitHub issues and #30 for release updates. Start a focused `codex/…` branch
    from current main after checking the browser batch merge status.
-2. Start with the rendering benchmark report and hardware calibration. Preserve unknown fields,
+2. Start with walkthrough motion #77, then broaden hardware calibration. Preserve unknown fields,
    explicit clears, independent import copies, fractional transforms and pooled
    local attachments. Do not rely on temporary QA directories as source artifacts.
 3. Web baseline: Node 24/npm; run `NODE_ENV=production npm run check`,
    `NODE_ENV=production npm test` and `NODE_ENV=production npm run build`.
+   Finish check before starting build; both regenerate SvelteKit artifacts.
    Production browser workflows run in GitHub CI with cloud uploads/analytics
    disabled. Use the approved browser-control tools for local interactive QA.
 4. Native baseline: `openPlan3d.xcodeproj`, scheme `FloorPlan`, Debug simulator

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -446,3 +446,15 @@ their deadline. Local validation passes 582 unit tests; two browser workflows ad
 viewport, hit-testing, timeout and saved-dismissal checks across all three engines.
 See [the hint report](2026-09-07-onboarding-hints.md). Hardware calibration,
 physical-device coverage and the #30 release/cost gates remain.
+
+## Twenty-fifth batch: idle 3D rendering and native Safari calibration
+
+Issue #75 stops continuous animation callbacks after orbit damping settles, wakes
+the viewer for dirty changes and furniture previews, and cancels work on teardown.
+Native Safari on M4 Max measured 1,500 callbacks before and zero after in matched
+25-second quiet intervals; a warm post-orbit repeat also returned to zero. Local
+validation passes 591 unit tests, with one new workflow across all three browser
+engines. See [the report and numeric metrics](2026-09-07-idle-rendering.md) for
+measurement limits and PR validation. Frame-rate-independent walkthrough motion
+is tracked in #77. Broader hardware budgets, physical devices and the #30
+release/cost gates remain; this batch adds no cloud writes or assets.

--- a/docs/reviews/2026-09-07-idle-rendering-metrics.json
+++ b/docs/reviews/2026-09-07-idle-rendering-metrics.json
@@ -1,0 +1,149 @@
+{
+  "date": "2026-09-07",
+  "fixture": "small",
+  "rooms": 4,
+  "furniture": 24,
+  "hardware": {
+    "model": "Mac16,9",
+    "chip": "Apple M4 Max",
+    "cpuCores": 14,
+    "memoryGB": 36,
+    "os": "macOS 26.2 (25C56)",
+    "browser": "Safari 26.2",
+    "baselineBodyCSSPixels": {
+      "width": 1324,
+      "height": 350
+    },
+    "devicePixelRatio": null
+  },
+  "units": {
+    "frameDurationMs": "Inspector elapsed frame span; not CPU work or GPU timing",
+    "memoryMB": "decimal megabytes",
+    "cpuPercent": "Safari page CPU samples; not whole-device power"
+  },
+  "samples": [
+    {
+      "name": "baseline",
+      "commit": "9e5eee59fbeb445a06cc31db15d91d17024d971b",
+      "origin": "production",
+      "recordingSeconds": 64.6642,
+      "rangeSeconds": {
+        "from": 10,
+        "to": 35
+      },
+      "renderingFrames": 1500,
+      "animationCallbacks": 1500,
+      "animationRequests": 1500,
+      "frameDurationMs": {
+        "count": 1500,
+        "min": 14.8941,
+        "mean": 16.6428,
+        "p95": 17.3196,
+        "max": 18.4265
+      },
+      "frameStartIntervalMs": {
+        "count": 1499,
+        "min": 14.9166,
+        "mean": 16.6667,
+        "p95": 17.3456,
+        "max": 18.4437
+      },
+      "cpuPercent": {
+        "count": 50,
+        "min": 1.6,
+        "mean": 1.87,
+        "p95": 2.1,
+        "max": 2.1
+      },
+      "memoryMB": {
+        "count": 50,
+        "min": 130.1847,
+        "mean": 130.7935,
+        "p95": 133.0683,
+        "max": 133.822
+      }
+    },
+    {
+      "name": "updated",
+      "commit": "552c09680bb239d15a75aefae8583a2587de7269",
+      "origin": "loopback",
+      "recordingSeconds": 83.5791,
+      "rangeSeconds": {
+        "from": 10,
+        "to": 35
+      },
+      "renderingFrames": 0,
+      "animationCallbacks": 0,
+      "animationRequests": 0,
+      "frameDurationMs": {
+        "count": 0,
+        "min": null,
+        "mean": null,
+        "p95": null,
+        "max": null
+      },
+      "frameStartIntervalMs": {
+        "count": 0,
+        "min": null,
+        "mean": null,
+        "p95": null,
+        "max": null
+      },
+      "cpuPercent": {
+        "count": 50,
+        "min": 0,
+        "mean": 0.006,
+        "p95": 0,
+        "max": 0.3
+      },
+      "memoryMB": {
+        "count": 50,
+        "min": 121.7142,
+        "mean": 122.3227,
+        "p95": 124.3028,
+        "max": 124.4339
+      }
+    },
+    {
+      "name": "updatedAfterOrbit",
+      "commit": "552c09680bb239d15a75aefae8583a2587de7269",
+      "origin": "loopback",
+      "recordingSeconds": 291.53,
+      "rangeSeconds": {
+        "from": 10,
+        "to": 35
+      },
+      "renderingFrames": 0,
+      "animationCallbacks": 0,
+      "animationRequests": 0,
+      "frameDurationMs": {
+        "count": 0,
+        "min": null,
+        "mean": null,
+        "p95": null,
+        "max": null
+      },
+      "frameStartIntervalMs": {
+        "count": 0,
+        "min": null,
+        "mean": null,
+        "p95": null,
+        "max": null
+      },
+      "cpuPercent": {
+        "count": 50,
+        "min": 0,
+        "mean": 0,
+        "p95": 0,
+        "max": 0
+      },
+      "memoryMB": {
+        "count": 50,
+        "min": 175.9452,
+        "mean": 176.2978,
+        "p95": 178.8943,
+        "max": 181.2372
+      }
+    }
+  ]
+}

--- a/docs/reviews/2026-09-07-idle-rendering.md
+++ b/docs/reviews/2026-09-07-idle-rendering.md
@@ -1,0 +1,102 @@
+# Idle 3D rendering and native Safari measurements
+
+September 7, 2026 · [Issue #75](https://github.com/laanlabs/openPlan3D/issues/75)
+· [PR #76](https://github.com/laanlabs/openPlan3D/pull/76)
+
+## Measured problem and change
+
+The existing dirty flag avoided unchanged WebGL draws, but the main viewer still
+requested an animation callback and updated OrbitControls on every browser frame.
+Native Safari recorded 1,500 fired callbacks and 1,500 new requests in a quiet
+25-second interval with the small furnished-home fixture: 60 callbacks per second.
+
+Dirty changes now request one coalesced frame. OrbitControls changes request the
+next damping step; once damping settles, the viewer leaves no callback queued.
+Lighting, textures, scene rebuilds, resizing, highlights and explicit camera views
+wake it. Walkthrough resumes continuous frames. Leaving walkthrough returns to
+demand-driven orbit updates. Teardown cancels queued work and prevents late model
+callbacks from scheduling work on a disposed viewer. Furniture placement previews
+also request redraws when they move, disappear or finish loading.
+
+## Hardware evidence and limits
+
+The baseline uses deployed main `9e5eee5`; the updated application uses `552c096`
+served locally from a production build. Both use the same generated small-home
+fixture: four rooms and 24 furniture instances. Hardware is an Apple M4 Max
+(14 CPU cores, 36 GB RAM, Mac16,9), macOS 26.2 build 25C56, Safari 26.2. `pmset`
+reported no recorded thermal or performance warning; actual chip temperatures
+were not measured. Other ordinary desktop apps remained open.
+
+Safari Web Inspector recorded Network, Layout & Rendering, JavaScript & Events,
+Rendering Frames, CPU and Memory. Screenshots and JavaScript Allocations were
+disabled. Inspector was docked below the app; the baseline document body measured
+1,324 × 350 CSS pixels. Device pixel ratio was not recorded. Memory instrumentation itself has
+overhead, and Safari's CPU samples describe the inspected page's threads; these
+are not whole-device power or battery measurements. See the
+[WebKit timeline reference](https://webkit.org/web-inspector/timelines-tab/).
+
+The recorded JSON summary is in [idle-rendering-metrics.json](2026-09-07-idle-rendering-metrics.json).
+For the matched interval from 10–35 seconds after recording started:
+
+| Measurement | Baseline | Updated |
+| --- | ---: | ---: |
+| Animation callbacks | 1,500 | 0 |
+| New animation requests | 1,500 | 0 |
+| Safari mean CPU sample | 1.870% | 0.006% |
+| Safari mean page-memory sample | 130.79 MB | 122.32 MB |
+
+A separate warm recording started with two orbit drags and then no interaction.
+The 10–35 second interval again contained zero callbacks, zero requests and zero
+rendering frames. All 50 CPU samples were zero. Its mean page-memory sample was
+176.30 MB, reinforcing that memory depends on allocation history and is not a
+claimed improvement here.
+
+The strict result is eliminated idle animation work, with later orbit/top-down
+interactions still rendering. Do not turn these samples into a battery-life,
+memory-saving or general FPS claim. The runs use different origins, resource-cache
+histories and prior allocations. Inspector frame spans include elapsed frame time;
+they are not isolated CPU work or GPU timer queries. Physical iPhone/iPad testing,
+repeated medium/large-home calibration and agreed memory/frame-time budgets remain
+open.
+
+## Repeating the measurement
+
+Generate ordinary local import files with `npm run benchmark:fixtures`. In native
+Safari, import `small.openplan.json`, open Inspector's Timelines tab and select the
+instruments above. Start recording, enter 3D, leave it untouched for at least 35
+seconds, then orbit and use Top-Down to verify wakeups. Stop and export the timeline
+locally. A separate recording after orbiting can check that damping returns to idle.
+
+Run `node tooling/safari-timeline.mjs recording.json --from 10 --to 35` to produce
+a numeric-only summary. The tool never copies network requests, cookies, headers,
+project names, screenshots, source URLs or stacks into its output. Raw Inspector
+exports stay local because they may contain browser data. Use a continuous
+recording and choose a quiet interval with no interactions; do not compare a
+paused interval with live execution.
+
+Build preparation is sequential: finish `npm run check` before `npm run build`.
+Both invoke SvelteKit generation, so running them concurrently can produce an HTML
+bootstrap identifier that differs from its client bundle. Rebuild and restart the
+local server if that happens. GitHub CI already runs these steps sequentially.
+
+## Validation and next work
+
+Local validation passes 591 unit tests, production build and type checking with
+zero errors and the 23 existing Svelte warnings. The new browser workflow observes
+requestAnimationFrame and WebGL at the browser boundary, asserts no idle callbacks
+or draws, and verifies orbit/damping, top-down, furniture previews, lighting,
+stacking, resize, walkthrough and remount. Existing geometry/history/preview tests
+and all six furnished-home benchmarks remain required. The browser suite now has
+66 workflows per engine, 198 across Chromium, Firefox and WebKit. See PR checks
+for final CI and deployment results.
+
+The first CI pass exposed two test corrections: software rendering needed more
+than ten seconds to complete the remaining orbit damping frames, and the active
+edit toggle is named Exit Edit Mode. The regression uses a smaller viewport and a
+bounded settling wait while retaining the zero-callback requirement.
+
+Walkthrough still integrates a fixed 16 ms step per callback; frame-rate-independent
+motion is the next focused follow-up in [#77](https://github.com/laanlabs/openPlan3D/issues/77).
+Device calibration, native release and the
+migration/billing gates in #30 remain open. This batch adds no Firebase writes,
+uploads, new assets, dependencies or production profiling hooks.

--- a/docs/reviews/2026-09-07-idle-rendering.md
+++ b/docs/reviews/2026-09-07-idle-rendering.md
@@ -95,6 +95,12 @@ than ten seconds to complete the remaining orbit damping frames, and the active
 edit toggle is named Exit Edit Mode. The regression uses a smaller viewport and a
 bounded settling wait while retaining the zero-callback requirement.
 
+The full workflow also reproduced a pre-existing desktop hit-target collision:
+Keyboard Shortcuts covered the Lighting Controls toggle. The lighting toggle and
+panel now align with the unused middle slot between Help and Undo History on
+desktop; phone placement stays at the left edge. The ordinary click in this
+regression verifies that the control is reachable before changing the night preset.
+
 Walkthrough still integrates a fixed 16 ms step per callback; frame-rate-independent
 motion is the next focused follow-up in [#77](https://github.com/laanlabs/openPlan3D/issues/77).
 Device calibration, native release and the

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -2513,7 +2513,7 @@
   <!-- Lighting Controls Toggle Button -->
   <button
     onclick={() => { lightingPanelOpen = !lightingPanelOpen; }}
-    class="absolute bottom-4 left-4 z-50 p-2 rounded-lg transition-colors {lightingPanelOpen ? 'bg-amber-500 text-white ring-2 ring-amber-300' : 'bg-black/70 text-white hover:bg-black/80'}"
+    class="absolute bottom-4 left-4 md:left-14 z-50 p-2 rounded-lg transition-colors {lightingPanelOpen ? 'bg-amber-500 text-white ring-2 ring-amber-300' : 'bg-black/70 text-white hover:bg-black/80'}"
     title="Lighting Controls"
     aria-label="Lighting Controls"
   >
@@ -2528,7 +2528,7 @@
 
   <!-- Lighting Controls Panel -->
   {#if lightingPanelOpen}
-    <div class="absolute bottom-14 left-4 z-50 bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm p-3 space-y-3 min-w-[220px] select-none">
+    <div class="absolute bottom-14 left-4 md:left-14 z-50 bg-black/80 text-white text-xs rounded-lg backdrop-blur-sm p-3 space-y-3 min-w-[220px] select-none">
       <div class="font-semibold text-white/90 text-sm flex items-center gap-1.5">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/></svg>
         Lighting Controls

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -37,9 +37,16 @@
 
   // Dirty flag — only render when scene changes or camera moves
   let sceneDirty = true;
-  function markSceneDirty() { sceneDirty = true; }
+  let viewerMounted = false;
+  let animId: number | undefined;
+  function requestRender() {
+    if (viewerMounted && animId === undefined) animId = requestAnimationFrame(animate);
+  }
+  function markSceneDirty() {
+    sceneDirty = true;
+    requestRender();
+  }
   let pointerControls: PointerLockControls;
-  let animId: number;
   let currentFloor = $state.raw<Floor | null>(null);
   let renderedSignature: string | null = null;
   let wallGroup: THREE.Group;
@@ -639,6 +646,7 @@
     velocity.set(0, 0, 0);
     moveForward = moveBackward = moveLeft = moveRight = false;
     lookLeft = lookRight = lookUp = lookDown = false;
+    markSceneDirty();
 
     if (typeof document !== 'undefined' && document.pointerLockElement) {
       document.exitPointerLock();
@@ -906,10 +914,12 @@
         } else if (ghostGroup) {
           ghostGroup.visible = false;
         }
+        markSceneDirty();
         renderer.domElement.style.cursor = 'crosshair';
         return;
-      } else if (ghostGroup) {
+      } else if (ghostGroup?.visible) {
         ghostGroup.visible = false;
+        markSceneDirty();
       }
 
       if (!editMode) {
@@ -993,9 +1003,7 @@
     removeGhostPreview();
     const cat = getCatalogItem(catalogId);
     if (!cat || cat.symbol) return;
-    const model = createFurnitureModelWithGLB(catalogId, cat, () => {
-      if (renderer && scene && camera) renderer.render(scene, camera);
-    }, { ghost: true });
+    const model = createFurnitureModelWithGLB(catalogId, cat, markSceneDirty, { ghost: true });
     model.visible = false;
     ghostGroup = model;
     scene.add(ghostGroup);
@@ -1006,6 +1014,7 @@
       scene.remove(ghostGroup);
       disposeModel(ghostGroup);
       ghostGroup = null;
+      markSceneDirty();
     }
   }
 
@@ -1527,7 +1536,7 @@
       };
       const model = createFurnitureModelWithGLB(fi.catalogId, furnitureDef, () => {
         // Re-render when GLB model finishes loading
-        if (renderer && scene && camera) renderer.render(scene, camera);
+        markSceneDirty();
       }, { color: fi.color, material: fi.material });
       model.position.set(fi.position.x, 1.5, fi.position.y);
       model.rotation.y = -(fi.rotation * Math.PI) / 180;
@@ -1939,12 +1948,13 @@
     } catch {
       walkthroughMouseUnavailable = true;
     }
+    markSceneDirty();
   }
 
 
 
   function animate() {
-    animId = requestAnimationFrame(animate);
+    animId = undefined;
 
     if (walkthroughMode) {
       const delta = 0.016; // Approximate 60fps
@@ -1974,8 +1984,10 @@
       }
       // Always render in walkthrough mode (camera constantly moving)
       renderer.render(scene, camera);
+      requestRender();
     } else {
-      // controls.update() may fire 'change' event (which sets sceneDirty)
+      // A change event schedules the next damping step. Once the controls settle,
+      // leave no callback queued until an interaction or scene update wakes us.
       controls.update();
       if (sceneDirty) {
         sceneDirty = false;
@@ -2010,7 +2022,8 @@
       openaiModel = getEffectiveModel(config);
     });
     init();
-    animate();
+    viewerMounted = true;
+    markSceneDirty();
 
     // Rebuild 3D scene when photo textures finish loading
     const stopTextures = setTextureLoadCallback(() => {
@@ -2041,6 +2054,7 @@
     });
 
     return () => {
+      viewerMounted = false;
       cancelAIRender();
       stopAISettings();
       stopTextures();
@@ -2048,7 +2062,8 @@
       unsub();
       stopSettings();
       unsubSel();
-      cancelAnimationFrame(animId);
+      if (animId !== undefined) cancelAnimationFrame(animId);
+      animId = undefined;
       document.removeEventListener('keydown', onKeyDown, false);
       document.removeEventListener('keyup', onKeyUp, false);
       releaseCameraPreview();

--- a/tests/browser/viewer-idle.spec.ts
+++ b/tests/browser/viewer-idle.spec.ts
@@ -99,9 +99,12 @@ test('3D sleeps when idle and wakes for controls, scene changes and walkthrough'
   await expect.poll(async () => (await gpu(page))[0].draws).toBeGreaterThan((await gpu(page))[0].draws);
   before = await pixels();
   await page.keyboard.down('ArrowUp');
-  await page.waitForTimeout(250);
-  await page.keyboard.up('ArrowUp');
-  await expect.poll(pixels).not.toBe(before);
+  try {
+    // Hold through an actual rendered movement step, including slow CI GPUs.
+    await expect.poll(pixels, { timeout: 10_000 }).not.toBe(before);
+  } finally {
+    await page.keyboard.up('ArrowUp');
+  }
   await page.getByRole('button', { name: 'Top-Down View', exact: true }).click();
   await expect(page.getByText('Walkthrough Controls', { exact: true })).not.toBeVisible();
   await idle();

--- a/tests/browser/viewer-idle.spec.ts
+++ b/tests/browser/viewer-idle.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+import { resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { observeGPU, gpu } from './gpu';
+
+test('3D sleeps when idle and wakes for controls, scene changes and walkthrough', async ({ page }) => {
+  test.setTimeout(120_000);
+  await observeGPU(page);
+  // Observe the browser boundary in CI, without production instrumentation.
+  await page.addInitScript(() => {
+    const request = window.requestAnimationFrame.bind(window);
+    const cancel = window.cancelAnimationFrame.bind(window);
+    const pending = new Set<number>();
+    let fired = 0;
+    (window as any).__animationAudit = () => ({ pending: pending.size, fired });
+    window.requestAnimationFrame = callback => {
+      const id = request(time => { pending.delete(id); fired++; callback(time); });
+      pending.add(id);
+      return id;
+    };
+    window.cancelAnimationFrame = id => { pending.delete(id); cancel(id); };
+  });
+  const errors: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  await page.goto('/editor');
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const chooser = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+  await (await chooser).setFiles(resolve('tests/fixtures/top-down-framing.openplan.json'));
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  await page.waitForLoadState('networkidle');
+  const hint = page.getByRole('button', { name: 'Got it', exact: true });
+  if (await hint.isVisible()) await hint.click();
+  const canvas = page.getByRole('region', { name: '3D floor plan viewer' }).locator('canvas').last();
+  const audit = () => page.evaluate(() => (window as any).__animationAudit());
+  const activeDraws = async () => (await gpu(page)).find((entry: any) => entry.connected && !entry.lost)?.draws ?? 0;
+  const pixels = async () => createHash('sha256').update(await canvas.evaluate((node: HTMLCanvasElement) => node.toDataURL())).digest('hex');
+  const idle = async () => {
+    await expect.poll(async () => (await audit()).pending).toBe(0);
+    const before = await audit(), draws = await activeDraws();
+    // A quiet interval must contain neither polling callbacks nor GPU draws.
+    await page.waitForTimeout(350);
+    expect(await audit()).toEqual(before);
+    expect(await activeDraws()).toBe(draws);
+  };
+  await idle();
+  let before = await pixels();
+  const bounds = (await canvas.boundingBox())!;
+  await page.mouse.move(bounds.x + bounds.width * 0.45, bounds.y + bounds.height * 0.6);
+  await page.mouse.down();
+  await page.mouse.move(bounds.x + bounds.width * 0.65, bounds.y + bounds.height * 0.5, { steps: 4 });
+  await page.mouse.up();
+  await idle();
+  expect(await pixels()).not.toBe(before);
+
+  before = await pixels();
+  await page.getByRole('button', { name: 'Top-Down View', exact: true }).click();
+  await idle();
+  expect(await pixels()).not.toBe(before);
+
+  // Moving/removing a placement preview must wake a sleeping viewer too.
+  await page.getByRole('button', { name: 'Edit Mode', exact: true }).click();
+  await page.getByRole('button', { name: 'Place Furniture', exact: true }).click();
+  await page.getByRole('button', { name: /Armchair/ }).click();
+  await page.mouse.move(bounds.x + bounds.width * 0.5, bounds.y + bounds.height * 0.65);
+  await page.waitForLoadState('networkidle');
+  await idle();
+  before = await pixels();
+  await page.mouse.move(bounds.x + bounds.width * 0.6, bounds.y + bounds.height * 0.65);
+  await idle();
+  expect(await pixels()).not.toBe(before);
+  before = await pixels();
+  await page.getByRole('button', { name: 'Exit Furniture Placement', exact: true }).click();
+  await idle();
+  expect(await pixels()).not.toBe(before);
+  await page.getByRole('button', { name: 'Edit Mode', exact: true }).click();
+
+  before = await pixels();
+  await page.getByRole('button', { name: 'Lighting Controls', exact: true }).click();
+  await page.getByRole('button', { name: /night/i }).click();
+  await page.getByRole('button', { name: 'Lighting Controls', exact: true }).click();
+  await idle();
+  expect(await pixels()).not.toBe(before);
+  before = await pixels();
+  await page.getByRole('button', { name: 'Show All Floors Stacked', exact: true }).click();
+  await idle();
+  expect(await pixels()).not.toBe(before);
+  const draws = (await gpu(page))[0].draws;
+  await page.setViewportSize({ width: 844, height: 390 });
+  await idle();
+  expect((await gpu(page))[0].draws).toBeGreaterThan(draws);
+
+  await page.evaluate(() => { HTMLCanvasElement.prototype.requestPointerLock = () => Promise.reject(new DOMException('Denied', 'NotAllowedError')); });
+  await page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true }).click();
+  await expect(page.getByText('Walkthrough Controls', { exact: true })).toBeVisible();
+  await expect.poll(async () => (await gpu(page))[0].draws).toBeGreaterThan((await gpu(page))[0].draws);
+  before = await pixels();
+  await page.keyboard.down('ArrowUp');
+  await page.waitForTimeout(250);
+  await page.keyboard.up('ArrowUp');
+  await expect.poll(pixels).not.toBe(before);
+  await page.getByRole('button', { name: 'Top-Down View', exact: true }).click();
+  await expect(page.getByText('Walkthrough Controls', { exact: true })).not.toBeVisible();
+  await idle();
+  await page.getByRole('button', { name: '2D', exact: true }).click();
+  await expect.poll(async () => (await gpu(page))[0].lost).toBe(true);
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  await idle();
+  expect((await gpu(page))[1].draws).toBeGreaterThan(0);
+  expect(errors).toEqual([]);
+});

--- a/tests/browser/viewer-idle.spec.ts
+++ b/tests/browser/viewer-idle.spec.ts
@@ -3,6 +3,8 @@ import { resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { observeGPU, gpu } from './gpu';
 
+test.use({ viewport: { width: 844, height: 600 } });
+
 test('3D sleeps when idle and wakes for controls, scene changes and walkthrough', async ({ page }) => {
   test.setTimeout(120_000);
   await observeGPU(page);
@@ -36,7 +38,8 @@ test('3D sleeps when idle and wakes for controls, scene changes and walkthrough'
   const activeDraws = async () => (await gpu(page)).find((entry: any) => entry.connected && !entry.lost)?.draws ?? 0;
   const pixels = async () => createHash('sha256').update(await canvas.evaluate((node: HTMLCanvasElement) => node.toDataURL())).digest('hex');
   const idle = async () => {
-    await expect.poll(async () => (await audit()).pending).toBe(0);
+    // Software-rendered CI needs time to draw each remaining damping step.
+    await expect.poll(async () => (await audit()).pending, { timeout: 40_000 }).toBe(0);
     const before = await audit(), draws = await activeDraws();
     // A quiet interval must contain neither polling callbacks nor GPU draws.
     await page.waitForTimeout(350);
@@ -73,7 +76,7 @@ test('3D sleeps when idle and wakes for controls, scene changes and walkthrough'
   await page.getByRole('button', { name: 'Exit Furniture Placement', exact: true }).click();
   await idle();
   expect(await pixels()).not.toBe(before);
-  await page.getByRole('button', { name: 'Edit Mode', exact: true }).click();
+  await page.getByRole('button', { name: 'Exit Edit Mode', exact: true }).click();
 
   before = await pixels();
   await page.getByRole('button', { name: 'Lighting Controls', exact: true }).click();

--- a/tests/safari-timeline.test.ts
+++ b/tests/safari-timeline.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeSafariTimeline } from '../tooling/safari-timeline.mjs';
+
+const trace = () => ({ version: 1, recording: { startTime: 100, endTime: 110, records: [
+  { type: 'timeline-record-type-rendering-frame', startTime: 101, endTime: 101.004 },
+  { type: 'timeline-record-type-rendering-frame', startTime: 101.02, endTime: 101.026 },
+  { type: 'timeline-record-type-script', eventType: 'animation-frame-fired', startTime: 101 },
+  { type: 'timeline-record-type-script', eventType: 'animation-frame-requested', startTime: 101 },
+  { type: 'timeline-record-type-cpu', timestamp: 101, usage: 2 },
+  { type: 'timeline-record-type-cpu', timestamp: 102, usage: 4 },
+  { type: 'timeline-record-type-memory', timestamp: 101, categories: [{ type: 'javascript', size: 1_000_000 }, { type: 'page', size: 2_000_000 }] },
+  { type: 'timeline-record-type-network', startTime: 101, request: { url: 'private-project', cookies: ['private-cookie'], headers: ['private-header'] } },
+], samples: ['private-stack'], displayName: 'private-name' } });
+
+describe('Safari timeline aggregation', () => {
+  it('reports elapsed frame timing and sampled CPU/memory with explicit units', () => {
+    const result = summarizeSafariTimeline(trace());
+    expect(result.animationCallbacks).toBe(1);
+    expect(result.animationRequests).toBe(1);
+    expect(result.frameDurationMs).toEqual({ count: 2, min: 4, mean: 5, p95: 6, max: 6 });
+    expect(result.frameStartIntervalMs.mean).toBe(20);
+    expect(result.cpuPercent.mean).toBe(3);
+    expect(result.memoryMB.max).toBe(3);
+  });
+  it('uses recording-relative, half-open time windows', () => {
+    const result = summarizeSafariTimeline(trace(), { from: 1, to: 2 });
+    expect(result.cpuPercent.count).toBe(1);
+    expect(result.cpuPercent.mean).toBe(2);
+    expect(result.rangeSeconds).toEqual({ from: 1, to: 2 });
+  });
+  it('represents a sleeping interval without inventing zero CPU or memory samples', () => {
+    const result = summarizeSafariTimeline(trace(), { from: 5, to: 10 });
+    expect(result.renderingFrames).toBe(0);
+    expect(result.animationCallbacks).toBe(0);
+    expect(result.frameDurationMs.mean).toBeNull();
+    expect(result.cpuPercent.mean).toBeNull();
+    expect(result.memoryMB.max).toBeNull();
+  });
+  it('does not expose request data, display names or stacks', () => {
+    expect(JSON.stringify(summarizeSafariTimeline(trace()))).not.toContain('private');
+  });
+  for (const options of [{ from: -1 }, { from: 2, to: 1 }, { to: 11 }, { from: NaN }]) {
+    it(`rejects invalid range ${JSON.stringify(options)}`, () => {
+      expect(() => summarizeSafariTimeline(trace(), options)).toThrow('time range');
+    });
+  }
+  it('rejects unknown or incomplete recording formats', () => {
+    expect(() => summarizeSafariTimeline({ ...trace(), version: 2 })).toThrow('Unsupported');
+    expect(() => summarizeSafariTimeline({ version: 1 })).toThrow('Unsupported');
+  });
+});

--- a/tooling/safari-timeline.mjs
+++ b/tooling/safari-timeline.mjs
@@ -1,0 +1,66 @@
+import { readFile, stat } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const round = value => Math.round(value * 10000) / 10000;
+function stats(values) {
+  const sorted = values.filter(Number.isFinite).sort((a, b) => a - b);
+  if (!sorted.length) return { count: 0, min: null, mean: null, p95: null, max: null };
+  return {
+    count: sorted.length, min: round(sorted[0]),
+    mean: round(sorted.reduce((sum, value) => sum + value, 0) / sorted.length),
+    p95: round(sorted[Math.ceil(sorted.length * 0.95) - 1]), max: round(sorted.at(-1)),
+  };
+}
+
+/** Aggregate only numeric measurements. Never copy requests, cookies, headers,
+ * screenshots, script sources, stack traces or project contents into a report. */
+export function summarizeSafariTimeline(data, { from = 0, to } = {}) {
+  const recording = data?.recording;
+  if (data?.version !== 1 || !Array.isArray(recording?.records)
+    || !Number.isFinite(recording.startTime) || !Number.isFinite(recording.endTime)
+    || recording.endTime <= recording.startTime) throw new Error('Unsupported Safari timeline recording');
+  const duration = recording.endTime - recording.startTime;
+  to ??= duration;
+  if (!Number.isFinite(from) || !Number.isFinite(to) || from < 0 || to <= from || to > duration) {
+    throw new Error('Choose a time range within the recording, in seconds');
+  }
+  const rows = recording.records.filter(row => {
+    const time = row.startTime ?? row.timestamp;
+    return Number.isFinite(time) && time >= recording.startTime + from && time < recording.startTime + to;
+  });
+  const frames = rows.filter(row => row.type === 'timeline-record-type-rendering-frame'
+    && Number.isFinite(row.endTime) && row.endTime >= row.startTime).sort((a, b) => a.startTime - b.startTime);
+  const frameIntervals = frames.slice(1).map((frame, index) => (frame.startTime - frames[index].startTime) * 1000);
+  const memoryKinds = new Set(['javascript', 'jit', 'images', 'layers', 'page', 'other']);
+  const memoryBytes = rows.filter(row => row.type === 'timeline-record-type-memory' && Array.isArray(row.categories))
+    .map(row => row.categories.filter(category => memoryKinds.has(category.type)
+      && Number.isFinite(category.size) && category.size >= 0).reduce((sum, category) => sum + category.size, 0));
+  return {
+    recordingSeconds: round(duration), rangeSeconds: { from: round(from), to: round(to) },
+    renderingFrames: frames.length,
+    animationCallbacks: rows.filter(row => row.type === 'timeline-record-type-script' && row.eventType === 'animation-frame-fired').length,
+    animationRequests: rows.filter(row => row.type === 'timeline-record-type-script' && row.eventType === 'animation-frame-requested').length,
+    // Inspector's elapsed frame span, not isolated CPU work or GPU timer queries.
+    frameDurationMs: stats(frames.map(frame => (frame.endTime - frame.startTime) * 1000)),
+    frameStartIntervalMs: stats(frameIntervals),
+    cpuPercent: stats(rows.filter(row => row.type === 'timeline-record-type-cpu' && row.usage >= 0).map(row => row.usage)),
+    memoryMB: stats(memoryBytes.map(bytes => bytes / 1_000_000)),
+  };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const [file, ...args] = process.argv.slice(2);
+    if (!file || args.length % 2) throw new Error('Usage: node tooling/safari-timeline.mjs recording.json [--from seconds] [--to seconds]');
+    const options = {};
+    for (let index = 0; index < args.length; index += 2) {
+      if (!['--from', '--to'].includes(args[index])) throw new Error('Unknown option');
+      options[args[index].slice(2)] = Number(args[index + 1]);
+    }
+    if ((await stat(file)).size > 128 * 1024 * 1024) throw new Error('Record a shorter trace (maximum 128 MiB)');
+    console.log(JSON.stringify(summarizeSafariTimeline(JSON.parse(await readFile(file, 'utf8')), options), null, 2));
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tooling/safari-timeline.mjs
+++ b/tooling/safari-timeline.mjs
@@ -1,39 +1,62 @@
 import { readFile, stat } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
+/** @param {number} value */
 const round = value => Math.round(value * 10000) / 10000;
+/** @param {number[]} values */
 function stats(values) {
   const sorted = values.filter(Number.isFinite).sort((a, b) => a - b);
   if (!sorted.length) return { count: 0, min: null, mean: null, p95: null, max: null };
   return {
     count: sorted.length, min: round(sorted[0]),
     mean: round(sorted.reduce((sum, value) => sum + value, 0) / sorted.length),
-    p95: round(sorted[Math.ceil(sorted.length * 0.95) - 1]), max: round(sorted.at(-1)),
+    p95: round(sorted[Math.ceil(sorted.length * 0.95) - 1]), max: round(sorted[sorted.length - 1]),
   };
 }
 
+/** @param {unknown} value @returns {Record<string, unknown>} */
+const object = value => value !== null && typeof value === 'object'
+  ? /** @type {Record<string, unknown>} */ (value) : {};
+/** @param {unknown} value */
+const number = value => typeof value === 'number' ? value : NaN;
+
 /** Aggregate only numeric measurements. Never copy requests, cookies, headers,
- * screenshots, script sources, stack traces or project contents into a report. */
+ * screenshots, script sources, stack traces or project contents into a report.
+ * @param {unknown} data
+ * @param {{from?: number, to?: number}} [options]
+ */
 export function summarizeSafariTimeline(data, { from = 0, to } = {}) {
-  const recording = data?.recording;
-  if (data?.version !== 1 || !Array.isArray(recording?.records)
-    || !Number.isFinite(recording.startTime) || !Number.isFinite(recording.endTime)
-    || recording.endTime <= recording.startTime) throw new Error('Unsupported Safari timeline recording');
-  const duration = recording.endTime - recording.startTime;
+  const recording = object(object(data).recording);
+  const start = number(recording.startTime), end = number(recording.endTime);
+  if (object(data).version !== 1 || !Array.isArray(recording.records)
+    || !Number.isFinite(start) || !Number.isFinite(end)
+    || end <= start) throw new Error('Unsupported Safari timeline recording');
+  const duration = end - start;
   to ??= duration;
   if (!Number.isFinite(from) || !Number.isFinite(to) || from < 0 || to <= from || to > duration) {
     throw new Error('Choose a time range within the recording, in seconds');
   }
-  const rows = recording.records.filter(row => {
-    const time = row.startTime ?? row.timestamp;
-    return Number.isFinite(time) && time >= recording.startTime + from && time < recording.startTime + to;
+  const rows = recording.records.map(value => {
+    const row = object(value);
+    return {
+      type: row.type, eventType: row.eventType,
+      startTime: number(row.startTime ?? row.timestamp), endTime: number(row.endTime),
+      usage: number(row.usage),
+      categories: Array.isArray(row.categories) ? row.categories.map(value => {
+        const category = object(value);
+        return { type: category.type, size: number(category.size) };
+      }) : [],
+    };
+  }).filter(row => {
+    const time = row.startTime;
+    return Number.isFinite(time) && time >= start + from && time < start + to;
   });
   const frames = rows.filter(row => row.type === 'timeline-record-type-rendering-frame'
     && Number.isFinite(row.endTime) && row.endTime >= row.startTime).sort((a, b) => a.startTime - b.startTime);
   const frameIntervals = frames.slice(1).map((frame, index) => (frame.startTime - frames[index].startTime) * 1000);
   const memoryKinds = new Set(['javascript', 'jit', 'images', 'layers', 'page', 'other']);
   const memoryBytes = rows.filter(row => row.type === 'timeline-record-type-memory' && Array.isArray(row.categories))
-    .map(row => row.categories.filter(category => memoryKinds.has(category.type)
+    .map(row => row.categories.filter(category => typeof category.type === 'string' && memoryKinds.has(category.type)
       && Number.isFinite(category.size) && category.size >= 0).reduce((sum, category) => sum + category.size, 0));
   return {
     recordingSeconds: round(duration), rangeSeconds: { from: round(from), to: round(to) },
@@ -52,15 +75,17 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   try {
     const [file, ...args] = process.argv.slice(2);
     if (!file || args.length % 2) throw new Error('Usage: node tooling/safari-timeline.mjs recording.json [--from seconds] [--to seconds]');
+    /** @type {{from?: number, to?: number}} */
     const options = {};
     for (let index = 0; index < args.length; index += 2) {
       if (!['--from', '--to'].includes(args[index])) throw new Error('Unknown option');
-      options[args[index].slice(2)] = Number(args[index + 1]);
+      if (args[index] === '--from') options.from = Number(args[index + 1]);
+      else options.to = Number(args[index + 1]);
     }
     if ((await stat(file)).size > 128 * 1024 * 1024) throw new Error('Record a shorter trace (maximum 128 MiB)');
     console.log(JSON.stringify(summarizeSafariTimeline(JSON.parse(await readFile(file, 'utf8')), options), null, 2));
   } catch (error) {
-    console.error(error.message);
+    console.error(error instanceof Error ? error.message : 'Could not read Safari recording');
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
The 3D viewer continued requesting animation frames while idle even though its dirty flag skipped unchanged WebGL draws. It now schedules one frame for a change, continues orbit damping only while the camera changes, and sleeps once settled. Scene updates, lighting, resize, furniture previews and walkthrough wake it; teardown prevents late model callbacks from reviving a disposed viewer.

The browser regression also exposed Help covering Lighting Controls on desktop. The lighting toggle and panel now use the unused middle slot between Help and Undo History, so an ordinary pointer click can open the lighting presets.

Native Safari 26.2 on M4 Max recorded 1,500 callbacks in a 25-second quiet interval before the change and zero afterward. A separate post-orbit recording also returned to zero. The report includes hardware/method limits and sanitized numeric metrics; raw browser recordings remain local. This does not claim a general FPS, memory or battery-life improvement.

Validation: 591 unit tests pass; production build and type checking pass with zero errors and 23 existing warnings. The new browser regression asserts zero idle callbacks/draws and checks orbit damping, top-down, furniture preview movement/removal, lighting, stacking, resize, denied-pointer-lock walkthrough and remount. All 66 workflows per engine and six furnished-home benchmarks are required by the aggregate CI check.

No Firebase writes, uploads, assets, dependencies or production profiling hooks were added. NEXT.md records frame-rate-independent walkthrough movement (#77) as the next focused fix; physical-device calibration and #30 release/cost gates remain open.

See [the measurement report](https://github.com/laanlabs/openPlan3D/blob/main/docs/reviews/2026-09-07-idle-rendering.md).

Fixes #75
Fixes #78
