### PR TITLE
Prevent stale cached versions from repeating deployment notices

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -22,7 +22,7 @@ intercepting field editing, and preserves furniture dimensions while replacing
 empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
 and PR checks for final engine results and merge/release status.
 
-Local validation: **614 web unit tests, 53 XCTest tests**, production build and
+Local validation: **626 web unit tests, 53 XCTest tests**, production build and
 audit pass; type checks report zero errors and 23 existing Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
@@ -40,15 +40,16 @@ hints that stay within resized viewports; idle 3D animation cleanup measured in
 native Safari; walkthrough timing, held-input recovery and stationary rendering cleanup. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
-## 1. Next engineering batch: deployment correctness, then device measurements
+## 1. Next engineering batch: device measurements and measured editor work
 
-The repeated production update notice in [#81](https://github.com/laanlabs/openPlan3D/issues/81)
-is the next focused fix. A likely cause is a stale version JSON response while
-loading the current client. The deployed static server's ETag uses fixed artifact
-modification time and file size, allowing validators to collide across releases.
-Confirm the cached response and fix version checks without weakening immutable
-asset caching or save-before-reload recovery. Add a cross-deployment regression
-with equal-size/equal-mtime version files and verify an already-open Safari tab.
+The deployment check for [#81](https://github.com/laanlabs/openPlan3D/issues/81)
+bypasses stale size/mtime validators when reading the version file. Native Safari
+confirmed the stale cached response and the fixed editor's unconditional request.
+The same polling limits, immutable asset caching and save-before-reload recovery
+remain. Real HTTP-cache regressions cover equal-size version replacements and
+recovery. See [the report](docs/reviews/2026-09-08-deployment-version-cache.md) and
+[#83](https://github.com/laanlabs/openPlan3D/pull/83) for final CI, native Safari
+and deployment verification.
 
 The measured resource batch for [#67](https://github.com/laanlabs/openPlan3D/issues/67)
 repairs blank reopened camera previews, releases renderer contexts and replaced
@@ -230,8 +231,8 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
 1. Fetch both repositories and confirm clean `main` against `origin/main`; reread
    open GitHub issues and #30 for release updates. Start a focused `codex/…` branch
    from current main after checking the browser batch merge status.
-2. Fix the repeated update notice in #81, then broaden furnished-home hardware
-   calibration and device coverage. Preserve unknown fields,
+2. Broaden furnished-home hardware calibration and device coverage; measure the
+   2D dirty-flag polling loop before selecting another idle optimization. Preserve unknown fields,
    explicit clears, independent import copies, fractional transforms and pooled
    local attachments. Do not rely on temporary QA directories as source artifacts.
 3. Web baseline: Node 24/npm; run `NODE_ENV=production npm run check`,

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -483,3 +483,15 @@ and retains cadence, pause and real-frame movement coverage. See
 limits and final PR/CI status. A repeated production update notice with a likely
 cache-validator collision is tracked separately in #81. Active-navigation/device
 budgets, native release and #30 cost gates remain; no cloud writes or assets are added.
+
+## Twenty-eighth batch: deployment version cache correctness
+
+Issue #81 reproduces Safari retaining old version JSON after a colliding
+size/mtime validator and moves the app's notice to a bounded no-store check.
+Polling frequency, immutable assets, local save/reload and recovery behavior stay
+intact. Local validation passes 626 unit tests; three new browser workflows use a
+real HTTP-cache fixture and exercise save failures, navigation and offline retries.
+See [the cache report](2026-09-08-deployment-version-cache.md) and PR #83 for native
+Safari, final CI and deployment verification. The remaining work is measured
+hardware/device coverage and the native release/Firebase gates in #30. This batch
+adds no cloud writes, endpoints, assets or dependencies.

--- a/docs/reviews/2026-09-08-deployment-version-cache.md
+++ b/docs/reviews/2026-09-08-deployment-version-cache.md
@@ -1,0 +1,82 @@
+# Deployment version cache correction
+
+Issue [#81](https://github.com/laanlabs/openPlan3D/issues/81), PR
+[#83](https://github.com/laanlabs/openPlan3D/pull/83).
+
+## Reproduced failure
+
+Native Safari previously displayed version `1788831576589` from a normal navigation
+while an unconditional HTTP request and the loaded editor's bootstrap matched
+`1788839033092`. The deployed version response carried a fixed 1980 Last-Modified
+value and an ETag calculated from the served file's size and modification time.
+The adapter-node static middleware runs before SvelteKit request handlers and
+uses sirv's size/mtime validators. Equal-sized representations can therefore
+collide across releases. Sizes can differ between deployments (including served
+compressed files); this does not happen on every release.
+
+The regression server serves two different, equal-byte-length, uncompressed
+version responses with the same ETag and Last-Modified. It proxies the actual
+production build for all other paths. It intentionally returns 304 to matching
+validators, even when the request includes no-cache headers. Playwright routing
+is absent so browser HTTP caching stays enabled.
+
+## Change
+
+The app's deployment notice compares `$app/environment.version` with a
+`cache: 'no-store'` request to the existing version file. A no-cache request can
+conditionally reuse a cached representation; no-store bypasses that browser
+cache lookup. See [Fetch cache modes](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)
+and [SvelteKit's embedded version](https://svelte.dev/docs/kit/$app-environment).
+Only a successful response containing a nonblank string version can announce an
+update. Requests time out after ten seconds; network, HTTP and JSON errors remain
+quiet and eligible for a later retry.
+
+The component retains its five-minute visible-page interval and one-minute
+focus/visibility throttle, permits only one in-flight check, and stops checking
+after detection. Development mode does not poll. The notice and its navigation
+guard share the confirmed update flag; a stale framework `updated` flag cannot
+independently recreate the banner. Framework internal failed-navigation recovery
+is unchanged. Direct navigation to version.json can still show a cached body;
+this patch makes the app's own update checks independent of those validators.
+
+Save-before-reload, local JSON recovery and destination navigation remain in
+place. No global fetch override, additional endpoint, asset cache-policy change,
+cache clearing or user-data migration is involved. Existing hashed assets retain
+their one-year immutable caching. Request frequency does not increase, and this
+adds no Firebase Storage objects, database, sync, analytics or cloud writes.
+
+## Validation
+
+- 626 unit tests pass (12 new deployment-response cases plus existing save guards).
+- Svelte check: zero errors, 23 existing warnings. Production build passes.
+- Three new browser workflows cover the actual cached 304 control, a quiet
+  current-version check, later same-size update detection, polling cessation,
+  save/reload persistence with the stale cache retained, immutable asset headers,
+  failed writes and JSON backup, deferred navigation, HTTP/offline errors and
+  recovery. These join the existing workflows in Chromium, Firefox and WebKit.
+- Native Safari and final CI/deployment results are recorded below and in the PR.
+- Native iOS sources are unchanged; the existing 53-test baseline was not rerun
+  for this web-only batch. Physical iPhone and release gates remain in #30.
+
+### Native Safari cache fixture
+
+Safari 26.2 on macOS 26.2, M4 Max Mac Studio, September 8, 2026. No Inspector,
+cache clearing, application instrumentation or browser clock overrides were used.
+The server proxied the local production build and changed only the version
+response. Real focus/visibility checks ran after the existing one-minute throttle.
+
+| Step | Version/body and server observation | Editor result |
+| --- | --- | --- |
+| Cache previous response | `1788853465361` | Version JSON opened normally |
+| Serve current response, open JSON in another tab | Current is `1788853465360`; browser sends both `W/"27-315532801000"` and the 1980 date; server returns 304; Safari still displays `1788853465361` | Reproduced stale body |
+| Open fixed editor with that cache retained | 200, neither conditional validator sent | No false notice |
+| Change served version to `1788853465361` | 200, neither validator sent | Update notice appears |
+| Restore served version to current and use Save and reload | Existing local project reopens | `Safari deployment cache recovery` name retained |
+| Focus reloaded editor after throttle | 200, neither validator sent | No repeated notice |
+
+The local fixture simulates a version switch while serving one production build;
+it does not claim to deploy two different app bundles. Final production verification
+uses an editor opened before the actual GitHub/App Hosting rollout. See the PR's
+completion comment for final deployment and full CI evidence. Automated tests
+separately verify that an unsaved revision is persisted by the reload action and
+that failed writes prevent reload and retain JSON recovery.

--- a/docs/reviews/2026-09-08-deployment-version-cache.md
+++ b/docs/reviews/2026-09-08-deployment-version-cache.md
@@ -81,20 +81,23 @@ completion comment for final deployment and full CI evidence. Automated tests
 separately verify that an unsaved revision is persisted by the reload action and
 that failed writes prevent reload and retain JSON recovery.
 
-### Regression setup correction
+### Engine-specific cache controls
 
-The first CI run passed all Firefox workflows but found that Chromium and WebKit
-fetches did not reuse the version JSON's document-navigation cache entry in this
-setup. The test now explicitly primes the fetch cache with a reload-mode fetch
-from the same app origin before changing the server response. It still requires
-an actual stale body and 304 from the original no-cache-header check before it
-accepts the fixed checker. No routing, fetch mock, skipped engine or weakened
-cache assertion was introduced. The intermediate run with that known setup issue
-was cancelled; final checks run against the corrected commit.
+The cache fixture explicitly seeds the fetch cache with reload mode. Its positive
+control then uses `cache: 'no-cache'` and requires a stale body and an actual 304
+before the application check can pass. Header-only requests are not a portable
+positive control: direct interaction with a separate local HTTP harness in the
+in-app Chromium browser returned fresh data without validators for those headers,
+but explicit no-cache mode reproduced a stale conditional response. No-store mode
+then returned the new body without a validator. This explains why early CI runs
+could not prove the cache was warm in Chromium/WebKit using the header-only control.
+The native Safari document-navigation reproduction remains separate evidence.
 
-The next run reached the reload assertion but exposed a fixture initialization
-issue: visiting the home page first set the onboarding flag that had also guarded
-project seeding. The fixture now seeds before the first app navigation, uses its
-own one-time marker, and asserts the intended project is open. This preserves the
-unsaved-revision assertion instead of allowing the app's fallback blank project
-to stand in for the fixture. Application code was unchanged by these test fixes.
+No browser routing, mocked fetch, skipped engine or weakened stale-body/304
+assertion is used. The project fixture initializes before any app navigation,
+uses its own one-time marker, and asserts the intended project is open. The reload
+check also asserts the edited revision is still unsaved before the action. An
+initial onboarding-flag seed guard allowed a fallback blank project after visiting
+the home page; the explicit initialization corrects that test setup. Application
+code was unchanged by these test fixes. See PR checks for final results; known
+intermediate failures/cancelled runs are not counted as successful validation.

--- a/docs/reviews/2026-09-08-deployment-version-cache.md
+++ b/docs/reviews/2026-09-08-deployment-version-cache.md
@@ -91,3 +91,10 @@ an actual stale body and 304 from the original no-cache-header check before it
 accepts the fixed checker. No routing, fetch mock, skipped engine or weakened
 cache assertion was introduced. The intermediate run with that known setup issue
 was cancelled; final checks run against the corrected commit.
+
+The next run reached the reload assertion but exposed a fixture initialization
+issue: visiting the home page first set the onboarding flag that had also guarded
+project seeding. The fixture now seeds before the first app navigation, uses its
+own one-time marker, and asserts the intended project is open. This preserves the
+unsaved-revision assertion instead of allowing the app's fallback blank project
+to stand in for the fixture. Application code was unchanged by these test fixes.

--- a/docs/reviews/2026-09-08-deployment-version-cache.md
+++ b/docs/reviews/2026-09-08-deployment-version-cache.md
@@ -101,3 +101,19 @@ initial onboarding-flag seed guard allowed a fallback blank project after visiti
 the home page; the explicit initialization corrects that test setup. Application
 code was unchanged by these test fixes. See PR checks for final results; known
 intermediate failures/cancelled runs are not counted as successful validation.
+
+WebKit's temporary contexts did not retain the cache entry needed by the positive
+control. The cache workflow now uses a disposable persistent profile in every
+engine, verifies a real force-cache hit before changing the server response, and
+removes the temporary profile after closing it. This matches the retained browser
+cache relevant to the defect. See [Playwright's context implementation](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/webkit/wkBrowser.ts)
+for the distinction between temporary contexts and disk caching. The two other
+deployment workflows keep the standard temporary test contexts.
+
+A Chromium run also exposed an existing viewer-idle test sampling race after
+stacking: the zero-pending poll succeeded, but its separate baseline snapshot
+already contained one pending frame; that final frame then completed. The helper
+now waits for an entire 350 ms quiet interval within the existing 40-second settle
+budget. It still requires zero pending work and exactly unchanged callback and
+GPU draw counts throughout the accepted interval. Viewer application code and all
+control/wakeup/pixel assertions are unchanged.

--- a/docs/reviews/2026-09-08-deployment-version-cache.md
+++ b/docs/reviews/2026-09-08-deployment-version-cache.md
@@ -80,3 +80,14 @@ uses an editor opened before the actual GitHub/App Hosting rollout. See the PR's
 completion comment for final deployment and full CI evidence. Automated tests
 separately verify that an unsaved revision is persisted by the reload action and
 that failed writes prevent reload and retain JSON recovery.
+
+### Regression setup correction
+
+The first CI run passed all Firefox workflows but found that Chromium and WebKit
+fetches did not reuse the version JSON's document-navigation cache entry in this
+setup. The test now explicitly primes the fetch cache with a reload-mode fetch
+from the same app origin before changing the server response. It still requires
+an actual stale body and 304 from the original no-cache-header check before it
+accepts the fixed checker. No routing, fetch mock, skipped engine or weakened
+cache assertion was introduced. The intermediate run with that known setup issue
+was cancelled; final checks run against the corrected commit.

--- a/src/lib/components/DeploymentNotice.svelte
+++ b/src/lib/components/DeploymentNotice.svelte
@@ -2,21 +2,23 @@
   import { onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { beforeNavigate, goto } from '$app/navigation';
-  import { updated } from '$app/state';
-  import { base } from '$app/paths';
+  import { dev, version } from '$app/environment';
+  import { assets, base } from '$app/paths';
   import { currentProject } from '$lib/stores/project';
   import { saveState } from '$lib/stores/saveStatus';
   import { loadingFailure, prepareToLeave } from '$lib/services/deployment';
+  import { hasDeploymentUpdate } from '$lib/services/deploymentVersion';
   import { downloadProjectJSON as exportAsJSON } from '$lib/utils/projectBackup';
 
   let busy = $state(false);
   let message = $state('');
   let target = $state<URL | null>(null);
+  let updateAvailable = $state(false);
 
   beforeNavigate(navigation => {
     if (navigation.willUnload || !navigation.to?.url) return;
     const dirtyEditor = navigation.from?.url.pathname === `${base}/editor` && get(saveState) !== 'saved';
-    if (!updated.current && !dirtyEditor) return;
+    if (!updateAvailable && !dirtyEditor) return;
     navigation.cancel();
     target = navigation.to.url;
     if (dirtyEditor && !busy) {
@@ -25,7 +27,7 @@
       void prepareToLeave().then(saved => {
         busy = false;
         if (!saved) { message = 'Your changes could not be saved. Stay here to retry or download a JSON backup.'; return; }
-        if (!updated.current && target === destination) {
+        if (!updateAvailable && target === destination) {
           target = null;
           void goto(destination, { replaceState: navigation.type === 'popstate' });
         }
@@ -44,22 +46,28 @@
   }
 
   onMount(() => {
+    if (dev) return;
     let lastCheck = Date.now();
+    let checking = false;
+    let disposed = false;
     const check = () => {
-      if (document.hidden || updated.current || Date.now() - lastCheck < 60_000) return;
+      if (document.hidden || updateAvailable || checking || Date.now() - lastCheck < 60_000) return;
       lastCheck = Date.now();
-      void updated.check();
+      checking = true;
+      void hasDeploymentUpdate(version, `${assets}/_app/version.json`).then(available => {
+        if (!disposed && available) updateAvailable = true;
+      }).finally(() => { checking = false; });
     };
     const timer = setInterval(check, 300_000);
     window.addEventListener('focus', check);
     document.addEventListener('visibilitychange', check);
-    return () => { clearInterval(timer); window.removeEventListener('focus', check); document.removeEventListener('visibilitychange', check); };
+    return () => { disposed = true; clearInterval(timer); window.removeEventListener('focus', check); document.removeEventListener('visibilitychange', check); };
   });
 </script>
 
-{#if updated.current || $loadingFailure || message}
+{#if updateAvailable || $loadingFailure || message}
   <aside role="status" class="fixed bottom-4 left-1/2 -translate-x-1/2 z-[90] w-[min(95vw,650px)] rounded-xl border border-blue-300 bg-white p-4 text-slate-800 shadow-xl print-hide">
-    <p class="text-sm">{message || (updated.current ? 'An app update is ready. Reload to use the latest version. Your project will be saved first.' : $loadingFailure)}</p>
+    <p class="text-sm">{message || (updateAvailable ? 'An app update is ready. Reload to use the latest version. Your project will be saved first.' : $loadingFailure)}</p>
     <div class="mt-3 flex flex-wrap gap-3">
       <button class="rounded bg-blue-600 px-3 py-1.5 text-sm text-white disabled:opacity-50" disabled={busy} onclick={reload}>{busy ? 'Saving…' : 'Save and reload'}</button>
       {#if $currentProject}<button class="text-sm underline" onclick={() => { if ($currentProject) exportAsJSON($currentProject); }}>Download JSON backup</button>{/if}

--- a/src/lib/services/deploymentVersion.ts
+++ b/src/lib/services/deploymentVersion.ts
@@ -1,0 +1,20 @@
+/** Read the deployed version without reusing size/mtime cache validators. */
+export async function hasDeploymentUpdate(currentVersion: string, url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      // `no-cache` alone can reuse a stale body after an incorrect 304. Build
+      // artifacts may have identical mtimes and sizes across deployments.
+      cache: 'no-store',
+      headers: { pragma: 'no-cache', 'cache-control': 'no-cache' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return false;
+    const data: unknown = await response.json();
+    return typeof data === 'object' && data !== null && 'version' in data &&
+      typeof data.version === 'string' && data.version.trim().length > 0 &&
+      data.version !== currentVersion;
+  } catch {
+    // Offline, unavailable and malformed responses are not evidence of an update.
+    return false;
+  }
+}

--- a/tests/browser/deployment-server.ts
+++ b/tests/browser/deployment-server.ts
@@ -1,0 +1,46 @@
+import { createServer, request as proxyRequest } from 'node:http';
+import { once } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import type { AddressInfo } from 'node:net';
+
+/** Real HTTP cache fixture: routing via Playwright would disable the cache. */
+export async function deploymentServer(upstream = 'http://127.0.0.1:4188') {
+  const { version: current } = JSON.parse(await readFile('build/client/_app/version.json', 'utf8'));
+  const different = current.slice(0, -1) + (current.endsWith('0') ? '1' : '0');
+  const etag = `W/"${Buffer.byteLength(JSON.stringify({ version: current }))}-315532801000"`;
+  const modified = 'Tue, 01 Jan 1980 00:00:01 GMT';
+  let body = JSON.stringify({ version: current }), status = 200;
+  const requests: { status: number; etag?: string; modified?: string }[] = [];
+  const server = createServer((req, res) => {
+    if (req.url?.split('?')[0] === '/_app/version.json') {
+      // Deliberately collide across equal-sized, uncompressed representations.
+      // Like the deployed adapter, explicit no-cache headers do not fix a 304.
+      const conditional = req.headers['if-none-match'] === etag ||
+        (!req.headers['if-none-match'] && req.headers['if-modified-since'] === modified);
+      const code = status === 200 && conditional ? 304 : status;
+      requests.push({ status: code, etag: req.headers['if-none-match'], modified: req.headers['if-modified-since'] });
+      res.writeHead(code, {
+        'content-type': 'application/json', 'cache-control': 'public, max-age=0, must-revalidate',
+        etag, 'last-modified': modified,
+      });
+      res.end(code === 304 ? undefined : body);
+      return;
+    }
+    const proxy = proxyRequest(new URL(req.url!, upstream), {
+      method: req.method, headers: { ...req.headers, host: new URL(upstream).host },
+    }, response => {
+      res.writeHead(response.statusCode!, response.headers);
+      response.pipe(res);
+    });
+    proxy.on('error', () => { res.writeHead(502); res.end(); });
+    req.pipe(proxy);
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return {
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    current, different, requests,
+    serve(version: string, code = 200) { body = JSON.stringify({ version }); status = code; },
+    async close() { server.closeAllConnections(); server.close(); await once(server, 'close'); },
+  };
+}

--- a/tests/browser/deployment.spec.ts
+++ b/tests/browser/deployment.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { readFile, readdir } from 'node:fs/promises';
+import { deploymentServer } from './deployment-server';
+import { failProjectWrites, savedProjects } from './storage';
+
+async function seed(context: BrowserContext, id: string) {
+  const project = JSON.parse(await readFile('tests/fixtures/save-conflicts.openplan.json', 'utf8'));
+  project.id = id;
+  await context.addInitScript(project => {
+    // Seed only once; reload must use the app's saved IndexedDB revision.
+    if (!localStorage.getItem('hasSeenWelcome')) {
+      localStorage.setItem('floorplan_projects', JSON.stringify({ [project.id]: JSON.stringify(project) }));
+      localStorage.setItem('hasSeenWelcome', 'true');
+    }
+  }, project);
+}
+
+async function advanceCheck(page: Page) {
+  const response = page.waitForResponse(r => new URL(r.url()).pathname === '/_app/version.json');
+  await page.clock.fastForward(300_001);
+  await response;
+  // Flush the response's JSON parsing and Svelte DOM update before assertions.
+  await page.getByRole('button', { name: 'Save', exact: true }).focus();
+}
+
+async function rename(page: Page, name: string) {
+  await page.getByTitle('Click to rename', { exact: true }).click();
+  await page.getByRole('textbox', { name: 'Project name' }).fill(name);
+  await page.getByRole('textbox', { name: 'Project name' }).press('Enter');
+}
+
+test('real cached validators cannot create a false update or hide a later deployment', async ({ page, context }) => {
+  const server = await deploymentServer();
+  try {
+    const errors: string[] = [];
+    page.on('pageerror', e => errors.push(e.message));
+    // Prime the actual browser HTTP cache with an older representation.
+    server.serve(server.different);
+    await page.goto(`${server.url}/_app/version.json`);
+    await expect(page.locator('body')).toContainText(server.different);
+    server.serve(server.current);
+    // Control: the original check's headers reproduce the stale 304/body.
+    const cached = await page.evaluate(async () => (await (await fetch('/_app/version.json', {
+      headers: { pragma: 'no-cache', 'cache-control': 'no-cache' },
+    })).json()).version);
+    expect(cached).toBe(server.different);
+    expect(server.requests.at(-1)?.status).toBe(304);
+
+    await seed(context, 'qa-deployment-cache');
+    await page.clock.install();
+    await page.goto(`${server.url}/editor?id=qa-deployment-cache`);
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+    await advanceCheck(page);
+    expect(server.requests.at(-1)).toEqual({ status: 200, etag: undefined, modified: undefined });
+    await expect(page.getByRole('button', { name: 'Save and reload', exact: true })).toHaveCount(0);
+
+    // A same-sized replacement still gets detected, without a stale validator.
+    server.serve(server.different);
+    await advanceCheck(page);
+    await expect(page.getByRole('status')).toContainText('An app update is ready');
+    expect(server.requests.at(-1)).toEqual({ status: 200, etag: undefined, modified: undefined });
+    const count = server.requests.length;
+    await page.clock.fastForward(300_001);
+    expect(server.requests).toHaveLength(count); // Stop polling after detection.
+
+    // Simulate loading the now-current build, retaining the old HTTP cache.
+    server.serve(server.current);
+    await rename(page, 'Saved across deployment');
+    await Promise.all([
+      page.waitForEvent('framenavigated', frame => frame === page.mainFrame()),
+      page.getByRole('button', { name: 'Save and reload', exact: true }).click(),
+    ]);
+    await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText('Saved across deployment');
+    await advanceCheck(page);
+    await expect(page.getByRole('button', { name: 'Save and reload', exact: true })).toHaveCount(0);
+    expect((await savedProjects(page))['qa-deployment-cache'].name).toBe('Saved across deployment');
+
+    const asset = (await readdir('build/client/_app/immutable/entry')).find(name => /^start\..*\.js$/.test(name));
+    expect(asset).toBeTruthy();
+    const response = await context.request.get(`${server.url}/_app/immutable/entry/${asset}`);
+    expect(response.headers()['cache-control']).toContain('max-age=31536000,immutable');
+    expect(errors).toEqual([]);
+  } finally { await server.close(); }
+});
+
+test('update reload preserves failed saves, JSON recovery and the chosen destination', async ({ page, context }) => {
+  const server = await deploymentServer();
+  try {
+    await seed(context, 'qa-deployment-save');
+    await page.clock.install();
+    await page.goto(`${server.url}/editor?id=qa-deployment-save`);
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+    server.serve(server.different);
+    await advanceCheck(page);
+    await expect(page.getByRole('status')).toContainText('An app update is ready');
+    await failProjectWrites(page);
+    await rename(page, 'Unsaved deployment recovery');
+    await page.getByRole('button', { name: 'Save and reload', exact: true }).click();
+    await expect(page.getByRole('status')).toContainText('Your changes could not be saved');
+    await expect(page).toHaveURL(/editor\?id=qa-deployment-save$/);
+    const download = page.waitForEvent('download');
+    await page.getByRole('status').getByRole('button', { name: 'Download JSON backup' }).click();
+    const backup = JSON.parse(await readFile((await (await download).path())!, 'utf8'));
+    expect(backup.name).toBe('Unsaved deployment recovery');
+    expect(backup.id).toBe('qa-deployment-save');
+    await page.getByRole('button', { name: 'Keep editing', exact: true }).click();
+    await page.getByTitle('Back to Projects', { exact: true }).click();
+    await expect(page.getByRole('status')).toContainText('Your changes could not be saved');
+    await expect(page).toHaveURL(/editor\?id=qa-deployment-save$/);
+    await page.evaluate(() => { (window as any).failProjectWrites = false; });
+    server.serve(server.current);
+    await page.getByRole('button', { name: 'Save and reload', exact: true }).click();
+    await expect(page).toHaveURL(`${server.url}/`);
+    expect((await savedProjects(page))['qa-deployment-save'].name).toBe(backup.name);
+  } finally { await server.close(); }
+});
+
+test('failed update requests remain quiet and retry after recovery', async ({ page, context }) => {
+  const server = await deploymentServer();
+  try {
+    const errors: string[] = [];
+    page.on('pageerror', e => errors.push(e.message));
+    await seed(context, 'qa-deployment-offline');
+    await page.clock.install();
+    await page.goto(`${server.url}/editor?id=qa-deployment-offline`);
+    await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+    server.serve(server.different, 503);
+    await advanceCheck(page);
+    await expect(page.getByRole('button', { name: 'Save and reload' })).toHaveCount(0);
+    await context.setOffline(true);
+    const failed = page.waitForEvent('requestfailed', r => new URL(r.url()).pathname === '/_app/version.json');
+    await page.clock.fastForward(300_001);
+    await failed;
+    await expect(page.getByRole('button', { name: 'Save and reload' })).toHaveCount(0);
+    await rename(page, 'Still editable offline');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
+    await context.setOffline(false);
+    server.serve(server.different);
+    await advanceCheck(page);
+    await expect(page.getByRole('status')).toContainText('An app update is ready');
+    expect(errors).toEqual([]);
+  } finally { await server.close(); }
+});

--- a/tests/browser/deployment.spec.ts
+++ b/tests/browser/deployment.spec.ts
@@ -1,7 +1,22 @@
 import { expect, test, type BrowserContext, type Page } from '@playwright/test';
-import { readFile, readdir } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { deploymentServer } from './deployment-server';
 import { failProjectWrites, savedProjects } from './storage';
+
+// WebKit's temporary contexts have no disk cache. Use a private, disposable
+// persistent profile for the cache regression, consistently in all engines.
+const cacheTest = test.extend({
+  context: async ({ playwright, browserName, launchOptions, contextOptions, headless, viewport }, use) => {
+    const profile = await mkdtemp(join(tmpdir(), 'openplan3d-cache-'));
+    const context = await playwright[browserName].launchPersistentContext(profile, {
+      ...launchOptions, ...contextOptions, headless, viewport,
+    });
+    try { await use(context); }
+    finally { await context.close(); await rm(profile, { recursive: true, force: true }); }
+  },
+});
 
 async function seed(context: BrowserContext, id: string) {
   const project = JSON.parse(await readFile('tests/fixtures/save-conflicts.openplan.json', 'utf8'));
@@ -30,7 +45,7 @@ async function rename(page: Page, name: string) {
   await page.getByRole('textbox', { name: 'Project name' }).press('Enter');
 }
 
-test('real cached validators cannot create a false update or hide a later deployment', async ({ page, context }) => {
+cacheTest('real cached validators cannot create a false update or hide a later deployment', async ({ page, context }) => {
   const server = await deploymentServer();
   try {
     const errors: string[] = [];
@@ -44,6 +59,15 @@ test('real cached validators cannot create a false update or hide a later deploy
       cache: 'reload',
     })).json()).version);
     expect(primed).toBe(server.different);
+    // Disk-cache commits may finish after the first fetch resolves. Establish
+    // an actual cache hit before replacing the server's representation.
+    await expect.poll(async () => {
+      const count = server.requests.length;
+      const cached = await page.evaluate(async () => (await (await fetch('/_app/version.json', {
+        cache: 'force-cache',
+      })).json()).version);
+      return cached === server.different && server.requests.length === count;
+    }).toBe(true);
     server.serve(server.current);
     // Positive control: explicitly request conditional revalidation. Header-only
     // requests bypass the cache in some engines, so they cannot prove it is warm.

--- a/tests/browser/deployment.spec.ts
+++ b/tests/browser/deployment.spec.ts
@@ -45,9 +45,10 @@ test('real cached validators cannot create a false update or hide a later deploy
     })).json()).version);
     expect(primed).toBe(server.different);
     server.serve(server.current);
-    // Control: the original check's headers reproduce the stale 304/body.
+    // Positive control: explicitly request conditional revalidation. Header-only
+    // requests bypass the cache in some engines, so they cannot prove it is warm.
     const cached = await page.evaluate(async () => (await (await fetch('/_app/version.json', {
-      headers: { pragma: 'no-cache', 'cache-control': 'no-cache' },
+      cache: 'no-cache',
     })).json()).version);
     expect(cached).toBe(server.different);
     expect(server.requests.at(-1)?.status).toBe(304);

--- a/tests/browser/deployment.spec.ts
+++ b/tests/browser/deployment.spec.ts
@@ -8,9 +8,10 @@ async function seed(context: BrowserContext, id: string) {
   project.id = id;
   await context.addInitScript(project => {
     // Seed only once; reload must use the app's saved IndexedDB revision.
-    if (!localStorage.getItem('hasSeenWelcome')) {
+    if (!localStorage.getItem('qaDeploymentSeeded')) {
       localStorage.setItem('floorplan_projects', JSON.stringify({ [project.id]: JSON.stringify(project) }));
       localStorage.setItem('hasSeenWelcome', 'true');
+      localStorage.setItem('qaDeploymentSeeded', 'true');
     }
   }, project);
 }
@@ -34,6 +35,7 @@ test('real cached validators cannot create a false update or hide a later deploy
   try {
     const errors: string[] = [];
     page.on('pageerror', e => errors.push(e.message));
+    await seed(context, 'qa-deployment-cache');
     // Prime the fetch cache, not a JSON document navigation: engines can keep
     // those in separate cache entries. No Playwright routes or mocked fetches.
     server.serve(server.different);
@@ -50,10 +52,10 @@ test('real cached validators cannot create a false update or hide a later deploy
     expect(cached).toBe(server.different);
     expect(server.requests.at(-1)?.status).toBe(304);
 
-    await seed(context, 'qa-deployment-cache');
     await page.clock.install();
     await page.goto(`${server.url}/editor?id=qa-deployment-cache`);
     await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeVisible();
+    await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText('QA Save Conflicts');
     await advanceCheck(page);
     expect(server.requests.at(-1)).toEqual({ status: 200, etag: undefined, modified: undefined });
     await expect(page.getByRole('button', { name: 'Save and reload', exact: true })).toHaveCount(0);

--- a/tests/browser/deployment.spec.ts
+++ b/tests/browser/deployment.spec.ts
@@ -18,9 +18,9 @@ async function seed(context: BrowserContext, id: string) {
 async function advanceCheck(page: Page) {
   const response = page.waitForResponse(r => new URL(r.url()).pathname === '/_app/version.json');
   await page.clock.fastForward(300_001);
-  await response;
+  await (await response).finished();
   // Flush the response's JSON parsing and Svelte DOM update before assertions.
-  await page.getByRole('button', { name: 'Save', exact: true }).focus();
+  await page.clock.runFor(50);
 }
 
 async function rename(page: Page, name: string) {
@@ -65,7 +65,9 @@ test('real cached validators cannot create a false update or hide a later deploy
 
     // Simulate loading the now-current build, retaining the old HTTP cache.
     server.serve(server.current);
+    await page.clock.pauseAt(new Date(await page.evaluate(() => Date.now()) + 1000));
     await rename(page, 'Saved across deployment');
+    expect((await savedProjects(page))['qa-deployment-cache'].name).not.toBe('Saved across deployment');
     await Promise.all([
       page.waitForEvent('framenavigated', frame => frame === page.mainFrame()),
       page.getByRole('button', { name: 'Save and reload', exact: true }).click(),

--- a/tests/browser/deployment.spec.ts
+++ b/tests/browser/deployment.spec.ts
@@ -34,10 +34,14 @@ test('real cached validators cannot create a false update or hide a later deploy
   try {
     const errors: string[] = [];
     page.on('pageerror', e => errors.push(e.message));
-    // Prime the actual browser HTTP cache with an older representation.
+    // Prime the fetch cache, not a JSON document navigation: engines can keep
+    // those in separate cache entries. No Playwright routes or mocked fetches.
     server.serve(server.different);
-    await page.goto(`${server.url}/_app/version.json`);
-    await expect(page.locator('body')).toContainText(server.different);
+    await page.goto(server.url);
+    const primed = await page.evaluate(async () => (await (await fetch('/_app/version.json', {
+      cache: 'reload',
+    })).json()).version);
+    expect(primed).toBe(server.different);
     server.serve(server.current);
     // Control: the original check's headers reproduce the stale 304/body.
     const cached = await page.evaluate(async () => (await (await fetch('/_app/version.json', {

--- a/tests/browser/viewer-idle.spec.ts
+++ b/tests/browser/viewer-idle.spec.ts
@@ -38,13 +38,16 @@ test('3D sleeps when idle and wakes for controls, scene changes and walkthrough'
   const activeDraws = async () => (await gpu(page)).find((entry: any) => entry.connected && !entry.lost)?.draws ?? 0;
   const pixels = async () => createHash('sha256').update(await canvas.evaluate((node: HTMLCanvasElement) => node.toDataURL())).digest('hex');
   const idle = async () => {
-    // Software-rendered CI needs time to draw each remaining damping step.
-    await expect.poll(async () => (await audit()).pending, { timeout: 40_000 }).toBe(0);
-    const before = await audit(), draws = await activeDraws();
-    // A quiet interval must contain neither polling callbacks nor GPU draws.
-    await page.waitForTimeout(350);
-    expect(await audit()).toEqual(before);
-    expect(await activeDraws()).toBe(draws);
+    // Software rendering and resize/scene observers may enqueue a final frame
+    // after the first zero-pending snapshot. Settle over a whole quiet interval.
+    await expect(async () => {
+      const before = await audit(), draws = await activeDraws();
+      expect(before.pending).toBe(0);
+      // The accepted interval still contains no callbacks, pending work or draws.
+      await page.waitForTimeout(350);
+      expect(await audit()).toEqual(before);
+      expect(await activeDraws()).toBe(draws);
+    }).toPass({ timeout: 40_000, intervals: [100, 250] });
   };
   await idle();
   let before = await pixels();

--- a/tests/deployment-version.test.ts
+++ b/tests/deployment-version.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { hasDeploymentUpdate } from '$lib/services/deploymentVersion';
+
+afterEach(() => vi.unstubAllGlobals());
+
+it.each([
+  ['current version', { version: 'release-a' }, false],
+  ['different version (including rollback)', { version: 'release-b' }, true],
+  ['missing version', {}, false],
+  ['null body', null, false],
+  ['numeric version', { version: 123 }, false],
+  ['blank version', { version: '  ' }, false],
+])('recognizes %s', async (_, body, expected) => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json(body)));
+  expect(await hasDeploymentUpdate('release-a', '/_app/version.json')).toBe(expected);
+});
+
+it('bypasses conditional browser validation and bounds the request', async () => {
+  const fetcher = vi.fn().mockResolvedValue(Response.json({ version: 'release-a' }));
+  vi.stubGlobal('fetch', fetcher);
+  await hasDeploymentUpdate('release-a', '/planner/_app/version.json');
+  expect(fetcher).toHaveBeenCalledWith('/planner/_app/version.json', {
+    cache: 'no-store', headers: { pragma: 'no-cache', 'cache-control': 'no-cache' },
+    signal: expect.any(AbortSignal),
+  });
+});
+
+it.each([
+  new Response('Unavailable', { status: 503 }),
+  new Response('Not JSON'),
+  new Response(null, { status: 304 }),
+])('ignores unavailable or unusable responses', async response => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+  expect(await hasDeploymentUpdate('release-a', '/_app/version.json')).toBe(false);
+});
+
+it.each([new TypeError('Offline'), new DOMException('Timed out', 'TimeoutError')])(
+  'ignores request failures and allows a later retry', async error => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(Response.json({ version: 'release-b' })));
+    expect(await hasDeploymentUpdate('release-a', '/_app/version.json')).toBe(false);
+    expect(await hasDeploymentUpdate('release-a', '/_app/version.json')).toBe(true);
+  },
+);


### PR DESCRIPTION
Safari could repeatedly announce an update after reloading because cached version JSON reused a colliding size/mtime validator. The notice now compares its embedded build version with a bounded no-store request. It keeps the existing polling rate, immutable asset caching, local save-before-reload and recovery behavior. Existing clients acquire the checker on their next page load.

The regression uses real HTTP responses and a disposable persistent browser profile. It proves a cache hit, reproduces a stale body/304 through conditional revalidation, then verifies fresh app checks, genuine update detection, unsaved-edit persistence, failed-save JSON recovery, deferred navigation and offline retry. No browser routing or fetch mock disables the cache. An existing viewer-idle test now settles over a complete quiet interval to avoid a snapshot race, while retaining zero-callback/zero-draw assertions; viewer code is unchanged.

Validation: 626 unit tests, 216 browser workflows (72 each in Chromium, Firefox and WebKit), six rendering benchmarks, build and audit pass. Final CI run 34203975757 passed without test retries. Type checks have zero errors and 23 existing warnings. Native Safari reproduced the stale cache, then verified fresh checks and no repeated notice after save/reload with the project retained. App Hosting deployment and the retained production Safari session passed: the update notice cleared after Save and reload, plan counts stayed intact, 3D rendered and the notice stayed clear past the polling interval. Main CI run 34204956645 also passed without retries; details are in the completion comment.

NEXT.md and the dated review report include the remaining priorities and validation limits. No new Firebase Storage objects, cloud writes, endpoints, dependencies or assets.

Fixes #81.
