### PR TITLE
Stop stationary walkthrough rendering and preserve interaction wakeups

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -1,6 +1,6 @@
 # Next work and pause handoff
 
-Updated September 7, 2026. This is the current backlog for the web app and iPhone
+Updated September 8, 2026. This is the current backlog for the web app and iPhone
 companion. It supersedes the historical “next” sections in the
 [original review and batch log](docs/reviews/2026-09-05-current-state-and-roadmap.md).
 Priorities below are proposed order, not release dates or a claim of complete
@@ -22,7 +22,7 @@ intercepting field editing, and preserves furniture dimensions while replacing
 empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
 and PR checks for final engine results and merge/release status.
 
-Local validation: **607 web unit tests, 53 XCTest tests**, production build and
+Local validation: **614 web unit tests, 53 XCTest tests**, production build and
 audit pass; type checks report zero errors and 23 existing Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
@@ -37,10 +37,18 @@ category continuity; field keyboard editing and browser-engine CI; camera previe
 and 3D resource cleanup; repeatable furnished-home benchmarks and preservation of
 3D views during metadata edits; responsive top-down camera framing; onboarding
 hints that stay within resized viewports; idle 3D animation cleanup measured in
-native Safari; walkthrough timing and held-input recovery. Earlier batches and pause hashes are recorded
+native Safari; walkthrough timing, held-input recovery and stationary rendering cleanup. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
-## 1. Next engineering batch: measured rendering improvements and device coverage
+## 1. Next engineering batch: deployment correctness, then device measurements
+
+The repeated production update notice in [#81](https://github.com/laanlabs/openPlan3D/issues/81)
+is the next focused fix. A likely cause is a stale version JSON response while
+loading the current client. The deployed static server's ETag uses fixed artifact
+modification time and file size, allowing validators to collide across releases.
+Confirm the cached response and fix version checks without weakening immutable
+asset caching or save-before-reload recovery. Add a cross-deployment regression
+with equal-size/equal-mtime version files and verify an already-open Safari tab.
 
 The measured resource batch for [#67](https://github.com/laanlabs/openPlan3D/issues/67)
 repairs blank reopened camera previews, releases renderer contexts and replaced
@@ -88,11 +96,19 @@ compare equal-duration movement/look at 30/60/120 Hz and preserve floor-relative
 eye height. See [the timing report](docs/reviews/2026-09-07-walkthrough-timing.md)
 and PR checks for final browser, native Safari and deployment verification.
 
-Next, measure medium/large fixtures on representative desktop/phone hardware and agree
+The [stationary walkthrough batch (#80)](https://github.com/laanlabs/openPlan3D/issues/80)
+stops frame requests after input/coasting settles and wakes for keyboard, mouse,
+eye-height and scene changes. Native Safari recorded zero callbacks and rendering
+frames in medium/large 25-second stationary samples, down from 1,500 each. See
+[the report and numerical measurements](docs/reviews/2026-09-08-walkthrough-idle.md)
+for provenance, limits and final PR/CI verification.
+
+Next, measure active orbit, stacking and editing on representative desktop/phone hardware and agree
 frame-time and memory targets. Use those results to choose shared geometry,
 object-level visual updates or mobile quality controls. Extend desktop Safari
 checks to actual iPhone/iPad touch devices. The initial small-home native Safari
-calibration is complete; medium/large homes and physical phones remain. Keep category contract
+calibration and initial medium/large stationary walkthrough samples are complete;
+repeated active-navigation measurements and physical phones remain. Keep category contract
 fixtures in both repositories synchronized when extending the catalog.
 
 Legacy saved package projects with chair fallbacks are protected on export and
@@ -147,9 +163,10 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
   Use the new furnished-home benchmarks to agree desktop/phone frame-time and
   memory targets on real hardware. Metadata edits now preserve the scene; visual
   edits still rebuild it. Measure shared geometry, object-level updates and mobile
-  quality settings before choosing the next optimization. Walkthrough still draws
-  continuously; measure its stationary cost before extending idle scheduling to
-  that mode, including mouse look and momentum wakeups.
+  quality settings before choosing the next optimization. Stationary walkthrough
+  now stops drawing after coasting; preserve mouse, keyboard and scene wakeup
+  coverage when changing scheduling. The medium/large stationary Safari samples
+  do not establish active-navigation FPS, memory or battery targets.
 - **Area/geometry agreement:** define whether area is measured at interior wall
   faces or another boundary, reconcile native raster-based areas with web polygons,
   and test room split/merge identity and schedules. Matching area totals are not
@@ -211,7 +228,8 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
 1. Fetch both repositories and confirm clean `main` against `origin/main`; reread
    open GitHub issues and #30 for release updates. Start a focused `codex/…` branch
    from current main after checking the browser batch merge status.
-2. Broaden furnished-home hardware calibration and device coverage. Preserve unknown fields,
+2. Fix the repeated update notice in #81, then broaden furnished-home hardware
+   calibration and device coverage. Preserve unknown fields,
    explicit clears, independent import copies, fractional transforms and pooled
    local attachments. Do not rely on temporary QA directories as source artifacts.
 3. Web baseline: Node 24/npm; run `NODE_ENV=production npm run check`,

--- a/NEXT.md
+++ b/NEXT.md
@@ -166,7 +166,9 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
   quality settings before choosing the next optimization. Stationary walkthrough
   now stops drawing after coasting; preserve mouse, keyboard and scene wakeup
   coverage when changing scheduling. The medium/large stationary Safari samples
-  do not establish active-navigation FPS, memory or battery targets.
+  do not establish active-navigation FPS, memory or battery targets. The 2D
+  canvas retains a separate animation loop that polls its dirty flag; measure
+  its idle cost separately before changing that broader editor lifecycle.
 - **Area/geometry agreement:** define whether area is measured at interior wall
   faces or another boundary, reconcile native raster-based areas with web polygons,
   and test room split/merge identity and schedules. Matching area totals are not

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -470,3 +470,16 @@ tests, with two new browser workflows for controlled cadence, rendered motion,
 pause recovery and field input. See [the timing report](2026-09-07-walkthrough-timing.md)
 for limits and PR validation. Hardware calibration, physical devices, native
 release and the #30 cost gates remain; this batch adds no cloud writes or assets.
+
+## Twenty-seventh batch: stationary walkthrough and larger Safari fixtures
+
+Issue #80 stops walkthrough callbacks after input and coasting settle, wakes on
+fresh keyboard/mouse/field/scene changes, and excludes elapsed idle time on wake.
+Native Safari on M4 Max measured 1,500 callbacks and rendering frames before and
+zero after in matched 25-second stationary medium/large-home intervals. Local
+validation passes 614 unit tests. The browser suite adds idle/wakeup assertions
+and retains cadence, pause and real-frame movement coverage. See
+[the report and sanitized metrics](2026-09-08-walkthrough-idle.md) for measurement
+limits and final PR/CI status. A repeated production update notice with a likely
+cache-validator collision is tracked separately in #81. Active-navigation/device
+budgets, native release and #30 cost gates remain; no cloud writes or assets are added.

--- a/docs/reviews/2026-09-08-walkthrough-idle-metrics.json
+++ b/docs/reviews/2026-09-08-walkthrough-idle-metrics.json
@@ -1,0 +1,194 @@
+{
+  "hardware": {
+    "model": "Mac16,9",
+    "chip": "Apple M4 Max",
+    "cpuCores": 14,
+    "memoryGB": 36,
+    "os": "macOS 26.2 (25C56)",
+    "browser": "Safari 26.2",
+    "thermalWarningRecorded": false,
+    "temperatureMeasured": false
+  },
+  "layout": {
+    "beforeWalkthrough": {
+      "documentCSS": [
+        1324,
+        350
+      ],
+      "canvasCSS": [
+        1324,
+        302
+      ],
+      "dpr": 1
+    },
+    "inspector": "docked below",
+    "pointerLockBannerPresent": true,
+    "lockedViewportMeasured": false
+  },
+  "measurements": [
+    {
+      "phase": "baseline",
+      "size": "medium",
+      "commit": "d7aef95ac8092b21ea14da4f6f89799c445b2872",
+      "recordingSeconds": 84.85,
+      "rangeSeconds": {
+        "from": 10,
+        "to": 35
+      },
+      "renderingFrames": 1500,
+      "animationCallbacks": 1500,
+      "animationRequests": 1500,
+      "frameDurationMs": {
+        "count": 1500,
+        "min": 7.6418,
+        "mean": 16.6437,
+        "p95": 17.4867,
+        "max": 25.9134
+      },
+      "frameStartIntervalMs": {
+        "count": 1499,
+        "min": 7.6631,
+        "mean": 16.6666,
+        "p95": 17.5095,
+        "max": 25.9352
+      },
+      "cpuPercent": {
+        "count": 50,
+        "min": 5.5,
+        "mean": 6.252,
+        "p95": 7.9,
+        "max": 11.9
+      },
+      "memoryMB": {
+        "count": 50,
+        "min": 191.0374,
+        "mean": 193.3171,
+        "p95": 196.5588,
+        "max": 209.4039
+      }
+    },
+    {
+      "phase": "baseline",
+      "size": "large",
+      "commit": "d7aef95ac8092b21ea14da4f6f89799c445b2872",
+      "recordingSeconds": 82.7381,
+      "rangeSeconds": {
+        "from": 10,
+        "to": 35
+      },
+      "renderingFrames": 1500,
+      "animationCallbacks": 1500,
+      "animationRequests": 1500,
+      "frameDurationMs": {
+        "count": 1500,
+        "min": 13.9089,
+        "mean": 16.6434,
+        "p95": 17.5377,
+        "max": 18.7912
+      },
+      "frameStartIntervalMs": {
+        "count": 1499,
+        "min": 13.9275,
+        "mean": 16.6665,
+        "p95": 17.5713,
+        "max": 18.8091
+      },
+      "cpuPercent": {
+        "count": 50,
+        "min": 7.6,
+        "mean": 8.054,
+        "p95": 8.5,
+        "max": 8.6
+      },
+      "memoryMB": {
+        "count": 50,
+        "min": 211.753,
+        "mean": 212.8766,
+        "p95": 213.506,
+        "max": 216.0292
+      }
+    },
+    {
+      "phase": "updated",
+      "size": "medium",
+      "commit": "107ef7e5d74770401f46e5b924f53575aef93d13",
+      "recordingSeconds": 198.2342,
+      "rangeSeconds": {
+        "from": 10,
+        "to": 35
+      },
+      "renderingFrames": 0,
+      "animationCallbacks": 0,
+      "animationRequests": 0,
+      "frameDurationMs": {
+        "count": 0,
+        "min": null,
+        "mean": null,
+        "p95": null,
+        "max": null
+      },
+      "frameStartIntervalMs": {
+        "count": 0,
+        "min": null,
+        "mean": null,
+        "p95": null,
+        "max": null
+      },
+      "cpuPercent": {
+        "count": 50,
+        "min": 0,
+        "mean": 0.028,
+        "p95": 0.1,
+        "max": 1
+      },
+      "memoryMB": {
+        "count": 50,
+        "min": 192.2371,
+        "mean": 193.0851,
+        "p95": 193.941,
+        "max": 197.3325
+      }
+    },
+    {
+      "phase": "updated",
+      "size": "large",
+      "commit": "107ef7e5d74770401f46e5b924f53575aef93d13",
+      "recordingSeconds": 79.3732,
+      "rangeSeconds": {
+        "from": 10,
+        "to": 35
+      },
+      "renderingFrames": 0,
+      "animationCallbacks": 0,
+      "animationRequests": 0,
+      "frameDurationMs": {
+        "count": 0,
+        "min": null,
+        "mean": null,
+        "p95": null,
+        "max": null
+      },
+      "frameStartIntervalMs": {
+        "count": 0,
+        "min": null,
+        "mean": null,
+        "p95": null,
+        "max": null
+      },
+      "cpuPercent": {
+        "count": 50,
+        "min": 0,
+        "mean": 0.006,
+        "p95": 0,
+        "max": 0.2
+      },
+      "memoryMB": {
+        "count": 50,
+        "min": 204.9777,
+        "mean": 205.9653,
+        "p95": 206.9437,
+        "max": 210.1714
+      }
+    }
+  ]
+}

--- a/docs/reviews/2026-09-08-walkthrough-idle.md
+++ b/docs/reviews/2026-09-08-walkthrough-idle.md
@@ -1,0 +1,113 @@
+# Stationary walkthrough rendering
+
+September 8, 2026 · [Issue #80](https://github.com/laanlabs/openPlan3D/issues/80)
+· [PR #82](https://github.com/laanlabs/openPlan3D/pull/82)
+
+## Measured problem and resulting behavior
+
+Walkthrough requested a new frame and rendered the scene on every callback,
+including when the user stood still. Native Safari recorded 1,500 callbacks,
+requests and rendering frames in each 25-second stationary interval with the
+medium and large furnished-home fixtures.
+
+The viewer now schedules frames while movement, keyboard look or coasting is
+active. Once these stop, no frame remains queued. Fresh input starts the clock
+at the input handler's monotonic timestamp, so time spent idle cannot become a
+movement jump. Repeated input during motion does not restart that clock. Shift
+alone and cancelling directions do not create animation demand.
+
+The exponential coasting tail finishes once remaining travel is below 0.001 cm,
+then velocity becomes zero. Straight-line travel includes that last tail rather
+than dropping it. The existing speed calibration, elapsed-time integration,
+independent Shift keys, floor-relative height and blur/repeat recovery remain.
+
+PointerLockControls' change event wakes mouse look; the eye-height range wakes
+on input. Existing dirty-scene paths wake lighting, geometry, textures, camera
+views and resize. Unmount removes the pointer listener and cancels queued work.
+Held look/movement keys still request motion frames; this change targets quiet
+walkthroughs, not every case where the visible camera pose happens to be unchanged.
+
+## Native Safari measurements
+
+[Sanitized numerical measurements](2026-09-08-walkthrough-idle-metrics.json) compare
+deployed main `d7aef95` (public version `1788839033092`) with a local production
+build of implementation commit `107ef7e`. Both use the same deterministic imports
+from `npm run benchmark:fixtures` and the first, unstacked active floor:
+
+| Home | Project floors / furniture | Active-floor furniture | Callbacks, before → after | Rendering frames, before → after | Mean page CPU sample, before → after |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Medium | 2 / 108 | 54 | 1,500 → 0 | 1,500 → 0 | 6.252% → 0.028% |
+| Large | 3 / 288 | 96 | 1,500 → 0 | 1,500 → 0 | 8.054% → 0.006% |
+
+Each range is 10–35 seconds after recording started. The fixture had already
+rendered before recording; walkthrough was entered immediately afterward. No
+input occurred during the measured range. Recording continued through later
+interaction attempts and exit; those later events are excluded from the range.
+
+Hardware: M4 Max Mac Studio (Mac16,9), 14 CPU cores, 36 GB RAM, macOS 26.2 build
+25C56 and Safari 26.2. No thermal/performance warning was recorded by `pmset`;
+actual temperatures were not measured. Inspector was docked below. Before entering
+walkthrough, the document measured 1,324 × 350 CSS pixels, canvas 1,324 × 302,
+DPR 1. Safari's pointer-lock banner was present in all four stationary samples;
+the reduced viewport during lock was not measured separately.
+
+Instruments: Network Requests, Layout & Rendering, JavaScript & Events, CPU and
+Memory. Screenshots, Media & Animations and JavaScript Allocations were disabled.
+Safari also exported rendering-frame records. The raw exports stay outside the
+repository; `tooling/safari-timeline.mjs` extracts numerical aggregates without
+copying requests, cookies, headers, source URLs, stacks or project contents.
+
+These are single samples per size/build with different origins, loading histories
+and fixture order (baseline medium then large; updated large then medium). Other
+desktop apps remained open. Memory instrumentation has overhead; mean page memory
+was 193.32/193.09 MB for medium and 212.88/205.97 MB for large. Those values do not
+establish a memory-saving claim. CPU samples support the idle-work result but are
+not whole-device power or battery measurements. No general FPS budget, active
+navigation performance target or physical-phone result is established here.
+
+A repeated update notice appeared on the baseline production origin despite
+current bootstrap scripts; its likely stale cache-validator cause is tracked in
+[#81](https://github.com/laanlabs/openPlan3D/issues/81). The static notice is another
+reason not to treat the CPU/memory differences as an isolated performance ratio.
+The strict result is eliminated stationary callbacks and rendering frames.
+
+## Functional verification and limits
+
+Local validation passes **614 unit tests**, production build and type checking
+with zero errors and 23 existing warnings. Seven additional motion tests cover
+animation demand, cancelled directions, bounded coasting, fresh wake timing,
+active-clock continuity, early first-frame timestamps and reset behavior. The existing 30/60/120 Hz and uneven
+cadence tests remain unchanged and pass.
+
+The browser suite now has 69 workflows per engine (207 across Chromium, Firefox
+and WebKit), plus six furnished-home benchmarks. The new workflow controls RAF
+and input-clock timestamps at the browser boundary, observes actual WebGL draws
+and rendered matrices/pixels, and asserts silence after entry, Shift alone,
+coasting, mouse look, eye-height changes, lighting, resizing and unmount. It mocks
+browser pointer-lock permission/state and dispatches mouse movement through the
+actual Three controls, without exposing application references or debug hooks.
+The existing real-cadence idle workflow also checks renewed held-key movement.
+
+The first CI run reached the final new-test assertion in Firefox and WebKit:
+it counted the newly mounted 2D canvas's two initial zoom-to-fit callbacks as a
+failure. The corrected check advances those startup frames, then asserts no
+further callbacks or disposed-GPU draws. It retains all earlier 3D silence and
+interaction checks. Chromium also reproduced a dropped wakeup when the first RAF timestamp preceded
+its input handler. A new unit regression first failed, then passed with the fix:
+wait for a frame after the wake time without discarding held input. The controlled
+browser workflow now exercises early/equal first-frame timestamps too. Animation
+callbacks receive a shared timestamp from the browser's rendering update (see the
+[HTML animation-frame algorithm](https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks));
+it is not a fresh clock read at each callback. This follow-up changes first-input
+handling after the recorded stationary measurements. See PR checks for final
+engine and deployment results.
+
+Native Safari verified walkthrough entry and Escape exit during every recording,
+and subsequent top-down rendering of the furnished medium home. Inspector
+instruments and the developer-features toggle were restored after profiling.
+Native automation did not change the locked eye-height slider, so that interaction
+is not claimed as a native pass; the CI keyboard/field test supplies that coverage.
+Physical iPhone/iPad input, active orbit/stacking measurements, repeated hardware
+samples, native distribution and the #30 release/cost gates remain outstanding.
+
+This batch adds no Firebase writes, uploads, catalog assets or dependencies.

--- a/docs/reviews/2026-09-08-walkthrough-idle.md
+++ b/docs/reviews/2026-09-08-walkthrough-idle.md
@@ -88,11 +88,12 @@ browser pointer-lock permission/state and dispatches mouse movement through the
 actual Three controls, without exposing application references or debug hooks.
 The existing real-cadence idle workflow also checks renewed held-key movement.
 
-The first CI run reached the final new-test assertion in Firefox and WebKit:
-it counted the newly mounted 2D canvas's two initial zoom-to-fit callbacks as a
-failure. The corrected check advances those startup frames, then asserts no
-further callbacks or disposed-GPU draws. It retains all earlier 3D silence and
-interaction checks. Chromium also reproduced a dropped wakeup when the first RAF timestamp preceded
+The initial CI runs reached the final new-test teardown assertion: they counted
+the newly mounted 2D canvas's startup callbacks and its separate animation loop
+as 3D work. The corrected check queues a viewer redraw, verifies cancellation
+of that exact request on unmount, and confirms no additional draws on the disposed
+WebGL context while 2D runs. All earlier 3D silence and interaction checks remain.
+Chromium also reproduced a dropped wakeup when the first RAF timestamp preceded
 its input handler. A new unit regression first failed, then passed with the fix:
 wait for a frame after the wake time without discarding held input. The controlled
 browser workflow now exercises early/equal first-frame timestamps too. Animation

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -663,11 +663,22 @@
     if (event.code === 'Escape') { exitWalkthroughMode(); return; }
     if (event.defaultPrevented || event.isComposing || event.ctrlKey || event.metaKey || event.altKey
       || isWalkthroughField(event.target)) return;
-    if (walkthroughMotion.setKey(event.code, true, event.repeat)) event.preventDefault();
+    if (walkthroughMotion.setKey(event.code, true, event.repeat)) {
+      event.preventDefault();
+      wakeWalkthrough();
+    }
   }
 
   function onKeyUp(event: KeyboardEvent) {
     walkthroughMotion.setKey(event.code, false);
+    wakeWalkthrough();
+  }
+
+  function wakeWalkthrough() {
+    if (walkthroughMode && walkthroughMotion.active) {
+      walkthroughMotion.startClock(performance.now());
+      requestRender();
+    }
   }
 
   function resetWalkthroughInput() {
@@ -919,6 +930,7 @@
 
     // Initialize PointerLock controls for walkthrough mode
     pointerControls = new PointerLockControls(camera, renderer.domElement);
+    pointerControls.addEventListener('change', markSceneDirty);
 
     // Keyboard event listeners for walkthrough
     document.addEventListener('keydown', onKeyDown, false);
@@ -1936,10 +1948,14 @@
     animId = undefined;
 
     if (walkthroughMode) {
+      const moving = walkthroughMotion.active;
       walkthroughMotion.advance(timestamp, camera, { moveSpeed, sprintSpeed, eyeHeight, floorElevation: activeFloorElevation });
-      // Always render in walkthrough mode (camera constantly moving)
-      renderer.render(scene, camera);
-      requestRender();
+      if (sceneDirty || moving) {
+        sceneDirty = false;
+        renderer.render(scene, camera);
+      }
+      if (walkthroughMotion.active) requestRender();
+      else walkthroughMotion.stopClock();
     } else {
       // A change event schedules the next damping step. Once the controls settle,
       // leave no callback queued until an interaction or scene update wakes us.
@@ -2032,6 +2048,7 @@
       sunLight.shadow.dispose();
       clearGroup(scene);
       wallMeshMap.clear();
+      pointerControls.removeEventListener('change', markSceneDirty);
       pointerControls.dispose();
       controls.dispose();
       releaseRenderer(renderer);
@@ -2376,7 +2393,7 @@
       <label class="flex items-center justify-between gap-2">
         <span class="text-white/70">Eye Height</span>
         <div class="flex items-center gap-1">
-          <input type="range" min="80" max="220" bind:value={eyeHeight} class="w-16 h-1 accent-blue-400" />
+          <input type="range" min="80" max="220" bind:value={eyeHeight} oninput={markSceneDirty} class="w-16 h-1 accent-blue-400" />
           <span class="w-10 text-right">{eyeHeight}cm</span>
         </div>
       </label>

--- a/src/lib/utils/walkthroughMotion.ts
+++ b/src/lib/utils/walkthroughMotion.ts
@@ -14,6 +14,7 @@ export interface WalkthroughSettings {
 export class WalkthroughMotion {
   private held = new Set<string>();
   private previous: number | null = null;
+  private waitingForFirstFrame = false;
   private rightVelocity = 0;
   private forwardVelocity = 0;
   private rotation = new Euler(0, 0, 0, 'YXZ');
@@ -27,10 +28,13 @@ export class WalkthroughMotion {
 
   /** Wake from the input event's clock, without counting the preceding idle time. */
   startClock(timestamp: number) {
-    if (this.previous === null && Number.isFinite(timestamp)) this.previous = timestamp;
+    if (this.previous === null && Number.isFinite(timestamp)) {
+      this.previous = timestamp;
+      this.waitingForFirstFrame = true;
+    }
   }
 
-  stopClock() { this.previous = null; }
+  stopClock() { this.previous = null; this.waitingForFirstFrame = false; }
 
   setKey(code: string, down: boolean, repeat = false) {
     if (!keys.has(code)) return false;
@@ -44,7 +48,7 @@ export class WalkthroughMotion {
 
   reset() {
     this.held.clear();
-    this.previous = null;
+    this.stopClock();
     this.rightVelocity = this.forwardVelocity = 0;
   }
 
@@ -53,9 +57,12 @@ export class WalkthroughMotion {
     if (!Number.isFinite(timestamp)) { this.reset(); return; }
     if (this.previous === null) { this.previous = timestamp; return; }
     if (timestamp <= this.previous) {
-      if (timestamp < this.previous) this.reset();
+      // RAF's shared frame timestamp can precede an input handler within that
+      // frame. Keep its keys and wait for a frame after the wakeup time.
+      if (timestamp < this.previous && !this.waitingForFirstFrame) this.reset();
       return;
     }
+    this.waitingForFirstFrame = false;
     // A delayed frame must not teleport through the plan. Blur/visibility resets
     // separately discard all held input, momentum and elapsed background time.
     const delta = Math.min((timestamp - this.previous) / 1000, 0.25);

--- a/src/lib/utils/walkthroughMotion.ts
+++ b/src/lib/utils/walkthroughMotion.ts
@@ -18,6 +18,20 @@ export class WalkthroughMotion {
   private forwardVelocity = 0;
   private rotation = new Euler(0, 0, 0, 'YXZ');
 
+  get active() {
+    const held = (code: string) => Number(this.held.has(code));
+    return Boolean(this.rightVelocity || this.forwardVelocity
+      || held('ArrowRight') !== held('ArrowLeft') || held('ArrowUp') !== held('ArrowDown')
+      || held('KeyA') !== held('KeyD') || held('KeyW') !== held('KeyS'));
+  }
+
+  /** Wake from the input event's clock, without counting the preceding idle time. */
+  startClock(timestamp: number) {
+    if (this.previous === null && Number.isFinite(timestamp)) this.previous = timestamp;
+  }
+
+  stopClock() { this.previous = null; }
+
   setKey(code: string, down: boolean, repeat = false) {
     if (!keys.has(code)) return false;
     // An OS repeat after returning to the page must not revive a key that blur
@@ -78,6 +92,14 @@ export class WalkthroughMotion {
       camera.position.z -= Math.sin(yaw) * rightDistance + Math.cos(yaw) * forwardDistance;
       this.rotation.y += yawSpeed * step;
       this.rotation.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, this.rotation.x + pitchSpeed * step));
+    }
+    // Finish the sub-pixel coasting tail rather than drawing forever as the
+    // exponential approaches zero. Remaining travel is at most 0.001 cm.
+    if (!right && !forward && Math.hypot(this.rightVelocity, this.forwardVelocity) < 0.01) {
+      const yaw = this.rotation.y;
+      camera.position.x += (Math.cos(yaw) * this.rightVelocity - Math.sin(yaw) * this.forwardVelocity) / 10;
+      camera.position.z -= (Math.sin(yaw) * this.rightVelocity + Math.cos(yaw) * this.forwardVelocity) / 10;
+      this.rightVelocity = this.forwardVelocity = 0;
     }
     camera.quaternion.setFromEuler(this.rotation);
   }

--- a/tests/browser/viewer-idle.spec.ts
+++ b/tests/browser/viewer-idle.spec.ts
@@ -96,7 +96,7 @@ test('3D sleeps when idle and wakes for controls, scene changes and walkthrough'
   await page.evaluate(() => { HTMLCanvasElement.prototype.requestPointerLock = () => Promise.reject(new DOMException('Denied', 'NotAllowedError')); });
   await page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true }).click();
   await expect(page.getByText('Walkthrough Controls', { exact: true })).toBeVisible();
-  await expect.poll(async () => (await gpu(page))[0].draws).toBeGreaterThan((await gpu(page))[0].draws);
+  await idle();
   before = await pixels();
   await page.keyboard.down('ArrowUp');
   try {

--- a/tests/browser/walkthrough.spec.ts
+++ b/tests/browser/walkthrough.spec.ts
@@ -18,6 +18,7 @@ async function openWalkthrough(page: Page, pointerLock = false) {
       view: null,
       fired: 0,
       pending: () => queued.size,
+      pendingIds: () => [...queued.keys()],
       ready: () => normal.size === 0,
       start: () => { if (normal.size) throw new Error('Wait for orbit to settle'); manual = true; },
       step: (delta: number, frames: number) => {
@@ -221,10 +222,18 @@ test('stationary walkthrough sleeps and wakes for movement, mouse look, fields a
   await step(page, 16, 1);
   expect((await gpu(page))[0].draws).toBeGreaterThan(draws);
   await idle();
+
+  // Unmount with a viewer frame queued, then verify that exact request is
+  // cancelled. The 2D canvas has its own animation loop after it mounts.
+  await page.evaluate(() => document.dispatchEvent(new MouseEvent('mousemove', { movementX: 10 })));
+  const viewerFrames: number[] = await page.evaluate(() => (window as any).__walkAudit.pendingIds());
+  expect(viewerFrames).toHaveLength(1);
   await page.getByRole('button', { name: '2D', exact: true }).click();
   expect((await gpu(page))[0].lost).toBe(true);
-  // The newly mounted 2D canvas schedules its own initial zoom-to-fit frames.
-  // Flush those, then require global silence and no further disposed-GPU draws.
-  await idle();
+  const remaining: number[] = await page.evaluate(() => (window as any).__walkAudit.pendingIds());
+  expect(remaining.filter(id => viewerFrames.includes(id))).toEqual([]);
+  const disposedDraws = (await gpu(page))[0].draws;
+  await step(page, 250, 8);
+  expect((await gpu(page))[0].draws).toBe(disposedDraws);
   expect(errors).toEqual([]);
 });

--- a/tests/browser/walkthrough.spec.ts
+++ b/tests/browser/walkthrough.spec.ts
@@ -2,18 +2,22 @@ import { test, expect, type Page } from '@playwright/test';
 import { resolve } from 'node:path';
 import { Matrix4, Vector3 } from 'three';
 import { createHash } from 'node:crypto';
+import { observeGPU, gpu } from './gpu';
 
 test.use({ viewport: { width: 844, height: 480 } });
 
-async function openWalkthrough(page: Page) {
+async function openWalkthrough(page: Page, pointerLock = false) {
   // CI-only control of RAF timestamps and observation of WebGL's view uniform.
   // No camera references, application internals or production debug hooks.
-  await page.addInitScript(() => {
+  await page.addInitScript(pointerLock => {
     const request = window.requestAnimationFrame.bind(window), cancel = window.cancelAnimationFrame.bind(window);
+    const realNow = performance.now.bind(performance);
     const normal = new Set<number>(), queued = new Map<number, FrameRequestCallback>();
     let manual = false, now = 0, next = -1;
     const audit: any = {
       view: null,
+      fired: 0,
+      pending: () => queued.size,
       ready: () => normal.size === 0,
       start: () => { if (normal.size) throw new Error('Wait for orbit to settle'); manual = true; },
       step: (delta: number, frames: number) => {
@@ -22,6 +26,7 @@ async function openWalkthrough(page: Page) {
           const callbacks = [...queued];
           for (const [id, callback] of callbacks) {
             if (!queued.delete(id)) continue;
+            audit.fired++;
             callback(now);
           }
         }
@@ -29,6 +34,8 @@ async function openWalkthrough(page: Page) {
       },
     };
     (window as any).__walkAudit = audit;
+    // Input wakeups use the same monotonic clock as the controlled RAF callbacks.
+    Object.defineProperty(performance, 'now', { value: () => manual ? now : realNow() });
     window.requestAnimationFrame = callback => {
       if (manual) { const id = next--; queued.set(id, callback); return id; }
       const id = request(time => { normal.delete(id); callback(time); });
@@ -53,8 +60,17 @@ async function openWalkthrough(page: Page) {
       };
       return gl;
     } as typeof getContext;
-    HTMLCanvasElement.prototype.requestPointerLock = () => Promise.reject(new DOMException('Denied', 'NotAllowedError'));
-  });
+    if (pointerLock) {
+      // Simulate browser lock permission/state, keeping the actual Three controls
+      // and their mouse event/change path. No application references are exposed.
+      let locked: HTMLCanvasElement | null = null;
+      Object.defineProperty(document, 'pointerLockElement', { get: () => locked });
+      HTMLCanvasElement.prototype.requestPointerLock = function () {
+        locked = this; document.dispatchEvent(new Event('pointerlockchange')); return Promise.resolve();
+      };
+      document.exitPointerLock = () => { locked = null; document.dispatchEvent(new Event('pointerlockchange')); };
+    } else HTMLCanvasElement.prototype.requestPointerLock = () => Promise.reject(new DOMException('Denied', 'NotAllowedError'));
+  }, pointerLock);
   await page.goto('/editor');
   await page.getByRole('button', { name: 'Export', exact: true }).click();
   const chooser = page.waitForEvent('filechooser');
@@ -137,4 +153,73 @@ test('walkthrough clears held input on pause and exit and lets fields handle arr
   const walked = position(await step(page));
   await page.keyboard.up('ArrowUp');
   expect(walked.distanceTo(initial)).toBeCloseTo(24.146525, 3);
+});
+
+test('stationary walkthrough sleeps and wakes for movement, mouse look, fields and scene changes', async ({ page }) => {
+  test.setTimeout(120_000);
+  const errors: string[] = []; page.on('pageerror', error => errors.push(error.message));
+  await observeGPU(page);
+  await openWalkthrough(page, true);
+  const audit = () => page.evaluate(() => {
+    const state = (window as any).__walkAudit;
+    return { pending: state.pending(), fired: state.fired };
+  });
+  const idle = async () => {
+    // Two seconds of motion time clears coasting without waiting on a CI GPU's
+    // real cadence. Once settled, even a minute must cause no callbacks/draws.
+    await step(page, 250, 8);
+    const before = await audit(), draws = (await gpu(page))[0].draws;
+    expect(before.pending).toBe(0);
+    await step(page, 1000, 60);
+    expect(await audit()).toEqual(before);
+    expect((await gpu(page))[0].draws).toBe(draws);
+  };
+  const initial = position(await enter(page));
+  await idle();
+  await page.keyboard.down('ShiftRight'); await idle(); // sprint alone is stationary
+  await page.keyboard.up('ShiftRight');
+  await page.keyboard.down('ArrowUp');
+  const moved = position(await step(page, 100, 4));
+  expect(moved.distanceTo(initial)).toBeCloseTo(24.146525, 3); // no idle-time jump
+  await page.keyboard.up('ArrowUp');
+  const coasting = position(await step(page, 100, 1));
+  expect(coasting.distanceTo(moved)).toBeGreaterThan(1);
+  await idle();
+
+  let before = await pixels(page);
+  await page.evaluate(() => document.dispatchEvent(new MouseEvent('mousemove', { movementX: 180, movementY: 45 })));
+  await step(page, 16, 1);
+  expect(await pixels(page)).not.toBe(before);
+  await idle();
+
+  const field = page.getByRole('slider', { name: /Eye Height/ });
+  const height = Number(await field.inputValue()), beforeHeight = position(await step(page));
+  await field.focus(); await page.keyboard.press('ArrowUp');
+  await expect(field).toHaveValue(String(height + 1));
+  const afterHeight = position(await step(page, 16, 1));
+  expect(afterHeight.y - beforeHeight.y).toBeCloseTo(1, 4);
+  expect(afterHeight.x).toBeCloseTo(beforeHeight.x, 4);
+  expect(afterHeight.z).toBeCloseTo(beforeHeight.z, 4);
+  await idle();
+
+  before = await pixels(page);
+  // Keyboard activation avoids moving the locked mouse while testing lighting.
+  await page.getByRole('button', { name: 'Lighting Controls', exact: true }).press('Enter');
+  await page.getByRole('button', { name: /night/i }).press('Enter');
+  await step(page, 16, 1);
+  expect(await pixels(page)).not.toBe(before);
+  await idle();
+  await page.getByRole('button', { name: 'Lighting Controls', exact: true }).press('Enter');
+
+  const draws = (await gpu(page))[0].draws;
+  await page.setViewportSize({ width: 780, height: 480 });
+  // ResizeObserver delivery is asynchronous even though RAF time is controlled.
+  await expect.poll(async () => (await audit()).pending).toBeGreaterThan(0);
+  await step(page, 16, 1);
+  expect((await gpu(page))[0].draws).toBeGreaterThan(draws);
+  await idle();
+  await page.getByRole('button', { name: '2D', exact: true }).click();
+  expect((await gpu(page))[0].lost).toBe(true);
+  expect((await audit()).pending).toBe(0);
+  expect(errors).toEqual([]);
 });

--- a/tests/browser/walkthrough.spec.ts
+++ b/tests/browser/walkthrough.spec.ts
@@ -179,6 +179,9 @@ test('stationary walkthrough sleeps and wakes for movement, mouse look, fields a
   await page.keyboard.down('ShiftRight'); await idle(); // sprint alone is stationary
   await page.keyboard.up('ShiftRight');
   await page.keyboard.down('ArrowUp');
+  // The first callback's shared timestamp may be older than the input handler.
+  // Neither an early nor equal-time callback may discard the fresh held key.
+  await step(page, -1, 1); await step(page, 1, 1);
   const moved = position(await step(page, 100, 4));
   expect(moved.distanceTo(initial)).toBeCloseTo(24.146525, 3); // no idle-time jump
   await page.keyboard.up('ArrowUp');
@@ -220,6 +223,8 @@ test('stationary walkthrough sleeps and wakes for movement, mouse look, fields a
   await idle();
   await page.getByRole('button', { name: '2D', exact: true }).click();
   expect((await gpu(page))[0].lost).toBe(true);
-  expect((await audit()).pending).toBe(0);
+  // The newly mounted 2D canvas schedules its own initial zoom-to-fit frames.
+  // Flush those, then require global silence and no further disposed-GPU draws.
+  await idle();
   expect(errors).toEqual([]);
 });

--- a/tests/walkthrough-motion.test.ts
+++ b/tests/walkthrough-motion.test.ts
@@ -58,6 +58,21 @@ describe('walkthrough cadence', () => {
     expect(-camera.position.z).toBeCloseTo(9.0826823, 6);
   });
 
+  it('keeps fresh input when the first RAF timestamp precedes its event handler', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    motion.setKey('ArrowUp', true); motion.startClock(100);
+    // RAF carries the frame's start time; input can arrive later in that frame.
+    motion.advance(96, camera, settings);
+    expect(motion.active).toBe(true);
+    expect(camera.position.z).toBe(0);
+    motion.advance(116, camera, settings);
+    expect(-camera.position.z).toBeCloseTo(80 * (0.016 + Math.expm1(-0.16) / 10), 10);
+    expect(motion.active).toBe(true);
+    // A genuinely backwards timestamp after animation starts still resets input.
+    motion.advance(110, camera, settings);
+    expect(motion.active).toBe(false);
+  });
+
   it('stops keyboard look immediately on release without inventing look momentum', () => {
     const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
     motion.setKey('KeyA', true); motion.startClock(0);

--- a/tests/walkthrough-motion.test.ts
+++ b/tests/walkthrough-motion.test.ts
@@ -16,6 +16,70 @@ function run(hz: number, keys: string[], coast = false) {
 }
 
 describe('walkthrough cadence', () => {
+  it('stays inactive for sprint alone and opposing input, then wakes when one direction is released', () => {
+    const motion = new WalkthroughMotion();
+    expect(motion.active).toBe(false);
+    motion.setKey('ShiftLeft', true);
+    expect(motion.active).toBe(false);
+    for (const key of ['ArrowUp', 'ArrowDown', 'KeyA', 'KeyD']) motion.setKey(key, true);
+    expect(motion.active).toBe(false);
+    motion.setKey('ArrowDown', false);
+    expect(motion.active).toBe(true);
+  });
+
+  it('finishes coasting within two seconds while preserving the full straight-line travel', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    motion.setKey('ArrowUp', true);
+    motion.advance(0, camera, settings); motion.advance(250, camera, settings);
+    motion.setKey('ArrowUp', false);
+    expect(motion.active).toBe(true);
+    for (let time = 500; time <= 2250; time += 250) motion.advance(time, camera, settings);
+    expect(motion.active).toBe(false);
+    expect(-camera.position.z).toBeCloseTo(20, 9); // acceleration impulse / drag
+    const settled = camera.position.clone();
+    motion.advance(2500, camera, settings);
+    expect(camera.position.equals(settled)).toBe(true);
+  });
+
+  it('wakes from the fresh input timestamp without integrating time spent stationary', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    motion.advance(0, camera, settings); motion.stopClock();
+    motion.setKey('ArrowUp', true); motion.startClock(60_000);
+    motion.advance(60_100, camera, settings);
+    expect(-camera.position.z).toBeCloseTo(2.9430355, 6);
+  });
+
+  it('does not restart an active clock when another input or key repeat arrives', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    motion.setKey('ArrowUp', true); motion.startClock(0);
+    motion.advance(100, camera, settings);
+    motion.setKey('ArrowUp', true, true); motion.startClock(150);
+    motion.advance(200, camera, settings);
+    expect(-camera.position.z).toBeCloseTo(9.0826823, 6);
+  });
+
+  it('stops keyboard look immediately on release without inventing look momentum', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    motion.setKey('KeyA', true); motion.startClock(0);
+    motion.advance(100, camera, settings);
+    expect(motion.active).toBe(true);
+    motion.setKey('KeyA', false);
+    expect(motion.active).toBe(false);
+    const rotation = camera.quaternion.clone();
+    motion.stopClock(); motion.advance(60_000, camera, settings);
+    expect(camera.quaternion.equals(rotation)).toBe(true);
+  });
+
+  it('reset drops all animation demand and ignores repeats after focus loss', () => {
+    const motion = new WalkthroughMotion(), camera = new PerspectiveCamera();
+    motion.setKey('ArrowUp', true); motion.startClock(0);
+    motion.advance(100, camera, settings); motion.reset();
+    motion.setKey('ArrowUp', true, true);
+    expect(motion.active).toBe(false);
+    motion.setKey('ArrowUp', false); motion.setKey('ArrowUp', true);
+    expect(motion.active).toBe(true);
+  });
+
   for (const [name, keys, coast] of [
     ['walking', ['ArrowUp'], false],
     ['diagonal sprint', ['ArrowUp', 'ArrowRight', 'ShiftLeft'], false],


### PR DESCRIPTION
Walkthrough rendered continuously while standing still. Native Safari recorded 1,500 callbacks and rendering frames per 25-second stationary interval in both medium and large furnished homes. The viewer now stops requesting frames after input and coasting settle, and wakes for keyboard input, pointer-lock mouse changes, eye-height changes and existing scene/resize updates.

Wakeups start from the fresh input timestamp, so idle time does not become movement time. The established pace, blur/repeat recovery and field behavior remain. Coasting finishes its final travel below 0.001 cm and stops instead of approaching zero indefinitely.

Local checks pass 614 unit tests, production build and type checking (zero errors, 23 existing warnings). Cross-engine CI adds a workflow checking callback/draw silence and wakeups through the actual viewer and Three controls, using controlled browser timestamps and simulated pointer-lock permission. Existing real-cadence and 30/60/120 Hz regressions remain. Native Safari now records zero callbacks, requests and rendering frames in matched 25-second medium and large stationary intervals. [The report and sanitized metrics](https://github.com/laanlabs/openPlan3D/blob/main/docs/reviews/2026-09-08-walkthrough-idle.md) record provenance and measurement limits.

Initial CI found an early first-frame timestamp could discard fresh input in Chromium; a failing unit regression and controlled browser case now cover the correction. The teardown test verifies cancellation of the queued viewer request and no disposed-GPU draws while 2D runs its separate animation loop. Final PR checks passed 614 unit tests, all 207 browser workflows and six rendering benchmarks, with no browser retries. Merged main passed the same full checks without retries. Firebase rollout succeeded, and production version 1788843198720 passed native Safari floor-stacking, walkthrough entry/exit, tab-switch recovery and top-down smoke checks. See the completion comment for run links.

No Firebase writes, uploads, dependencies or assets are added. Physical phone testing, broader performance budgets and #30 release/cost gates remain open. A repeated production update notice found during measurement is tracked separately in #81.

Fixes #80
