### PR TITLE
Make walkthrough motion consistent across frame rates and pauses

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -22,7 +22,7 @@ intercepting field editing, and preserves furniture dimensions while replacing
 empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
 and PR checks for final engine results and merge/release status.
 
-Local validation: **606 web unit tests, 53 XCTest tests**, production build and
+Local validation: **607 web unit tests, 53 XCTest tests**, production build and
 audit pass; type checks report zero errors and 23 existing Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.

--- a/NEXT.md
+++ b/NEXT.md
@@ -22,7 +22,7 @@ intercepting field editing, and preserves furniture dimensions while replacing
 empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
 and PR checks for final engine results and merge/release status.
 
-Local validation: **591 web unit tests, 53 XCTest tests**, production build and
+Local validation: **606 web unit tests, 53 XCTest tests**, production build and
 audit pass; type checks report zero errors and 23 existing Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
@@ -37,7 +37,7 @@ category continuity; field keyboard editing and browser-engine CI; camera previe
 and 3D resource cleanup; repeatable furnished-home benchmarks and preservation of
 3D views during metadata edits; responsive top-down camera framing; onboarding
 hints that stay within resized viewports; idle 3D animation cleanup measured in
-native Safari. Earlier batches and pause hashes are recorded
+native Safari; walkthrough timing and held-input recovery. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
 ## 1. Next engineering batch: measured rendering improvements and device coverage
@@ -80,12 +80,15 @@ all three engines. It also fixes the desktop Help button covering Lighting Contr
 These results establish idle behavior, not general FPS or
 battery-life targets.
 
-The next focused fix is [frame-rate-independent walkthrough motion (#77)](https://github.com/laanlabs/openPlan3D/issues/77).
-Movement currently uses a fixed 16 ms step per callback, so its speed changes with
-frame cadence. Integrate elapsed time with bounded pause recovery and test equal
-elapsed input at 30/60/120 Hz, key-state cleanup and pointer-lock denial.
+The [walkthrough timing batch (#77)](https://github.com/laanlabs/openPlan3D/issues/77)
+uses elapsed animation time and consistent acceleration/coasting, bounds stall
+catch-up, and clears input on blur, visibility changes and mode transitions.
+Field arrows and both Shift keys have independent behavior. Controlled tests
+compare equal-duration movement/look at 30/60/120 Hz and preserve floor-relative
+eye height. See [the timing report](docs/reviews/2026-09-07-walkthrough-timing.md)
+and PR checks for final browser, native Safari and deployment verification.
 
-Then measure the same fixtures on representative desktop/phone hardware and agree
+Next, measure medium/large fixtures on representative desktop/phone hardware and agree
 frame-time and memory targets. Use those results to choose shared geometry,
 object-level visual updates or mobile quality controls. Extend desktop Safari
 checks to actual iPhone/iPad touch devices. The initial small-home native Safari
@@ -144,7 +147,9 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
   Use the new furnished-home benchmarks to agree desktop/phone frame-time and
   memory targets on real hardware. Metadata edits now preserve the scene; visual
   edits still rebuild it. Measure shared geometry, object-level updates and mobile
-  quality settings before choosing the next optimization.
+  quality settings before choosing the next optimization. Walkthrough still draws
+  continuously; measure its stationary cost before extending idle scheduling to
+  that mode, including mouse look and momentum wakeups.
 - **Area/geometry agreement:** define whether area is measured at interior wall
   faces or another boundary, reconcile native raster-based areas with web polygons,
   and test room split/merge identity and schedules. Matching area totals are not
@@ -206,7 +211,7 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
 1. Fetch both repositories and confirm clean `main` against `origin/main`; reread
    open GitHub issues and #30 for release updates. Start a focused `codex/…` branch
    from current main after checking the browser batch merge status.
-2. Start with walkthrough motion #77, then broaden hardware calibration. Preserve unknown fields,
+2. Broaden furnished-home hardware calibration and device coverage. Preserve unknown fields,
    explicit clears, independent import copies, fractional transforms and pooled
    local attachments. Do not rely on temporary QA directories as source artifacts.
 3. Web baseline: Node 24/npm; run `NODE_ENV=production npm run check`,

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -458,3 +458,15 @@ engines. See [the report and numeric metrics](2026-09-07-idle-rendering.md) for
 measurement limits and PR validation. Frame-rate-independent walkthrough motion
 is tracked in #77. Broader hardware budgets, physical devices and the #30
 release/cost gates remain; this batch adds no cloud writes or assets.
+
+## Twenty-sixth batch: walkthrough timing and input recovery
+
+Issue #77 replaces fixed per-callback movement with elapsed-time integration,
+consistent drag/coasting and short camera-motion substeps. It preserves the
+existing speed calibration, horizontal movement and floor-relative eye height.
+Blur, visibility and mode transitions clear held input and momentum; slider
+arrows and both Shift keys behave independently. Local validation passes 606 unit
+tests, with two new browser workflows for controlled cadence, rendered motion,
+pause recovery and field input. See [the timing report](2026-09-07-walkthrough-timing.md)
+for limits and PR validation. Hardware calibration, physical devices, native
+release and the #30 cost gates remain; this batch adds no cloud writes or assets.

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -465,7 +465,7 @@ Issue #77 replaces fixed per-callback movement with elapsed-time integration,
 consistent drag/coasting and short camera-motion substeps. It preserves the
 existing speed calibration, horizontal movement and floor-relative eye height.
 Blur, visibility and mode transitions clear held input and momentum; slider
-arrows and both Shift keys behave independently. Local validation passes 606 unit
+arrows and both Shift keys behave independently. Local validation passes 607 unit
 tests, with two new browser workflows for controlled cadence, rendered motion,
 pause recovery and field input. See [the timing report](2026-09-07-walkthrough-timing.md)
 for limits and PR validation. Hardware calibration, physical devices, native

--- a/docs/reviews/2026-09-07-walkthrough-timing.md
+++ b/docs/reviews/2026-09-07-walkthrough-timing.md
@@ -59,6 +59,12 @@ The suite now has 68 workflows per engine (204 across Chromium, Firefox and
 WebKit), plus six furnished-home rendering benchmarks. See the linked GitHub issue
 and PR checks for final CI, native Safari and deployment verification.
 
+The first CI run retried the existing Chromium phone-width field-editing test:
+it reloaded immediately after clicking an asynchronous Save and read the previous
+note. That test now waits for the expected IndexedDB record before reloading,
+then retains its full editor and saved-document assertions. The walkthrough
+workflows passed their first attempts in Chromium and Firefox in that run.
+
 The controlled cadence tests establish integration behavior, not a hardware FPS
 budget. Actual iPhone/iPad touch and backgrounding checks, medium/large-home device
 calibration, native distribution and the #30 migration/billing gates remain.

--- a/docs/reviews/2026-09-07-walkthrough-timing.md
+++ b/docs/reviews/2026-09-07-walkthrough-timing.md
@@ -32,7 +32,7 @@ A single delayed frame consumes at most 250 ms, limiting catch-up after a stall.
 Below four callbacks per second this deliberately limits traveled time. Actual
 blur, visibility changes, entry, exit and teardown reset elapsed time, momentum
 and all held keys. A user returning to the page starts movement with a fresh key
-press. Both Shift keys are tracked independently, and releasing Shift outside
+press; OS key repeats cannot revive cleared movement. Both Shift keys are tracked independently, and releasing Shift outside
 walkthrough cannot leave sprint enabled on the next entry.
 
 Focused inputs, selects, text areas and editable content retain their keyboard
@@ -43,11 +43,11 @@ available. Orbit idle scheduling from #75 and top-down exit behavior remain.
 
 ## Verification
 
-Local validation: **606 unit tests**, zero type-check errors with 23 existing
-Svelte warnings, and the production build. Fifteen motion tests cover 30/60/120 Hz,
+Local validation: **607 unit tests**, zero type-check errors with 23 existing
+Svelte warnings, and the production build. Sixteen motion tests cover 30/60/120 Hz,
 uneven timing, diagonal normalization, simultaneous turning/movement, release
 momentum, speed calibration, pause limits, duplicate timestamps, input reset,
-both Shift keys, pitch limits and floor-relative height.
+key-repeat recovery, both Shift keys, pitch limits and floor-relative height.
 
 Two production-browser workflows control RAF timestamps and observe WebGL view
 uniforms at the browser boundary in CI. They compare actual rendered camera views

--- a/docs/reviews/2026-09-07-walkthrough-timing.md
+++ b/docs/reviews/2026-09-07-walkthrough-timing.md
@@ -1,0 +1,65 @@
+# Walkthrough timing and input recovery
+
+September 7, 2026 · [Issue #77](https://github.com/laanlabs/openPlan3D/issues/77)
+
+## Problem and resulting behavior
+
+The viewer integrated a fixed 16 ms on every animation callback. A one-second
+forward input therefore traveled different distances at 30, 60 and 120 callbacks
+per second. Keyboard turning and momentum had the same dependency. The extracted
+old calculation failed 11 of the initial 14 motion regressions, including every
+30/120 Hz comparison against 60 Hz. These are controlled simulation results, not
+measurements of three physical displays.
+
+Walkthrough now consumes the RAF timestamp. Exponential velocity decay and its
+displacement integral make acceleration, coasting and sprint changes independent
+of callback cadence. Camera motion uses short substeps (at most 1/120 second) so
+simultaneous turning and movement follow a consistent path. Only the final pose
+is rendered once per callback. Uneven callback intervals retain elapsed time;
+there is no fixed-tick accumulator or extra rendering loop.
+
+The existing slider calibration stays intact: the default 800 setting approaches
+80 cm/s under the existing drag factor of 10. From rest, one second now covers
+about 72 cm at each tested cadence. This removes the old approximate-clock error
+without interpreting the slider as a ten-times-faster travel speed. Keyboard look
+turns at two radians per second. Mouse look still uses PointerLockControls; both
+paths use its YXZ yaw/pitch convention. Movement remains horizontal and eye height
+is relative to the active floor elevation.
+
+## Pauses and input ownership
+
+A single delayed frame consumes at most 250 ms, limiting catch-up after a stall.
+Below four callbacks per second this deliberately limits traveled time. Actual
+blur, visibility changes, entry, exit and teardown reset elapsed time, momentum
+and all held keys. A user returning to the page starts movement with a fresh key
+press. Both Shift keys are tracked independently, and releasing Shift outside
+walkthrough cannot leave sprint enabled on the next entry.
+
+Focused inputs, selects, text areas and editable content retain their keyboard
+behavior. Focusing one clears movement; arrows adjust the eye-height slider
+without also walking the camera. Modified browser shortcuts and composition input
+are not treated as movement. Denied pointer lock keeps keyboard movement/look
+available. Orbit idle scheduling from #75 and top-down exit behavior remain.
+
+## Verification
+
+Local validation: **606 unit tests**, zero type-check errors with 23 existing
+Svelte warnings, and the production build. Fifteen motion tests cover 30/60/120 Hz,
+uneven timing, diagonal normalization, simultaneous turning/movement, release
+momentum, speed calibration, pause limits, duplicate timestamps, input reset,
+both Shift keys, pitch limits and floor-relative height.
+
+Two production-browser workflows control RAF timestamps and observe WebGL view
+uniforms at the browser boundary in CI. They compare actual rendered camera views
+after equal-duration input at 30/60/120 Hz and verify changed canvas pixels. They
+also exercise simulated blur/visibility events with held keys, input-field arrows,
+denied pointer lock and leaving/re-entering while Shift is released outside the
+mode. No application camera references or production debug hooks are exposed.
+The suite now has 68 workflows per engine (204 across Chromium, Firefox and
+WebKit), plus six furnished-home rendering benchmarks. See the linked GitHub issue
+and PR checks for final CI, native Safari and deployment verification.
+
+The controlled cadence tests establish integration behavior, not a hardware FPS
+budget. Actual iPhone/iPad touch and backgrounding checks, medium/large-home device
+calibration, native distribution and the #30 migration/billing gates remain.
+This change adds no Firebase writes, uploads, model assets or dependencies.

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -663,7 +663,7 @@
     if (event.code === 'Escape') { exitWalkthroughMode(); return; }
     if (event.defaultPrevented || event.isComposing || event.ctrlKey || event.metaKey || event.altKey
       || isWalkthroughField(event.target)) return;
-    if (walkthroughMotion.setKey(event.code, true)) event.preventDefault();
+    if (walkthroughMotion.setKey(event.code, true, event.repeat)) event.preventDefault();
   }
 
   function onKeyUp(event: KeyboardEvent) {

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -16,6 +16,7 @@
   import { setFloorCameraPose } from '$lib/utils/floorCamera';
   import { frameScene } from '$lib/utils/frameScene';
   import { sceneSignature } from '$lib/utils/sceneSignature';
+  import { WalkthroughMotion } from '$lib/utils/walkthroughMotion';
   import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
   import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
   import MaterialPicker from './MaterialPicker.svelte';
@@ -74,21 +75,9 @@
   // Walkthrough mode
   let walkthroughMode = $state(false);
   let walkthroughMouseUnavailable = $state(false);
-  let moveForward = false;
-  let moveBackward = false;
-  let moveLeft = false;
-  let moveRight = false;
-  let lookLeft = false;
-  let lookRight = false;
-  let lookUp = false;
-  let lookDown = false;
-  let isShiftHeld = false;
-  const LOOK_SPEED = 2.0; // radians/s
-  let canJump = false;
-  let velocity = new THREE.Vector3();
-  const direction = new THREE.Vector3();
-  let moveSpeed = $state(800); // cm/s
-  let sprintSpeed = $state(1600); // cm/s
+  const walkthroughMotion = new WalkthroughMotion();
+  let moveSpeed = $state(800);
+  let sprintSpeed = $state(1600);
   let eyeHeight = $state(160); // cm
 
   // Lighting controls state
@@ -643,9 +632,7 @@
   function exitWalkthroughMode() {
     walkthroughMode = false;
     controls.enabled = true;
-    velocity.set(0, 0, 0);
-    moveForward = moveBackward = moveLeft = moveRight = false;
-    lookLeft = lookRight = lookUp = lookDown = false;
+    walkthroughMotion.reset();
     markSceneDirty();
 
     if (typeof document !== 'undefined' && document.pointerLockElement) {
@@ -673,39 +660,27 @@
       return;
     }
     if (!walkthroughMode) return;
-
-    switch (event.code) {
-      // Arrows = move
-      case 'ArrowUp': moveForward = true; break;
-      case 'ArrowDown': moveBackward = true; break;
-      case 'ArrowLeft': moveLeft = true; break;
-      case 'ArrowRight': moveRight = true; break;
-      // WASD = look
-      case 'KeyW': lookUp = true; break;
-      case 'KeyS': lookDown = true; break;
-      case 'KeyA': lookLeft = true; break;
-      case 'KeyD': lookRight = true; break;
-      case 'ShiftLeft':
-      case 'ShiftRight': isShiftHeld = true; break;
-      case 'Escape': exitWalkthroughMode(); break;
-    }
+    if (event.code === 'Escape') { exitWalkthroughMode(); return; }
+    if (event.defaultPrevented || event.isComposing || event.ctrlKey || event.metaKey || event.altKey
+      || isWalkthroughField(event.target)) return;
+    if (walkthroughMotion.setKey(event.code, true)) event.preventDefault();
   }
 
   function onKeyUp(event: KeyboardEvent) {
-    if (!walkthroughMode) return;
+    walkthroughMotion.setKey(event.code, false);
+  }
 
-    switch (event.code) {
-      case 'ArrowUp': moveForward = false; break;
-      case 'ArrowDown': moveBackward = false; break;
-      case 'ArrowLeft': moveLeft = false; break;
-      case 'ArrowRight': moveRight = false; break;
-      case 'KeyW': lookUp = false; break;
-      case 'KeyS': lookDown = false; break;
-      case 'KeyA': lookLeft = false; break;
-      case 'KeyD': lookRight = false; break;
-      case 'ShiftLeft':
-      case 'ShiftRight': isShiftHeld = false; break;
-    }
+  function resetWalkthroughInput() {
+    walkthroughMotion.reset();
+  }
+
+  function isWalkthroughField(target: EventTarget | null) {
+    return target instanceof HTMLElement && (target.isContentEditable
+      || Boolean(target.closest('input, textarea, select')));
+  }
+
+  function onWalkthroughFocus(event: FocusEvent) {
+    if (isWalkthroughField(event.target)) resetWalkthroughInput();
   }
 
   function init() {
@@ -948,6 +923,9 @@
     // Keyboard event listeners for walkthrough
     document.addEventListener('keydown', onKeyDown, false);
     document.addEventListener('keyup', onKeyUp, false);
+    window.addEventListener('blur', resetWalkthroughInput);
+    document.addEventListener('visibilitychange', resetWalkthroughInput);
+    document.addEventListener('focusin', onWalkthroughFocus);
 
     // ESC key to exit walkthrough mode
     pointerControls.addEventListener('unlock', () => {
@@ -1898,6 +1876,7 @@
     furniturePlacementMode = false;
     removeGhostPreview();
     walkthroughMode = true;
+    walkthroughMotion.reset();
     walkthroughMouseUnavailable = false;
     controls.enabled = false;
 
@@ -1953,35 +1932,11 @@
 
 
 
-  function animate() {
+  function animate(timestamp: number) {
     animId = undefined;
 
     if (walkthroughMode) {
-      const delta = 0.016; // Approximate 60fps
-      const speed = isShiftHeld ? sprintSpeed : moveSpeed;
-
-      velocity.x -= velocity.x * 10.0 * delta;
-      velocity.z -= velocity.z * 10.0 * delta;
-
-      direction.z = Number(moveForward) - Number(moveBackward);
-      direction.x = Number(moveRight) - Number(moveLeft);
-      direction.normalize();
-
-      if (moveForward || moveBackward) velocity.z -= direction.z * speed * delta;
-      if (moveLeft || moveRight) velocity.x -= direction.x * speed * delta;
-
-      pointerControls.moveRight(-velocity.x * delta);
-      pointerControls.moveForward(-velocity.z * delta);
-      camera.position.y = activeFloorElevation + eyeHeight;
-
-      if (lookLeft || lookRight) {
-        const yaw = ((lookLeft ? 1 : 0) - (lookRight ? 1 : 0)) * LOOK_SPEED * delta;
-        camera.rotation.y += yaw;
-      }
-      if (lookUp || lookDown) {
-        const pitch = ((lookUp ? 1 : 0) - (lookDown ? 1 : 0)) * LOOK_SPEED * delta;
-        camera.rotation.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, camera.rotation.x + pitch));
-      }
+      walkthroughMotion.advance(timestamp, camera, { moveSpeed, sprintSpeed, eyeHeight, floorElevation: activeFloorElevation });
       // Always render in walkthrough mode (camera constantly moving)
       renderer.render(scene, camera);
       requestRender();
@@ -2066,6 +2021,10 @@
       animId = undefined;
       document.removeEventListener('keydown', onKeyDown, false);
       document.removeEventListener('keyup', onKeyUp, false);
+      window.removeEventListener('blur', resetWalkthroughInput);
+      document.removeEventListener('visibilitychange', resetWalkthroughInput);
+      document.removeEventListener('focusin', onWalkthroughFocus);
+      walkthroughMotion.reset();
       releaseCameraPreview();
       wallHighlight.clear();
       removeGhostPreview();

--- a/src/lib/utils/walkthroughMotion.ts
+++ b/src/lib/utils/walkthroughMotion.ts
@@ -18,8 +18,11 @@ export class WalkthroughMotion {
   private forwardVelocity = 0;
   private rotation = new Euler(0, 0, 0, 'YXZ');
 
-  setKey(code: string, down: boolean) {
+  setKey(code: string, down: boolean, repeat = false) {
     if (!keys.has(code)) return false;
+    // An OS repeat after returning to the page must not revive a key that blur
+    // cleared. Accept movement again on a fresh press after release.
+    if (down && repeat && !this.held.has(code)) return true;
     if (down) this.held.add(code);
     else this.held.delete(code);
     return true;

--- a/src/lib/utils/walkthroughMotion.ts
+++ b/src/lib/utils/walkthroughMotion.ts
@@ -1,0 +1,81 @@
+import { Euler, type Camera } from 'three';
+
+const keys = new Set(['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+  'KeyW', 'KeyS', 'KeyA', 'KeyD', 'ShiftLeft', 'ShiftRight']);
+
+export interface WalkthroughSettings {
+  moveSpeed: number;
+  sprintSpeed: number;
+  eyeHeight: number;
+  floorElevation: number;
+}
+
+/** Local walkthrough input and motion; independent of rendering and pointer lock. */
+export class WalkthroughMotion {
+  private held = new Set<string>();
+  private previous: number | null = null;
+  private rightVelocity = 0;
+  private forwardVelocity = 0;
+  private rotation = new Euler(0, 0, 0, 'YXZ');
+
+  setKey(code: string, down: boolean) {
+    if (!keys.has(code)) return false;
+    if (down) this.held.add(code);
+    else this.held.delete(code);
+    return true;
+  }
+
+  reset() {
+    this.held.clear();
+    this.previous = null;
+    this.rightVelocity = this.forwardVelocity = 0;
+  }
+
+  advance(timestamp: number, camera: Camera, settings: WalkthroughSettings) {
+    camera.position.y = settings.floorElevation + settings.eyeHeight;
+    if (!Number.isFinite(timestamp)) { this.reset(); return; }
+    if (this.previous === null) { this.previous = timestamp; return; }
+    if (timestamp <= this.previous) {
+      if (timestamp < this.previous) this.reset();
+      return;
+    }
+    // A delayed frame must not teleport through the plan. Blur/visibility resets
+    // separately discard all held input, momentum and elapsed background time.
+    const delta = Math.min((timestamp - this.previous) / 1000, 0.25);
+    this.previous = timestamp;
+    const held = (code: string) => Number(this.held.has(code));
+    const speed = this.held.has('ShiftLeft') || this.held.has('ShiftRight')
+      ? settings.sprintSpeed : settings.moveSpeed;
+    const right = held('ArrowRight') - held('ArrowLeft');
+    const forward = held('ArrowUp') - held('ArrowDown');
+    const length = Math.hypot(right, forward) || 1;
+    const yawSpeed = (held('KeyA') - held('KeyD')) * 2;
+    const pitchSpeed = (held('KeyW') - held('KeyS')) * 2;
+    if (!right && !forward && !yawSpeed && !pitchSpeed && !this.rightVelocity && !this.forwardVelocity) return;
+
+    // Preserve the old slider's acceleration/drag balance (800 gives 80 cm/s
+    // once settled). Integrate dv/dt = acceleration - 10v analytically, so
+    // acceleration, coasting and sprint changes do not depend on frame cadence.
+    const targetRight = right / length * speed / 10;
+    const targetForward = forward / length * speed / 10;
+    // Short substeps also keep simultaneous turning/movement consistent. They
+    // update only the camera pose; the scene is still drawn once per RAF.
+    const steps = Math.max(1, Math.ceil(delta * 120 - 1e-8));
+    const step = delta / steps;
+    const decay = Math.exp(-10 * step);
+    const integral = -Math.expm1(-10 * step) / 10;
+    this.rotation.setFromQuaternion(camera.quaternion, 'YXZ');
+    for (let i = 0; i < steps; i++) {
+      const rightDistance = targetRight * step + (this.rightVelocity - targetRight) * integral;
+      const forwardDistance = targetForward * step + (this.forwardVelocity - targetForward) * integral;
+      this.rightVelocity = targetRight + (this.rightVelocity - targetRight) * decay;
+      this.forwardVelocity = targetForward + (this.forwardVelocity - targetForward) * decay;
+      const yaw = this.rotation.y + yawSpeed * step / 2;
+      camera.position.x += Math.cos(yaw) * rightDistance - Math.sin(yaw) * forwardDistance;
+      camera.position.z -= Math.sin(yaw) * rightDistance + Math.cos(yaw) * forwardDistance;
+      this.rotation.y += yawSpeed * step;
+      this.rotation.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, this.rotation.x + pitchSpeed * step));
+    }
+    camera.quaternion.setFromEuler(this.rotation);
+  }
+}

--- a/tests/browser/item-details.spec.ts
+++ b/tests/browser/item-details.spec.ts
@@ -84,6 +84,10 @@ for (const width of [1440, 390]) test(`field keyboard editing cannot select or p
   await notes.pressSequentially('Soft green fabric chair');
   await notes.press('Tab');
   await page.getByRole('button', { name: 'Save', exact: true }).click();
+  // A click does not await the async IndexedDB transaction. Verify the saved
+  // note before navigating away, then independently check the reloaded editor.
+  await expect.poll(async () => (await savedProjects(page))[original.id]?.floors[0].furniture[0].details.note)
+    .toBe('Soft green fabric chair');
   await page.reload(); await selectFurniture(page);
   await expect(notes).toHaveValue('Soft green fabric chair');
   await expect(itemWidth).toHaveValue('78.125');

--- a/tests/browser/walkthrough.spec.ts
+++ b/tests/browser/walkthrough.spec.ts
@@ -110,6 +110,8 @@ test('walkthrough clears held input on pause and exit and lets fields handle arr
     await page.keyboard.down('ArrowUp'); await page.keyboard.down('ShiftRight'); await page.keyboard.down('a');
     const before = await step(page);
     await page.evaluate(event => (event === 'blur' ? window : document).dispatchEvent(new Event(event)), event);
+    // Playwright marks another down on an already-held key as an OS repeat.
+    await page.keyboard.down('ArrowUp'); await page.keyboard.down('a');
     await step(page, 60_000, 1);
     expect(await step(page)).toEqual(before);
     await page.keyboard.up('ArrowUp'); await page.keyboard.up('ShiftRight'); await page.keyboard.up('a');

--- a/tests/browser/walkthrough.spec.ts
+++ b/tests/browser/walkthrough.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from '@playwright/test';
+import { resolve } from 'node:path';
+import { Matrix4, Vector3 } from 'three';
+import { createHash } from 'node:crypto';
+
+test.use({ viewport: { width: 844, height: 480 } });
+
+async function openWalkthrough(page: Page) {
+  // CI-only control of RAF timestamps and observation of WebGL's view uniform.
+  // No camera references, application internals or production debug hooks.
+  await page.addInitScript(() => {
+    const request = window.requestAnimationFrame.bind(window), cancel = window.cancelAnimationFrame.bind(window);
+    const normal = new Set<number>(), queued = new Map<number, FrameRequestCallback>();
+    let manual = false, now = 0, next = -1;
+    const audit: any = {
+      view: null,
+      ready: () => normal.size === 0,
+      start: () => { if (normal.size) throw new Error('Wait for orbit to settle'); manual = true; },
+      step: (delta: number, frames: number) => {
+        for (let frame = 0; frame < frames; frame++) {
+          now += delta;
+          const callbacks = [...queued];
+          for (const [id, callback] of callbacks) {
+            if (!queued.delete(id)) continue;
+            callback(now);
+          }
+        }
+        return audit.view;
+      },
+    };
+    (window as any).__walkAudit = audit;
+    window.requestAnimationFrame = callback => {
+      if (manual) { const id = next--; queued.set(id, callback); return id; }
+      const id = request(time => { normal.delete(id); callback(time); });
+      normal.add(id); return id;
+    };
+    window.cancelAnimationFrame = id => {
+      if (id < 0) queued.delete(id);
+      else { normal.delete(id); cancel(id); }
+    };
+    const seen = new WeakSet(), getContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (this: HTMLCanvasElement, ...args: any[]) {
+      const gl = (getContext as any).apply(this, args);
+      if (!gl || !String(args[0]).startsWith('webgl') || seen.has(gl)) return gl;
+      seen.add(gl);
+      const uniforms = new Map(), locate = gl.getUniformLocation.bind(gl), matrix = gl.uniformMatrix4fv.bind(gl);
+      gl.getUniformLocation = (program: WebGLProgram, name: string) => {
+        const location = locate(program, name); if (location) uniforms.set(location, name); return location;
+      };
+      gl.uniformMatrix4fv = (location: WebGLUniformLocation, transpose: boolean, values: Float32Array, ...rest: any[]) => {
+        if (uniforms.get(location) === 'viewMatrix') audit.view = Array.from(values);
+        return matrix(location, transpose, values, ...rest);
+      };
+      return gl;
+    } as typeof getContext;
+    HTMLCanvasElement.prototype.requestPointerLock = () => Promise.reject(new DOMException('Denied', 'NotAllowedError'));
+  });
+  await page.goto('/editor');
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const chooser = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
+  await (await chooser).setFiles(resolve('tests/fixtures/top-down-framing.openplan.json'));
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  const hint = page.getByRole('button', { name: 'Got it', exact: true });
+  if (await hint.isVisible()) await hint.click();
+  await page.waitForLoadState('networkidle');
+  await expect.poll(() => page.evaluate(() => (window as any).__walkAudit.ready())).toBe(true);
+  await page.evaluate(() => (window as any).__walkAudit.start());
+}
+
+const step = (page: Page, delta = 1000 / 60, frames = 24): Promise<number[]> =>
+  page.evaluate(({ delta, frames }) => (window as any).__walkAudit.step(delta, frames), { delta, frames });
+const position = (view: number[]) => new Vector3().setFromMatrixPosition(new Matrix4().fromArray(view).invert());
+const pixels = async (page: Page) => createHash('sha256').update(await page.getByRole('region', { name: '3D floor plan viewer' })
+  .locator('canvas').last().evaluate((canvas: HTMLCanvasElement) => canvas.toDataURL())).digest('hex');
+async function enter(page: Page) {
+  const exit = page.getByRole('button', { name: 'Exit Walkthrough Mode', exact: true });
+  if (await exit.isVisible()) await exit.click();
+  await page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true }).click();
+  await expect(page.getByText('Walkthrough Controls', { exact: true })).toBeVisible();
+  const view = await step(page, 0, 1);
+  expect(view).toHaveLength(16);
+  return view;
+}
+
+test('walkthrough renders the same movement and look at 30, 60 and 120 Hz', async ({ page }) => {
+  test.setTimeout(120_000);
+  const errors: string[] = []; page.on('pageerror', error => errors.push(error.message));
+  await openWalkthrough(page);
+  const views: number[][] = [];
+  for (const hz of [30, 60, 120]) {
+    const initial = await enter(page), before = await pixels(page);
+    await page.keyboard.down('ArrowUp'); await page.keyboard.down('a');
+    let view: number[];
+    try { view = await step(page, 1000 / hz, hz * 0.4); }
+    finally { await page.keyboard.up('ArrowUp'); await page.keyboard.up('a'); }
+    expect(position(view).distanceTo(position(initial))).toBeGreaterThan(20);
+    expect(await pixels(page)).not.toBe(before);
+    views.push(view);
+  }
+  for (const view of views.slice(1)) view.forEach((value, index) => expect(value).toBeCloseTo(views[0][index], 4));
+  expect(errors).toEqual([]);
+});
+
+test('walkthrough clears held input on pause and exit and lets fields handle arrows', async ({ page }) => {
+  test.setTimeout(120_000);
+  await openWalkthrough(page);
+  await enter(page);
+  for (const event of ['blur', 'visibilitychange']) {
+    await page.keyboard.down('ArrowUp'); await page.keyboard.down('ShiftRight'); await page.keyboard.down('a');
+    const before = await step(page);
+    await page.evaluate(event => (event === 'blur' ? window : document).dispatchEvent(new Event(event)), event);
+    await step(page, 60_000, 1);
+    expect(await step(page)).toEqual(before);
+    await page.keyboard.up('ArrowUp'); await page.keyboard.up('ShiftRight'); await page.keyboard.up('a');
+  }
+  const field = page.getByRole('slider', { name: /Eye Height/ });
+  const beforeField = position(await step(page));
+  await field.focus();
+  const height = Number(await field.inputValue());
+  await page.keyboard.press('ArrowUp');
+  await expect(field).toHaveValue(String(height + 1));
+  const afterField = position(await step(page));
+  expect(afterField.x).toBeCloseTo(beforeField.x, 4);
+  expect(afterField.z).toBeCloseTo(beforeField.z, 4);
+  expect(afterField.y - beforeField.y).toBeCloseTo(1, 4);
+
+  // Releasing Shift outside walkthrough used to leave sprint enabled next time.
+  await page.getByRole('button', { name: 'Exit Walkthrough Mode', exact: true }).focus();
+  await page.keyboard.down('ShiftRight');
+  await page.getByRole('button', { name: 'Exit Walkthrough Mode', exact: true }).click();
+  await page.keyboard.up('ShiftRight');
+  const initial = position(await enter(page));
+  await page.keyboard.down('ArrowUp');
+  const walked = position(await step(page));
+  await page.keyboard.up('ArrowUp');
+  expect(walked.distanceTo(initial)).toBeCloseTo(24.146525, 3);
+});

--- a/tests/walkthrough-motion.test.ts
+++ b/tests/walkthrough-motion.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { Euler, PerspectiveCamera } from 'three';
+import { WalkthroughMotion, type WalkthroughSettings } from '../src/lib/utils/walkthroughMotion';
+
+const settings: WalkthroughSettings = { moveSpeed: 800, sprintSpeed: 1600, eyeHeight: 160, floorElevation: 425.5 };
+function run(hz: number, keys: string[], coast = false) {
+  const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+  keys.forEach(key => motion.setKey(key, true));
+  motion.advance(0, camera, settings);
+  for (let frame = 1; frame <= hz; frame++) motion.advance(frame * 1000 / hz, camera, settings);
+  if (coast) {
+    keys.forEach(key => motion.setKey(key, false));
+    for (let frame = 1; frame <= hz; frame++) motion.advance(1000 + frame * 1000 / hz, camera, settings);
+  }
+  return camera;
+}
+
+describe('walkthrough cadence', () => {
+  for (const [name, keys, coast] of [
+    ['walking', ['ArrowUp'], false],
+    ['diagonal sprint', ['ArrowUp', 'ArrowRight', 'ShiftLeft'], false],
+    ['turning while walking', ['ArrowUp', 'KeyA'], false],
+    ['released momentum', ['ArrowUp'], true],
+  ] as const) {
+    it.each([30, 120])(`${name} travels the same path at %s Hz as at 60 Hz`, hz => {
+      const actual = run(hz, [...keys], coast), reference = run(60, [...keys], coast);
+      expect(actual.position.distanceTo(reference.position)).toBeLessThan(1e-7);
+      expect(1 - Math.abs(actual.quaternion.dot(reference.quaternion))).toBeLessThan(1e-10);
+    });
+  }
+
+  it('keeps the established walking pace without multiplying the speed slider by ten', () => {
+    // dv/dt = 800 - 10v, so from rest the first second covers about 72 cm.
+    expect(-run(60, ['ArrowUp']).position.z).toBeCloseTo(72.0003632, 6);
+  });
+
+  it('handles uneven callback timing without accumulating simulation drift', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    ['ArrowUp', 'KeyA'].forEach(key => motion.setKey(key, true));
+    motion.advance(0, camera, settings);
+    let time = 0, frame = 0;
+    while (time < 1000) {
+      time = Math.min(1000, time + [7, 19, 31, 12, 9][frame++ % 5]);
+      motion.advance(time, camera, settings);
+    }
+    const reference = run(60, ['ArrowUp', 'KeyA']);
+    expect(camera.position.distanceTo(reference.position)).toBeLessThan(0.001);
+    expect(1 - Math.abs(camera.quaternion.dot(reference.quaternion))).toBeLessThan(1e-10);
+  });
+
+  it('does not move faster diagonally and keeps height relative to the active floor', () => {
+    const straight = run(60, ['ArrowUp']), diagonal = run(60, ['ArrowUp', 'ArrowRight']);
+    expect(Math.hypot(diagonal.position.x, diagonal.position.z)).toBeCloseTo(-straight.position.z, 8);
+    expect(diagonal.position.y).toBe(585.5);
+  });
+
+  it('bounds catch-up after a long stall and does not integrate duplicate timestamps', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    motion.setKey('ArrowUp', true);
+    motion.advance(0, camera, settings);
+    motion.advance(10_000, camera, settings);
+    expect(-camera.position.z).toBeGreaterThan(0);
+    expect(-camera.position.z).toBeLessThanOrEqual(20);
+    const before = camera.position.clone();
+    motion.advance(10_000, camera, settings);
+    expect(camera.position.equals(before)).toBe(true);
+  });
+
+  it('reset discards held movement, turning, sprint and momentum across a pause', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    ['ArrowUp', 'KeyA', 'ShiftLeft'].forEach(key => motion.setKey(key, true));
+    motion.advance(0, camera, settings); motion.advance(100, camera, settings);
+    const position = camera.position.clone(), rotation = camera.quaternion.clone();
+    motion.reset();
+    motion.advance(60_000, camera, settings); motion.advance(60_100, camera, settings);
+    expect(camera.position.equals(position)).toBe(true);
+    expect(1 - Math.abs(camera.quaternion.dot(rotation))).toBeLessThan(1e-12);
+    motion.setKey('ArrowUp', true);
+    motion.advance(60_200, camera, settings);
+    expect(camera.position.distanceTo(position)).toBeLessThan(4); // walking, not stuck sprint
+  });
+
+  it('releasing one Shift key retains sprint while the other is held', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    ['ArrowUp', 'ShiftLeft', 'ShiftRight'].forEach(key => motion.setKey(key, true));
+    motion.setKey('ShiftLeft', false);
+    motion.advance(0, camera, settings);
+    for (let frame = 1; frame <= 60; frame++) motion.advance(frame * 1000 / 60, camera, settings);
+    expect(camera.position.z).toBeCloseTo(run(60, ['ArrowUp']).position.z * 2, 8);
+  });
+
+  it('turns at two radians per second and clamps pitch without changing eye height', () => {
+    const yaw = new Euler().setFromQuaternion(run(120, ['KeyA']).quaternion, 'YXZ');
+    expect(yaw.y).toBeCloseTo(2, 8);
+    const camera = run(30, ['KeyW']);
+    const pitch = new Euler().setFromQuaternion(camera.quaternion, 'YXZ');
+    expect(pitch.x).toBeCloseTo(Math.PI / 2, 8);
+    expect(camera.position.y).toBe(585.5);
+  });
+});

--- a/tests/walkthrough-motion.test.ts
+++ b/tests/walkthrough-motion.test.ts
@@ -89,6 +89,21 @@ describe('walkthrough cadence', () => {
     expect(camera.position.z).toBeCloseTo(run(60, ['ArrowUp']).position.z * 2, 8);
   });
 
+  it('ignores old key repeats after reset until a fresh press arrives', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    motion.setKey('ArrowUp', true);
+    motion.reset();
+    motion.setKey('ArrowUp', true, true);
+    motion.setKey('KeyA', true, true);
+    motion.advance(0, camera, settings); motion.advance(100, camera, settings);
+    expect(camera.position.z).toBe(0);
+    expect(camera.rotation.y).toBe(0);
+    motion.setKey('ArrowUp', false);
+    motion.setKey('ArrowUp', true);
+    motion.advance(200, camera, settings);
+    expect(camera.position.z).toBeLessThan(-2);
+  });
+
   it('turns at two radians per second and clamps pitch without changing eye height', () => {
     const yaw = new Euler().setFromQuaternion(run(120, ['KeyA']).quaternion, 'YXZ');
     expect(yaw.y).toBeCloseTo(2, 8);


### PR DESCRIPTION
Walkthrough movement, turning and coasting used a fixed 16 ms per animation callback, so the same input traveled different distances at different frame rates. The viewer now integrates elapsed RAF time with consistent velocity decay and short motion substeps while drawing once per callback. It preserves the current speed calibration, horizontal movement and floor-relative eye height, and bounds catch-up after stalls.

Blur, visibility changes and mode transitions clear held keys, momentum and timing. OS key repeats cannot revive input cleared by focus loss. Both Shift keys work independently; releasing Shift outside walkthrough cannot leave sprint enabled next time. Input fields retain arrow-key behavior, and denied pointer lock still permits keyboard navigation.

Validation: the extracted old calculation failed 11 of 14 initial motion regressions. The corrected implementation passes all 607 unit tests, production build and type checking with zero errors and 23 existing warnings. Two browser workflows compare rendered view matrices and canvas changes under controlled 30/60/120 Hz timestamps and exercise pause recovery, fields and mode changes. The existing field-editing regression now waits for its IndexedDB save before reloading, repairing a save/reload timing failure found in CI. All 204 workflows across Chromium/Firefox/WebKit and six rendering benchmarks passed on the final PR commit and merged main without browser retries. Firebase rollout succeeded; production version 1788839033092 passed native Safari walkthrough entry, Escape exit, tab-switch recovery and top-down rendering checks. See the completion comment for run links and measurement limits.

The controlled cadence tests establish motion integration behavior, not physical-display FPS budgets. No Firebase writes, uploads, assets, dependencies or production debug hooks are added. NEXT.md records hardware calibration, stationary walkthrough measurement, physical-device coverage and #30 release/cost gates.

See [the timing report](https://github.com/laanlabs/openPlan3D/blob/main/docs/reviews/2026-09-07-walkthrough-timing.md).

Fixes #77
