### PR TITLE
Protect editor state while modal dialogs have keyboard focus

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -22,9 +22,9 @@ intercepting field editing, and preserves furniture dimensions while replacing
 empty/invalid drafts. See [the browser report](docs/reviews/2026-09-07-cross-browser-editing.md)
 and PR checks for final engine results and merge/release status.
 
-Local validation: **645 web unit tests**; native baseline **53 XCTest tests**
+Local validation: **647 web unit tests**; native baseline **53 XCTest tests**
 (unchanged this batch). Production build and audit pass; type checks report zero
-errors and 22 remaining Svelte warnings.
+errors and nine remaining Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
 
@@ -131,6 +131,13 @@ RoomPlan chairs without a retained source are not guessed. See
 [the report](docs/reviews/2026-09-08-legacy-furniture-previews.md) and PR checks for
 final browser and deployment verification.
 
+The [modal keyboard batch (#88)](https://github.com/laanlabs/openPlan3D/issues/88)
+prevents editing shortcuts from changing a selected object behind an open dialog.
+Native dialogs provide focus and background inertness; keyboard guards also cover
+window/document listeners, elevation Escape and 3D input. Command actions execute
+after their palette closes. See [the report](docs/reviews/2026-09-08-modal-keyboard-safety.md)
+and PR checks for final browser, Safari and deployment verification.
+
 ## 2. Release and Firebase cost gates
 
 Keep [#30](https://github.com/laanlabs/openPlan3D/issues/30) open until all three
@@ -233,7 +240,7 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
   matrix. Refresh README counts/import features and add contributor guidance,
   fixture-oriented issue/PR templates and a release checklist. Historical review
   findings and original package metadata are not authoritative current status.
-- Reduce the 22 remaining Svelte warnings with focused accessibility/component
+- Reduce the nine remaining Svelte warnings with focused accessibility/component
   changes. The CI artifact actions now use pinned Node 24 releases. Continue dependency
   auditing rather than treating the original resolved advisories as still open.
 - Decide whether to publish/license the currently private iOS repository, add a

--- a/NEXT.md
+++ b/NEXT.md
@@ -135,7 +135,9 @@ The [modal keyboard batch (#88)](https://github.com/laanlabs/openPlan3D/issues/8
 prevents editing shortcuts from changing a selected object behind an open dialog.
 Native dialogs provide focus and background inertness; keyboard guards also cover
 window/document listeners, elevation Escape and 3D input. Command actions execute
-after their palette closes. See [the report](docs/reviews/2026-09-08-modal-keyboard-safety.md)
+after their palette closes. Area Summary safely includes imported room categories
+it does not recognize and releases its subscriptions when closed.
+See [the report](docs/reviews/2026-09-08-modal-keyboard-safety.md)
 and PR checks for final browser, Safari and deployment verification.
 
 ## 2. Release and Firebase cost gates

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -530,7 +530,7 @@ window/document editor shortcuts pause while a modal is open. Closing a dialog
 preserves elevation and 3D edit modes. Command palette semantics identify the
 active result, and actions dispatch after modal teardown. Local validation passes
 647 unit tests, the production build and type checks with zero errors and nine
-remaining warnings. Seven new browser workflows cover desktop/phone keyboard
+remaining warnings. Eight new browser workflows cover desktop/phone keyboard
 protection, field edits, command execution, cancellation, mode preservation and
 printing. See [the report](2026-09-08-modal-keyboard-safety.md) and PR checks for
 final validation and deployment. This adds no Firebase writes or dependencies.

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -521,3 +521,16 @@ save/reload/export, bundled 3D models, retained bytes and quota recovery. See
 [the report](2026-09-08-legacy-furniture-previews.md) and PR checks for final browser,
 native Safari and deployment verification. The native format and iOS source are
 unchanged; this batch adds no cloud writes, assets or dependencies.
+
+## Thirty-first batch: modal keyboard safety
+
+Issue #88 reproduces Delete removing the selected QA bed behind Version History
+in production Safari. Eight overlay dialogs now use native modal focus/inertness;
+window/document editor shortcuts pause while a modal is open. Closing a dialog
+preserves elevation and 3D edit modes. Command palette semantics identify the
+active result, and actions dispatch after modal teardown. Local validation passes
+647 unit tests, the production build and type checks with zero errors and nine
+remaining warnings. Seven new browser workflows cover desktop/phone keyboard
+protection, field edits, command execution, cancellation, mode preservation and
+printing. See [the report](2026-09-08-modal-keyboard-safety.md) and PR checks for
+final validation and deployment. This adds no Firebase writes or dependencies.

--- a/docs/reviews/2026-09-08-modal-keyboard-safety.md
+++ b/docs/reviews/2026-09-08-modal-keyboard-safety.md
@@ -35,6 +35,11 @@ or dependency changes are introduced.
 The Settings command's previously missing listener is also connected and cleaned
 up with the toolbar lifecycle.
 
+The broader dialog pass also reproduced an Area Summary crash on the saved import
+fixture's retained `roomType: "kitchen"`. The summary now groups unsupported values
+as Uncategorized, retaining room names, areas and original metadata. Store
+subscriptions end when the summary closes instead of accumulating on every open.
+
 ## Validation
 
 Local unit suite: **647 pass**. Production build passes; type checks report zero
@@ -60,6 +65,10 @@ The Settings modal layout was visually inspected on the local production build.
 Safari also retained elevation and 3D edit modes after Settings was closed with
 Escape. With a real captured walkthrough mouse, opening the palette released the
 mouse, focused command search and ended the locked walkthrough session as intended.
+The corrected Area Summary showed Kitchen & Dining and its 24.0 m² area under
+Uncategorized. Area Summary and keyboard help retained focus under Tab/Shift+Tab
+and left the plan unchanged after Delete and Escape. Safari also downloaded a
+valid PDF and displayed the floor plan in its native print sheet.
 
 Physical iPhone/iPad keyboard, touch and share-sheet testing remains part of the
 release backlog. This batch does not change the Firebase cost gates in #30.

--- a/docs/reviews/2026-09-08-modal-keyboard-safety.md
+++ b/docs/reviews/2026-09-08-modal-keyboard-safety.md
@@ -1,0 +1,58 @@
+# Modal keyboard safety
+
+Issue [#88](https://github.com/laanlabs/openPlan3D/issues/88) fixes a reproduced
+background-editing bug. In native Safari on production commit `8426776`, selecting
+the QA bed, opening Version History and pressing Delete removed the bed behind
+the still-open panel. Closing the panel and undoing restored the QA object.
+
+## Behavior
+
+Settings, Version History, Area Summary, Print Preview, Keyboard Shortcuts,
+Command Palette, RoomPlan options and Floor Plan Templates now use native modal
+dialogs. Opening moves focus inside, the browser makes the background inert, and
+closing restores available prior focus. Escape, close buttons and existing
+backdrop dismissal update component state consistently. RoomPlan and template
+cards remain scrollable within short viewports.
+A shared Tab/Shift+Tab loop keeps visible enabled controls reachable even when
+Safari's keyboard preference skips buttons. Existing package and library-restore
+dialogs use the same lifecycle and retain their busy-state cancellation rules.
+
+Native inertness alone does not disable window/document listeners. Editor keyboard
+handlers now check for an open dialog before modifying the plan, switching views,
+starting tools or processing Escape. This also protects the existing native
+package and library-restore dialogs. Elevation's capture-phase Escape handler
+and 3D input follow the same rule; modal focus clears held walkthrough input.
+Closing a modal leaves those view modes intact. Key releases still clear held input.
+
+The command palette uses a named search combobox and result list with an active
+option. Its commands execute after the dialog closes, preserving actions such as
+Toggle Grid and opening Settings. Print preview keeps its existing PDF/export
+behavior, and its bound canvas is reactive. No data format, cloud service, asset
+or dependency changes are introduced.
+The Settings command's previously missing listener is also connected and cleaned
+up with the toolbar lifecycle.
+
+## Validation
+
+Local unit suite: **647 pass**. Production build passes; type checks report zero
+errors and **nine remaining Svelte warnings**, down from 22. Two unit regressions
+cover shortcut isolation even with a background event target and resumption after
+closing the dialog.
+
+Seven new browser workflows run across Chromium, Firefox and WebKit. They cover
+desktop and 390-pixel dialog focus, Tab/Shift+Tab, selected-wall preservation,
+deletion/undo after closing, field edits, command search/execution, cancelled
+RoomPlan import, template focus restoration, elevation/3D mode preservation,
+PDF download and print-media canvas visibility. Each rejects page errors and
+external requests. Existing import/recovery and rendering workflows remain in the
+full suite. Final CI, native Safari and deployment results are recorded on the
+issue and pull request; merge requires passing checks.
+
+Local native Safari confirmed the selected wall survived Delete while history
+was open, Tab reached Restore, Shift+Tab returned to Close, and Escape retained
+the wall selection and dimensions. The command palette's Settings and Toggle Grid
+actions passed, and Print Preview focused its page control with PDF export enabled.
+The Settings modal layout was visually inspected on the local production build.
+
+Physical iPhone/iPad keyboard, touch and share-sheet testing remains part of the
+release backlog. This batch does not change the Firebase cost gates in #30.

--- a/docs/reviews/2026-09-08-modal-keyboard-safety.md
+++ b/docs/reviews/2026-09-08-modal-keyboard-safety.md
@@ -46,8 +46,9 @@ Eight new browser workflows run across Chromium, Firefox and WebKit. They cover
 desktop and 390-pixel dialog focus, Tab/Shift+Tab, selected-wall preservation,
 deletion/undo after closing, field edits, command search/execution, cancelled
 RoomPlan import, template focus restoration, elevation/3D mode preservation,
-PDF download and print-media canvas visibility. Each rejects page errors and
-external requests. Existing import/recovery and rendering workflows remain in the
+PDF download, print-media canvas visibility and walkthrough mouse release. Each
+rejects page errors; the dialog, command and import workflows also reject external
+requests. Existing import/recovery and rendering workflows remain in the
 full suite. Final CI, native Safari and deployment results are recorded on the
 issue and pull request; merge requires passing checks.
 
@@ -56,6 +57,9 @@ was open, Tab reached Restore, Shift+Tab returned to Close, and Escape retained
 the wall selection and dimensions. The command palette's Settings and Toggle Grid
 actions passed, and Print Preview focused its page control with PDF export enabled.
 The Settings modal layout was visually inspected on the local production build.
+Safari also retained elevation and 3D edit modes after Settings was closed with
+Escape. With a real captured walkthrough mouse, opening the palette released the
+mouse, focused command search and ended the locked walkthrough session as intended.
 
 Physical iPhone/iPad keyboard, touch and share-sheet testing remains part of the
 release backlog. This batch does not change the Firebase cost gates in #30.

--- a/docs/reviews/2026-09-08-modal-keyboard-safety.md
+++ b/docs/reviews/2026-09-08-modal-keyboard-safety.md
@@ -23,6 +23,9 @@ starting tools or processing Escape. This also protects the existing native
 package and library-restore dialogs. Elevation's capture-phase Escape handler
 and 3D input follow the same rule; modal focus clears held walkthrough input.
 Closing a modal leaves those view modes intact. Key releases still clear held input.
+Opening a modal also releases any captured mouse; the existing unlock handler
+ends a locked walkthrough session so dialog controls remain usable. A controlled
+browser regression verifies movement stops and a fresh walkthrough has no held keys.
 
 The command palette uses a named search combobox and result list with an active
 option. Its commands execute after the dialog closes, preserving actions such as
@@ -39,7 +42,7 @@ errors and **nine remaining Svelte warnings**, down from 22. Two unit regression
 cover shortcut isolation even with a background event target and resumption after
 closing the dialog.
 
-Seven new browser workflows run across Chromium, Firefox and WebKit. They cover
+Eight new browser workflows run across Chromium, Firefox and WebKit. They cover
 desktop and 390-pixel dialog focus, Tab/Shift+Tab, selected-wall preservation,
 deletion/undo after closing, field edits, command search/execution, cancelled
 RoomPlan import, template focus restoration, elevation/3D mode preservation,

--- a/src/app.css
+++ b/src/app.css
@@ -124,6 +124,18 @@ html.dark .hover\:border-blue-400:hover { border-color: #3b82f6 !important; }
 html.dark .hover\:bg-blue-50:hover { background-color: #1e3a5f !important; }
 html.dark .bg-blue-50 { background-color: #1e3a5f !important; }
 
+/* Full-viewport native modal surfaces retain each dialog's existing card layout. */
+dialog.modal-overlay {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  width: 100%;
+  height: 100dvh;
+  max-width: none;
+  max-height: none;
+}
+dialog.modal-overlay::backdrop { background: transparent; }
+
 /* ── Print styles ─────────────────────────────────────────────── */
 @media print {
   body * { visibility: hidden !important; }

--- a/src/lib/components/LibraryRestoreDialog.svelte
+++ b/src/lib/components/LibraryRestoreDialog.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onDestroy } from 'svelte';
+  import { modalDialog } from '$lib/utils/modalDialog';
   import { prepareLibraryRestore, type LibraryRestorePreview, type RestoreResult } from '$lib/services/libraryRestore';
   import { storageErrorMessage } from '$lib/services/datastore';
 
   let { onclose, onrestored }: { onclose: () => void; onrestored: () => Promise<void> } = $props();
-  let dialog: HTMLDialogElement;
   let input = $state<HTMLInputElement>();
   let preview = $state.raw<LibraryRestorePreview | null>(null);
   let result = $state.raw<RestoreResult | null>(null);
@@ -15,7 +15,6 @@
   let error = $state<string | null>(null);
   let readRequest = 0;
   const lifetime = new AbortController();
-  onMount(() => dialog.showModal());
   onDestroy(() => { readRequest++; lifetime.abort(); });
 
   async function selectFile(event: Event) {
@@ -58,7 +57,7 @@
   }
 </script>
 
-<dialog bind:this={dialog} aria-labelledby="library-restore-title" aria-describedby="library-restore-description"
+<dialog use:modalDialog aria-labelledby="library-restore-title" aria-describedby="library-restore-description"
   oncancel={(event) => { if (restoring) event.preventDefault(); else onclose(); }}
   class="m-auto w-[36rem] max-w-[calc(100vw-2rem)] max-h-[85vh] rounded-2xl bg-white p-0 shadow-2xl backdrop:bg-black/50">
   <div class="flex max-h-[85vh] flex-col text-gray-800">

--- a/src/lib/components/ProjectPackageDialog.svelte
+++ b/src/lib/components/ProjectPackageDialog.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onDestroy } from 'svelte';
+  import { modalDialog } from '$lib/utils/modalDialog';
   import { prepareProjectPackage } from '$lib/services/projectPackage';
   import { storageErrorMessage } from '$lib/services/datastore';
   let { onclose, onimported }: { onclose: () => void; onimported: () => Promise<void> } = $props();
-  let dialog: HTMLDialogElement;
   let input = $state<HTMLInputElement>();
   let preview = $state.raw<Awaited<ReturnType<typeof prepareProjectPackage>> | null>(null);
   let error = $state<string | null>(null), reading = $state(false), importing = $state(false), complete = $state(false);
   const lifetime = new AbortController();
   let request = 0;
-  onMount(() => dialog.showModal());
   onDestroy(() => { request++; lifetime.abort(); });
   async function choose(event: Event) {
     const file = (event.target as HTMLInputElement).files?.[0];
@@ -42,7 +41,7 @@
     const link = document.createElement('a'); link.href = url; link.download = 'openplan3d-original.zip'; link.click(); URL.revokeObjectURL(url);
   }
 </script>
-<dialog bind:this={dialog} aria-labelledby="package-title" aria-describedby="package-description"
+<dialog use:modalDialog aria-labelledby="package-title" aria-describedby="package-description"
   oncancel={(event) => { if (importing) event.preventDefault(); else onclose(); }}
   class="m-auto w-[36rem] max-w-[calc(100vw-2rem)] max-h-[85vh] rounded-2xl bg-white p-0 shadow-2xl backdrop:bg-black/50">
   <div class="flex max-h-[85vh] flex-col text-gray-800">

--- a/src/lib/components/editor/CommandPalette.svelte
+++ b/src/lib/components/editor/CommandPalette.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { tick } from 'svelte';
+  import { modalDialog } from '$lib/utils/modalDialog';
   import { furnitureCatalog } from '$lib/utils/furnitureCatalog';
   import { selectedTool, snapEnabled, placingFurnitureId, undo, redo, currentProject, viewMode } from '$lib/stores/project';
   import { exportAsPNG, exportAsJSON, exportAsSVG, exportPDF } from '$lib/utils/export';
@@ -75,8 +77,6 @@
     if (open) {
       query = '';
       selectedIndex = 0;
-      // Focus after mount
-      requestAnimationFrame(() => inputEl?.focus());
     }
   });
 
@@ -86,8 +86,10 @@
     selectedIndex = 0;
   });
 
-  function execute(item: ResultItem) {
+  async function execute(item: ResultItem) {
     open = false;
+    // Close the modal before commands dispatch editor shortcuts or open Settings.
+    await tick();
     item.action();
   }
 
@@ -109,20 +111,14 @@
 </script>
 
 {#if open}
-  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <div
-    class="fixed inset-0 bg-black/40 z-[100] flex justify-center"
-    onclick={() => open = false}
-    onkeydown={(e) => { if (e.key === 'Escape') open = false; }}
-    role="dialog"
+  <dialog use:modalDialog
+    class="modal-overlay fixed inset-0 bg-black/40 z-[100] flex justify-center"
+    onclick={(e) => { if (e.target === e.currentTarget) open = false; }}
+    oncancel={(e) => { e.preventDefault(); open = false; }}
     aria-label="Command Palette"
   >
-    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <div
-      class="mt-[15vh] w-full max-w-lg h-fit bg-white rounded-xl shadow-2xl overflow-hidden"
-      onclick={(e) => e.stopPropagation()}
-      onkeydown={() => {}}
-      role="listbox"
+      class="mt-[15vh] mx-4 w-full max-w-lg h-fit bg-white rounded-xl shadow-2xl overflow-hidden"
     >
       <!-- Search input -->
       <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-200">
@@ -135,32 +131,38 @@
           placeholder="Search furniture, tools, actions…"
           type="text"
           spellcheck="false"
+          role="combobox"
+          aria-label="Search commands"
+          aria-expanded="true"
+          aria-controls="command-results"
+          aria-autocomplete="list"
+          aria-activedescendant={results[selectedIndex] ? `command-result-${results[selectedIndex].id}` : undefined}
         />
         <kbd class="text-[10px] px-1.5 py-0.5 bg-gray-100 rounded border border-gray-200 text-gray-400">ESC</kbd>
       </div>
 
       <!-- Results -->
-      <div class="max-h-[50vh] overflow-y-auto">
+      <div id="command-results" role="listbox" aria-label="Commands" tabindex="-1" class="max-h-[50vh] overflow-y-auto">
         {#if results.length === 0}
           <div class="px-4 py-6 text-center text-sm text-gray-400">No results found</div>
         {:else}
           {#each results as item, i}
-            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-            <div
-              class="flex items-center gap-3 px-4 py-2 cursor-pointer text-sm transition-colors"
+            <button
+              id={`command-result-${item.id}`}
+              tabindex="-1"
+              class="flex w-full text-left items-center gap-3 px-4 py-2 cursor-pointer text-sm transition-colors"
               class:bg-blue-50={i === selectedIndex}
               class:text-blue-700={i === selectedIndex}
               class:text-gray-700={i !== selectedIndex}
               onmouseenter={() => selectedIndex = i}
               onclick={() => execute(item)}
-              onkeydown={() => {}}
               role="option"
               aria-selected={i === selectedIndex}
             >
               <span class="text-base w-6 text-center flex-shrink-0">{item.icon}</span>
               <span class="flex-1 truncate">{item.name}</span>
               <span class="text-xs text-gray-400 flex-shrink-0">{item.categoryLabel}</span>
-            </div>
+            </button>
           {/each}
         {/if}
       </div>
@@ -172,5 +174,5 @@
         <span><kbd class="px-1 py-0.5 bg-gray-100 rounded border border-gray-200">esc</kbd> close</span>
       </div>
     </div>
-  </div>
+  </dialog>
 {/if}

--- a/src/lib/components/editor/ElevationView.svelte
+++ b/src/lib/components/editor/ElevationView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { hasOpenModal } from '$lib/utils/modalDialog';
   /**
    * ElevationView — integrated face-on view + editor for a single wall.
    * Fills the canvas area (replaces the plan canvas while active — sidebars stay).
@@ -134,6 +135,7 @@
   $effect(() => {
     if (!$elevationWallId) return;
     const onKey = (e: KeyboardEvent) => {
+      if (hasOpenModal()) return;
       if (e.key === 'Escape') {
         e.preventDefault();
         e.stopImmediatePropagation();

--- a/src/lib/components/editor/FloorPlanCanvas.svelte
+++ b/src/lib/components/editor/FloorPlanCanvas.svelte
@@ -13,6 +13,7 @@
   import { getCatalogItem, getFurnitureSize, type FurnitureDef } from '$lib/utils/furnitureCatalog';
   import { drawFurnitureIcon } from '$lib/utils/furnitureIcons';
   import { handleGlobalShortcut, isEditingField } from '$lib/utils/shortcuts';
+  import { hasOpenModal } from '$lib/utils/modalDialog';
   import ContextMenu from './ContextMenu.svelte';
   import { roomPresets, placePreset } from '$lib/utils/roomPresets';
   import { getWallTextureCanvas, getFloorTextureCanvas, setTextureLoadCallback } from '$lib/utils/textureGenerator';
@@ -3110,6 +3111,7 @@
   }
 
   function onKeyDown(e: KeyboardEvent) {
+    if (hasOpenModal()) return;
     // This listener is on window, so field keystrokes reach it too. Keep every
     // canvas action (including Space, select/copy/paste and annotation deletion)
     // out of focused inputs; only the explicit Save shortcut is global there.

--- a/src/lib/components/editor/PrintLayout.svelte
+++ b/src/lib/components/editor/PrintLayout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { modalDialog } from '$lib/utils/modalDialog';
   import { tick } from 'svelte';
   import { currentProject } from '$lib/stores/project';
   import { renderPrintPage, createPrintPDF } from '$lib/utils/scaledPrint';
@@ -8,7 +9,7 @@
   let pageSize = $state<PrintOptions['pageSize']>('letter');
   let orientation = $state<PrintOptions['orientation']>('landscape');
   let scale = $state<PrintOptions['scale']>(50);
-  let canvas: HTMLCanvasElement;
+  let canvas = $state<HTMLCanvasElement>();
   let layout = $state<ReturnType<typeof calculatePrintLayout> | null>(null);
   let error = $state('');
   let rendering = $state(false);
@@ -30,7 +31,7 @@
   });
 
   function downloadPDF() {
-    if (!$currentProject || !layout?.fits || rendering) return;
+    if (!$currentProject || !canvas || !layout?.fits || rendering) return;
     try { createPrintPDF(canvas, $currentProject, options).save(`${$currentProject.name || 'floorplan'}-${layout.scaleLabel.replaceAll(':', '-')}.pdf`); }
     catch (e) { error = e instanceof Error ? e.message : 'Unable to download PDF.'; }
   }
@@ -39,10 +40,9 @@
 <svelte:head>
   {#if open}<style>{`@page { size: ${pageSize === 'a4' ? 'A4' : 'letter'} ${orientation}; margin: 0; }`}</style>{/if}
 </svelte:head>
-<svelte:window onkeydown={(e) => { if (open && e.key === 'Escape') open = false; }} />
 
 {#if open}
-  <div class="fixed inset-0 bg-slate-950/70 z-[100] overflow-auto print-overlay-backdrop" role="dialog" aria-modal="true" aria-label="Print Preview" tabindex="-1">
+  <dialog use:modalDialog class="modal-overlay fixed inset-0 bg-slate-950/70 z-[100] overflow-auto print-overlay-backdrop" aria-label="Print Preview" oncancel={(e) => { e.preventDefault(); open = false; }}>
     <div class="sticky top-0 bg-slate-800 text-white p-3 flex flex-wrap items-center gap-3 z-[101] print-hide">
       <h2 class="font-semibold">Print Preview</h2>
       <label>Page: <select bind:value={pageSize} class="bg-slate-700 rounded p-1"><option value="letter">Letter</option><option value="a4">A4</option></select></label>
@@ -59,5 +59,5 @@
     <div class="print-page bg-white mx-auto my-6 shadow-xl" style:width={layout ? `${layout.pageWidth}mm` : '279.4mm'} style:max-width="100%">
       <canvas bind:this={canvas} class="block w-full h-auto" aria-label="Floor plan print preview"></canvas>
     </div>
-  </div>
+  </dialog>
 {/if}

--- a/src/lib/components/sidebar/AreaSummaryPanel.svelte
+++ b/src/lib/components/sidebar/AreaSummaryPanel.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
   import { activeFloor, detectedRoomsStore } from '$lib/stores/project';
   import { projectSettings, formatArea, formatLength } from '$lib/stores/settings';
-  import type { Floor, Room, Wall, RoomCategory } from '$lib/models/types';
+  import type { Room, Wall, RoomCategory } from '$lib/models/types';
 
-  let floor = $state<Floor | null>(null);
-  let detectedRooms: Room[] = $state([]);
-  let settings = $state($projectSettings);
-
-  activeFloor.subscribe((f) => { floor = f; });
-  detectedRoomsStore.subscribe((r) => { detectedRooms = r; });
-  projectSettings.subscribe((s) => { settings = s; });
+  // Auto subscriptions end when the summary dialog closes.
+  let floor = $derived($activeFloor);
+  let detectedRooms = $derived($detectedRoomsStore);
+  let settings = $derived($projectSettings);
+  type SummaryCategory = RoomCategory | 'uncategorized';
 
   // Merge floor rooms + detected rooms (detected take precedence for dynamic data)
   let allRooms = $derived.by(() => {
@@ -22,19 +20,22 @@
   let totalArea = $derived(allRooms.reduce((sum: number, r: Room) => sum + r.area, 0));
 
   let roomsByCategory = $derived.by(() => {
-    const cats: Record<RoomCategory, Room[]> = { indoor: [], outdoor: [], garage: [], utility: [] };
+    const cats: Record<SummaryCategory, Room[]> = { indoor: [], outdoor: [], garage: [], utility: [], uncategorized: [] };
     for (const r of allRooms) {
       const cat = r.roomType ?? 'indoor';
-      cats[cat].push(r);
+      // Imported projects can retain category values outside the current model.
+      // Keep those rooms and their original metadata, without guessing a category.
+      if (cat === 'indoor' || cat === 'outdoor' || cat === 'garage' || cat === 'utility') cats[cat].push(r);
+      else cats.uncategorized.push(r);
     }
     return cats;
   });
 
   let categoryTotals = $derived.by(() => {
     const cats = roomsByCategory;
-    const result: { category: RoomCategory; label: string; area: number; count: number }[] = [];
-    const labels: Record<RoomCategory, string> = { indoor: '🏠 Indoor', outdoor: '🌳 Outdoor', garage: '🚗 Garage', utility: '🔧 Utility' };
-    for (const [cat, rooms] of Object.entries(cats) as [RoomCategory, Room[]][]) {
+    const result: { category: SummaryCategory; label: string; area: number; count: number }[] = [];
+    const labels: Record<SummaryCategory, string> = { indoor: '🏠 Indoor', outdoor: '🌳 Outdoor', garage: '🚗 Garage', utility: '🔧 Utility', uncategorized: 'Uncategorized' };
+    for (const [cat, rooms] of Object.entries(cats) as [SummaryCategory, Room[]][]) {
       if (rooms.length > 0) {
         result.push({ category: cat, label: labels[cat], area: rooms.reduce((s: number, r: Room) => s + r.area, 0), count: rooms.length });
       }

--- a/src/lib/components/sidebar/BuildPanel.svelte
+++ b/src/lib/components/sidebar/BuildPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { modalDialog } from '$lib/utils/modalDialog';
   import { openProject } from '$lib/services/projectOpening';
   import ImportError from '$lib/components/ImportError.svelte';
   import { onDestroy } from 'svelte';
@@ -769,8 +770,8 @@
 
 <!-- RoomPlan Import Options Dialog -->
 {#if showImportDialog}
-  <div class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center" onclick={cancelImport}>
-    <div class="bg-white rounded-xl shadow-2xl w-80 p-5" onclick={(e) => e.stopPropagation()}>
+  <dialog use:modalDialog class="modal-overlay fixed inset-0 bg-black/50 z-50 flex items-center justify-center" aria-label="Import RoomPlan" onclick={(e) => { if (e.target === e.currentTarget) cancelImport(); }} oncancel={(e) => { e.preventDefault(); cancelImport(); }}>
+    <div class="bg-white rounded-xl shadow-2xl w-80 max-w-[calc(100vw-2rem)] max-h-[85vh] overflow-auto p-5">
       <h3 class="text-sm font-bold text-gray-800 mb-1">Import RoomPlan</h3>
       <p class="text-xs text-gray-400 mb-4">{importFileName}</p>
 
@@ -802,7 +803,7 @@
         <button onclick={confirmImport} class="flex-1 px-3 py-2 bg-blue-500 text-white rounded-lg text-sm font-medium hover:bg-blue-600 transition-colors">Import</button>
       </div>
     </div>
-  </div>
+  </dialog>
 {/if}
 
 {#if importError}

--- a/src/lib/components/toolbar/SettingsDialog.svelte
+++ b/src/lib/components/toolbar/SettingsDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { modalDialog } from '$lib/utils/modalDialog';
   import { projectSettings } from '$lib/stores/settings';
   import type { ProjectSettings } from '$lib/stores/settings';
   import { currentProject, updateProjectName } from '$lib/stores/project';
@@ -90,9 +91,8 @@
 </script>
 
 {#if open}
-  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <div class="fixed inset-0 bg-black/50 z-50 flex items-center justify-center" onclick={close} onkeydown={(e) => { if (e.key === 'Escape') close(); }} role="dialog" tabindex="-1" aria-label="Settings">
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-[420px] max-w-[calc(100vw-1rem)] max-h-[80vh] flex flex-col" onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') close(); e.stopPropagation(); }} role="document">
+  <dialog use:modalDialog class="modal-overlay fixed inset-0 bg-black/50 z-50 flex items-center justify-center" onclick={(e) => { if (e.target === e.currentTarget) close(); }} oncancel={(e) => { e.preventDefault(); close(); }} aria-label="Settings">
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-[420px] max-w-[calc(100vw-1rem)] max-h-[80vh] flex flex-col">
       <!-- Header -->
       <div class="flex items-center justify-between px-5 pt-4 pb-2">
         <h2 class="text-lg font-bold text-gray-800 dark:text-gray-100">Settings</h2>
@@ -345,5 +345,5 @@
         {/if}
       </div>
     </div>
-  </div>
+  </dialog>
 {/if}

--- a/src/lib/components/toolbar/TopBar.svelte
+++ b/src/lib/components/toolbar/TopBar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { modalDialog, hasOpenModal } from '$lib/utils/modalDialog';
   import { openProject } from '$lib/services/projectOpening';
   import { saveConflict, savingCopy, saveCurrentAsCopy } from '$lib/stores/saveStatus';
   import ImportError from '$lib/components/ImportError.svelte';
@@ -222,6 +223,8 @@
   onMount(() => {
     const stopAutoSave = initAutoSave();
     initVersionHistory();
+    const openSettings = () => { if (!hasOpenModal()) settingsOpen = true; };
+    window.addEventListener('open-settings', openSettings);
 
     // Update relative timestamp every 15s
     const interval = setInterval(updateLastSavedText, 15000);
@@ -238,6 +241,7 @@
       }
     }
     function handleKeydown(e: KeyboardEvent) {
+      if (hasOpenModal()) return;
       if (e.key !== 'Escape') return;
       if (exportOpen) exportOpen = false;
       if (e.key === 'Escape' && moreOpen) moreOpen = false;
@@ -248,6 +252,7 @@
     document.addEventListener('click', handleClickOutside, true);
     document.addEventListener('keydown', handleKeydown, true);
     return () => {
+      window.removeEventListener('open-settings', openSettings);
       if (get(saveState) === 'unsaved') void autoSave();
       stopAutoSave();
       stopVersionHistory();
@@ -619,19 +624,17 @@
 <VersionHistoryPanel bind:open={versionHistoryOpen} />
 
 {#if areaOpen}
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onclick={() => areaOpen = false} onkeydown={(e) => { if (e.key === 'Escape') areaOpen = false; }}>
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="bg-white rounded-xl shadow-2xl w-[420px] max-w-[calc(100vw-2rem)] max-h-[80vh] overflow-hidden" onclick={(e) => e.stopPropagation()}>
+<dialog use:modalDialog class="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/40" aria-label="Area Summary" onclick={(e) => { if (e.target === e.currentTarget) areaOpen = false; }} oncancel={(e) => { e.preventDefault(); areaOpen = false; }}>
+  <div class="bg-white rounded-xl shadow-2xl w-[420px] max-w-[calc(100vw-2rem)] max-h-[80vh] overflow-hidden">
     <div class="flex items-center justify-between px-5 py-3 border-b border-gray-200">
       <h2 class="text-base font-semibold text-gray-800">📐 Area Summary</h2>
-      <button onclick={() => areaOpen = false} class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
+      <button aria-label="Close area summary" onclick={() => areaOpen = false} class="text-gray-400 hover:text-gray-600 text-xl leading-none">&times;</button>
     </div>
     <div class="overflow-y-auto max-h-[calc(80vh-52px)] p-1">
       <AreaSummaryPanel />
     </div>
   </div>
-</div>
+</dialog>
 {/if}
 
 {#if importError}

--- a/src/lib/components/toolbar/VersionHistoryPanel.svelte
+++ b/src/lib/components/toolbar/VersionHistoryPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { modalDialog } from '$lib/utils/modalDialog';
   import { onDestroy } from 'svelte';
   import { snapshotError, downloadSnapshotBackup, snapshotsStore, refreshSnapshots, restoreSnapshot, deleteAllSnapshots, type Snapshot } from '$lib/stores/versionHistory';
   import { currentProject } from '$lib/stores/project';
@@ -46,10 +47,8 @@
 </script>
 
 {#if open}
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="fixed inset-0 bg-black/40 z-50 flex items-center justify-center" onclick={() => open = false} onkeydown={(e) => { if (e.key === 'Escape') open = false; }}>
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div role="dialog" aria-label="Version History" aria-modal="true" tabindex="-1" class="bg-white rounded-xl shadow-2xl w-96 max-w-[calc(100vw-2rem)] max-h-[70vh] flex flex-col" onclick={(e) => e.stopPropagation()} onkeydown={() => {}}>
+<dialog use:modalDialog class="modal-overlay fixed inset-0 bg-black/40 z-50 flex items-center justify-center" aria-label="Version History" onclick={(e) => { if (e.target === e.currentTarget) open = false; }} oncancel={(e) => { e.preventDefault(); open = false; }}>
+  <div class="bg-white rounded-xl shadow-2xl w-96 max-w-[calc(100vw-2rem)] max-h-[70vh] flex flex-col">
     <div class="flex items-center justify-between px-4 py-3 border-b border-gray-100">
       <h2 class="text-sm font-semibold text-gray-800 flex items-center gap-2">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
@@ -98,5 +97,5 @@
       </div>
     {/if}
   </div>
-</div>
+</dialog>
 {/if}

--- a/src/lib/components/viewer3d/ThreeViewer.svelte
+++ b/src/lib/components/viewer3d/ThreeViewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { hasOpenModal } from '$lib/utils/modalDialog';
   import { onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { openAISettings, setOpenAIModel } from '$lib/stores/aiKeys';
@@ -641,6 +642,7 @@
   }
 
   function onKeyDown(event: KeyboardEvent) {
+    if (hasOpenModal()) return;
     // ESC exits edit mode
     if (event.code === 'Escape' && editMode && !walkthroughMode) {
       if (furniturePlacementMode) {
@@ -691,7 +693,7 @@
   }
 
   function onWalkthroughFocus(event: FocusEvent) {
-    if (isWalkthroughField(event.target)) resetWalkthroughInput();
+    if (hasOpenModal() || isWalkthroughField(event.target)) resetWalkthroughInput();
   }
 
   function init() {

--- a/src/lib/utils/modalDialog.ts
+++ b/src/lib/utils/modalDialog.ts
@@ -1,0 +1,31 @@
+/** Native modal focus, background inertness and focus restoration. Components
+ * own cancellation so closing also clears their Svelte open state. */
+export function modalDialog(dialog: HTMLDialogElement) {
+  const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  dialog.showModal();
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Tab' || event.ctrlKey || event.metaKey || event.altKey) return;
+    // Safari's keyboard preference may otherwise skip buttons and leave the
+    // document. Keep the dialog controls reachable in either direction.
+    const controls = [...dialog.querySelectorAll<HTMLElement>(
+      'button, input, select, textarea, a[href], [tabindex], [contenteditable="true"]',
+    )].filter(element => element.tabIndex >= 0 && !element.matches(':disabled') && !element.closest('[inert]') && element.getClientRects().length > 0);
+    if (!controls.length) { event.preventDefault(); dialog.focus(); return; }
+    const index = controls.indexOf(document.activeElement as HTMLElement);
+    const next = event.shiftKey ? (index <= 0 ? controls.length - 1 : index - 1) : (index + 1) % controls.length;
+    event.preventDefault(); controls[next].focus();
+  }
+  dialog.addEventListener('keydown', onKeydown);
+  return { destroy: () => {
+    dialog.removeEventListener('keydown', onKeydown);
+    dialog.close();
+    // Conditional blocks may already have detached the dialog during teardown.
+    if (previous?.isConnected) previous.focus({ preventScroll: true });
+  } };
+}
+
+/** Inert background elements still have window/document keyboard listeners.
+ * Check before handling editor shortcuts, including capture-phase listeners. */
+export function hasOpenModal(): boolean {
+  return typeof document !== 'undefined' && document.querySelector('dialog[open]') !== null;
+}

--- a/src/lib/utils/modalDialog.ts
+++ b/src/lib/utils/modalDialog.ts
@@ -2,6 +2,9 @@
  * own cancellation so closing also clears their Svelte open state. */
 export function modalDialog(dialog: HTMLDialogElement) {
   const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  // A keyboard-opened dialog must be usable while walkthrough has captured the
+  // mouse. The viewer's existing unlock handler ends that walkthrough session.
+  if (document.pointerLockElement) document.exitPointerLock();
   dialog.showModal();
   function onKeydown(event: KeyboardEvent) {
     if (event.key !== 'Tab' || event.ctrlKey || event.metaKey || event.altKey) return;

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -1,6 +1,7 @@
 import { selectedTool, activateMeasurementTool, undo, redo, viewMode, selectedElementId, selectedElementIds, removeElement, panMode, beginUndoGroup, endUndoGroup } from '$lib/stores/project';
 import { get } from 'svelte/store';
 import { manualSave } from '$lib/stores/saveStatus';
+import { hasOpenModal } from './modalDialog';
 
 export interface ShortcutContext {
   rotateFurniture?: () => void;
@@ -13,6 +14,7 @@ export function isEditingField(target: EventTarget | null): boolean {
 }
 
 export function handleGlobalShortcut(e: KeyboardEvent, ctx: ShortcutContext = {}): boolean {
+  if (hasOpenModal()) return false;
   const mod = e.metaKey || e.ctrlKey;
 
   // Save remains available while editing. Text selection, clipboard and undo

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { modalDialog } from '$lib/utils/modalDialog';
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
@@ -293,11 +294,11 @@
 
   <!-- Template Modal -->
   {#if showTemplateModal}
-    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" onclick={() => showTemplateModal = false}>
-      <div class="bg-white rounded-2xl shadow-2xl p-8 max-w-xl w-full mx-4" onclick={(e) => e.stopPropagation()}>
+    <dialog use:modalDialog class="modal-overlay fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" aria-label="Floor Plan Templates" onclick={(e) => { if (e.target === e.currentTarget) showTemplateModal = false; }} oncancel={(e) => { e.preventDefault(); showTemplateModal = false; }}>
+      <div class="bg-white rounded-2xl shadow-2xl p-8 max-w-xl w-full mx-4 max-h-[85vh] overflow-auto">
         <div class="flex items-center justify-between mb-2">
           <h2 class="text-2xl font-bold text-gray-800">Floor Plan Templates</h2>
-          <button onclick={() => showTemplateModal = false} class="text-gray-400 hover:text-gray-600 text-xl">✕</button>
+          <button aria-label="Close templates" onclick={() => showTemplateModal = false} class="text-gray-400 hover:text-gray-600 text-xl">✕</button>
         </div>
         <p class="text-sm text-gray-400 mb-6">Complete house layouts with walls, doors & windows</p>
         <div class="space-y-3">
@@ -316,6 +317,6 @@
           {/each}
         </div>
       </div>
-    </div>
+    </dialog>
   {/if}
 </div>

--- a/src/routes/editor/+page.svelte
+++ b/src/routes/editor/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { modalDialog, hasOpenModal } from '$lib/utils/modalDialog';
   import { onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { base } from '$app/paths';
@@ -190,6 +191,7 @@
     };
   });
   function onEditorKeydown(e: KeyboardEvent) {
+    if (hasOpenModal()) return;
     const target = e.target as HTMLElement | null;
     const typing = !!target && (['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) || target.isContentEditable);
     const mod = e.ctrlKey || e.metaKey;
@@ -297,9 +299,8 @@
   <!-- Shortcuts overlay -->
   {#if showHelp}
     {@const shortcutsCopied = { value: false }}
-    <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onclick={() => showHelp = false} onkeydown={(e) => { if (e.key === 'Escape') showHelp = false; }} role="dialog" tabindex="-1" aria-label="Keyboard Shortcuts">
-      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-      <div class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full mx-4 max-h-[85vh] flex flex-col" onclick={(e) => e.stopPropagation()} onkeydown={(e) => e.stopPropagation()} role="document">
+    <dialog use:modalDialog class="modal-overlay fixed inset-0 bg-black/50 flex items-center justify-center z-50" onclick={(e) => { if (e.target === e.currentTarget) showHelp = false; }} oncancel={(e) => { e.preventDefault(); showHelp = false; }} onkeydown={(e) => { if (e.key === '?') { e.preventDefault(); showHelp = false; } }} aria-label="Keyboard Shortcuts">
+      <div class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full mx-4 max-h-[85vh] flex flex-col">
         <!-- Header -->
         <div class="flex items-center justify-between px-6 pt-5 pb-3 border-b border-gray-100">
           <div class="flex items-center gap-2">
@@ -462,7 +463,7 @@
           <p class="text-xs text-gray-400">Press <kbd class="px-1 py-0.5 bg-gray-100 rounded text-xs font-mono border border-gray-200">?</kbd> or <kbd class="px-1 py-0.5 bg-gray-100 rounded text-xs font-mono border border-gray-200">Esc</kbd> to close</p>
         </div>
       </div>
-    </div>
+    </dialog>
   {/if}
 
   <CommandPalette bind:open={commandPaletteOpen} />

--- a/tests/browser/modal-keyboard.spec.ts
+++ b/tests/browser/modal-keyboard.spec.ts
@@ -51,6 +51,12 @@ for (const width of [1440, 390]) test(`modal focus and keys preserve the selecte
     if (name === 'Print Preview') await page.getByRole('button', { name: 'Save', exact: true }).press('ControlOrMeta+p');
     else await toolbar(page, name);
     const dialog = await focusInside(page, name);
+    if (name === 'Area Summary') {
+      // The fixture retains a historical roomType="kitchen" outside today's categories.
+      await expect(dialog).toContainText('Uncategorized');
+      await expect(dialog).toContainText('Kitchen & Dining');
+      await expect(dialog).toContainText('24.0 m²');
+    }
     // Playwright's role queries do not account for native modal inertness.
     // Test the browser's actual focus boundary instead of DOM accessibility heuristics.
     await page.getByLabel('Floor plan editor canvas', { exact: true }).evaluate((canvas: HTMLCanvasElement) => canvas.focus());

--- a/tests/browser/modal-keyboard.spec.ts
+++ b/tests/browser/modal-keyboard.spec.ts
@@ -136,7 +136,9 @@ test('closing a dialog preserves elevation and 3D edit modes and print remains u
   const pending = page.waitForEvent('download'); await print.getByRole('button', { name: 'Download PDF', exact: true }).click();
   expect((await readFile((await (await pending).path())!)).subarray(0, 4).toString()).toBe('%PDF');
   await page.emulateMedia({ media: 'print' });
-  await expect(print.getByLabel('Floor plan print preview', { exact: true })).toBeVisible();
+  // Print hides the dialog chrome while explicitly showing its canvas descendant.
+  // A role query for the hidden dialog cannot locate the visible printed content.
+  await expect(page.getByLabel('Floor plan print preview', { exact: true })).toBeVisible();
   await page.emulateMedia({ media: 'screen' });
   await print.getByRole('button', { name: 'Close', exact: true }).click();
   check();

--- a/tests/browser/modal-keyboard.spec.ts
+++ b/tests/browser/modal-keyboard.spec.ts
@@ -51,7 +51,10 @@ for (const width of [1440, 390]) test(`modal focus and keys preserve the selecte
     if (name === 'Print Preview') await page.getByRole('button', { name: 'Save', exact: true }).press('ControlOrMeta+p');
     else await toolbar(page, name);
     const dialog = await focusInside(page, name);
-    await expect(page.getByRole('application')).toHaveCount(0); // Background is inert.
+    // Playwright's role queries do not account for native modal inertness.
+    // Test the browser's actual focus boundary instead of DOM accessibility heuristics.
+    await page.getByLabel('Floor plan editor canvas', { exact: true }).evaluate((canvas: HTMLCanvasElement) => canvas.focus());
+    await focusInside(page, name);
     for (const key of ['Delete', 'Backspace', 'w', 'r', 'l', 'ControlOrMeta+z']) await page.keyboard.press(key);
     for (const key of ['Tab', 'Tab', 'Shift+Tab']) {
       await page.keyboard.press(key); await focusInside(page, name);
@@ -122,7 +125,7 @@ test('closing a dialog preserves elevation and 3D edit modes and print remains u
   await page.getByRole('button', { name: '2D', exact: true }).click();
   await page.getByRole('button', { name: 'Save', exact: true }).press('ControlOrMeta+p');
   const print = await focusInside(page, 'Print Preview');
-  await print.getByLabel('Scale:', { exact: true }).selectOption('fit');
+  await print.getByRole('combobox', { name: 'Scale:', exact: true }).selectOption('fit');
   await expect(print.getByRole('button', { name: 'Download PDF', exact: true })).toBeEnabled();
   const pending = page.waitForEvent('download'); await print.getByRole('button', { name: 'Download PDF', exact: true }).click();
   expect((await readFile((await (await pending).path())!)).subarray(0, 4).toString()).toBe('%PDF');

--- a/tests/browser/modal-keyboard.spec.ts
+++ b/tests/browser/modal-keyboard.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test, type Page } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { storedRecords } from './storage';
+
+const id = 'qa-modal-keyboard';
+async function seed(page: Page) {
+  const project = JSON.parse(await readFile('tests/fixtures/save-conflicts.openplan.json', 'utf8'));
+  project.id = id; project.name = 'QA Modal Keyboard';
+  await page.addInitScript(project => {
+    if (!localStorage.getItem('qaModalSeeded')) {
+      localStorage.setItem('floorplan_projects', JSON.stringify({ [project.id]: JSON.stringify(project) }));
+      localStorage.setItem('hasSeenWelcome', 'true');
+      localStorage.setItem('qaModalSeeded', 'true');
+    }
+  }, project);
+  await page.goto(`/editor?id=${id}`);
+  await page.getByRole('button', { name: 'Save', exact: true }).press('l');
+  await page.getByRole('button', { name: '─ Wall 1', exact: true }).click();
+  return project;
+}
+function observe(page: Page) {
+  const errors: string[] = [], external: string[] = [];
+  page.on('pageerror', e => errors.push(e.message));
+  page.on('request', r => { if (/^https?:/.test(r.url()) && new URL(r.url()).origin !== 'http://127.0.0.1:4188') external.push(r.url()); });
+  return () => { expect(errors).toEqual([]); expect(external).toEqual([]); };
+}
+async function toolbar(page: Page, name: string) {
+  const button = page.getByRole('button', { name, exact: true });
+  if (!await button.isVisible()) await page.getByRole('button', { name: 'More actions', exact: true }).click();
+  await button.press('Enter');
+}
+async function exported(page: Page) {
+  await page.getByRole('button', { name: 'Export', exact: true }).click();
+  const pending = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Download JSON', exact: true }).click();
+  return JSON.parse(await readFile((await (await pending).path())!, 'utf8'));
+}
+async function focusInside(page: Page, name: string) {
+  const dialog = page.getByRole('dialog', { name, exact: true });
+  await expect(dialog).toBeVisible();
+  await expect.poll(() => dialog.evaluate(node => node.matches(':modal') && node.contains(document.activeElement))).toBe(true);
+  return dialog;
+}
+
+for (const width of [1440, 390]) test(`modal focus and keys preserve the selected plan at ${width}px`, async ({ page }, testInfo) => {
+  await page.setViewportSize({ width, height: 900 });
+  const check = observe(page); await seed(page);
+  const before = await exported(page), stored = await storedRecords(page);
+  for (const name of ['Settings', 'Version History', 'Area Summary', 'Keyboard Shortcuts', 'Print Preview']) {
+    if (name === 'Print Preview') await page.getByRole('button', { name: 'Save', exact: true }).press('ControlOrMeta+p');
+    else await toolbar(page, name);
+    const dialog = await focusInside(page, name);
+    await expect(page.getByRole('application')).toHaveCount(0); // Background is inert.
+    for (const key of ['Delete', 'Backspace', 'w', 'r', 'l', 'ControlOrMeta+z']) await page.keyboard.press(key);
+    for (const key of ['Tab', 'Tab', 'Shift+Tab']) {
+      await page.keyboard.press(key); await focusInside(page, name);
+    }
+    if (name === 'Settings') {
+      await testInfo.attach(`settings-modal-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+    }
+    await page.keyboard.press('Escape'); await expect(dialog).toHaveCount(0);
+    await expect(page.getByRole('spinbutton', { name: 'Thickness (cm)', exact: true })).toHaveValue('20');
+    await expect(page.getByRole('application')).toContainText('4 walls');
+    expect((await exported(page)).floors).toEqual(before.floors);
+    expect(await storedRecords(page)).toEqual(stored);
+  }
+  // Editor deletion and undo resume after the dialog has gone away.
+  await page.getByRole('button', { name: 'Save', exact: true }).press('Delete');
+  await expect(page.getByRole('application')).toContainText('3 walls');
+  await page.getByRole('button', { name: 'Undo', exact: true }).click();
+  await expect(page.getByRole('application')).toContainText('4 walls');
+  check();
+});
+
+for (const width of [1440, 390]) test(`command palette and modal field editing remain usable at ${width}px`, async ({ page }) => {
+  await page.setViewportSize({ width, height: 900 }); const check = observe(page); await seed(page);
+  const save = page.getByRole('button', { name: 'Save', exact: true });
+  await save.press('ControlOrMeta+k');
+  await focusInside(page, 'Command Palette');
+  const search = page.getByRole('combobox', { name: 'Search commands', exact: true });
+  await search.fill('not-a-command');
+  await page.keyboard.press('ArrowDown'); await page.keyboard.press('Enter');
+  await expect(page.getByText('No results found', { exact: true })).toBeVisible();
+  await expect(search).not.toHaveAttribute('aria-activedescendant');
+  await search.fill('wall tool');
+  await expect(page.getByRole('option', { name: /Wall Tool/ })).toHaveAttribute('aria-selected', 'true');
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+  await expect(page.getByLabel('Floor plan editor canvas', { exact: true })).toHaveCSS('cursor', 'crosshair');
+  await save.press('ControlOrMeta+k'); await search.fill('settings'); await page.keyboard.press('Enter');
+  const dialog = await focusInside(page, 'Settings');
+  const name = dialog.getByRole('textbox', { name: 'Project Name', exact: true });
+  await name.fill('Keyboard-safe settings'); await name.press('Tab');
+  await dialog.getByRole('button', { name: 'Dimensions', exact: true }).click();
+  await page.keyboard.press('Escape'); await expect(dialog).toHaveCount(0);
+  await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText('Keyboard-safe settings');
+  // Commands that dispatch keyboard events must run after modal teardown.
+  const grid = page.getByTitle('Toggle Grid (G)', { exact: true });
+  const before = await grid.textContent();
+  await save.press('ControlOrMeta+k'); await search.fill('toggle grid'); await page.keyboard.press('Enter');
+  await expect(grid).not.toHaveText(before!);
+  await save.press('ControlOrMeta+k'); await page.keyboard.press('Escape');
+  await expect(save).toBeFocused();
+  check();
+});
+
+test('closing a dialog preserves elevation and 3D edit modes and print remains usable', async ({ page }) => {
+  const check = observe(page); await seed(page);
+  await page.getByRole('button', { name: 'Elevation', exact: true }).first().click();
+  await toolbar(page, 'Version History'); await focusInside(page, 'Version History');
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('button', { name: 'Elevation', exact: true }).first()).toHaveAttribute('aria-pressed', 'true');
+  await toolbar(page, 'Settings');
+  const settings = await focusInside(page, 'Settings');
+  await settings.click({ position: { x: 5, y: 5 } });
+  await expect(settings).toHaveCount(0);
+  await page.getByRole('button', { name: '3D', exact: true }).click();
+  await page.getByRole('button', { name: 'Edit Mode', exact: true }).click();
+  await toolbar(page, 'Settings'); await page.keyboard.press('Escape');
+  await expect(page.getByRole('button', { name: 'Exit Edit Mode', exact: true })).toBeVisible();
+  await page.getByRole('button', { name: '2D', exact: true }).click();
+  await page.getByRole('button', { name: 'Save', exact: true }).press('ControlOrMeta+p');
+  const print = await focusInside(page, 'Print Preview');
+  await print.getByLabel('Scale:', { exact: true }).selectOption('fit');
+  await expect(print.getByRole('button', { name: 'Download PDF', exact: true })).toBeEnabled();
+  const pending = page.waitForEvent('download'); await print.getByRole('button', { name: 'Download PDF', exact: true }).click();
+  expect((await readFile((await (await pending).path())!)).subarray(0, 4).toString()).toBe('%PDF');
+  await page.emulateMedia({ media: 'print' });
+  await expect(print.getByLabel('Floor plan print preview', { exact: true })).toBeVisible();
+  await page.emulateMedia({ media: 'screen' });
+  await print.getByRole('button', { name: 'Close', exact: true }).click();
+  check();
+});
+
+for (const width of [1440, 390]) test(`RoomPlan cancellation and template modal focus stay local at ${width}px`, async ({ page }) => {
+  await page.setViewportSize({ width, height: 900 }); const check = observe(page); await seed(page);
+  const before = await storedRecords(page);
+  if (width < 768) await page.getByRole('button', { name: 'Toggle tools panel', exact: true }).click();
+  const pending = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: /Import RoomPlan iOS LiDAR scan/ }).click();
+  await (await pending).setFiles(resolve('tests/fixtures/handoff-roomplan.json'));
+  const dialog = await focusInside(page, 'Import RoomPlan');
+  await page.keyboard.press('Tab'); await focusInside(page, 'Import RoomPlan');
+  await page.keyboard.press('Escape'); await expect(dialog).toHaveCount(0);
+  expect(await storedRecords(page)).toEqual(before);
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Templates', exact: true }).press('Enter');
+  const templates = await focusInside(page, 'Floor Plan Templates');
+  await page.keyboard.press('Shift+Tab'); await focusInside(page, 'Floor Plan Templates');
+  await page.keyboard.press('Escape'); await expect(templates).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Templates', exact: true })).toBeFocused();
+  expect(await storedRecords(page)).toEqual(before);
+  check();
+});

--- a/tests/browser/modal-keyboard.spec.ts
+++ b/tests/browser/modal-keyboard.spec.ts
@@ -49,6 +49,7 @@ for (const width of [1440, 390]) test(`modal focus and keys preserve the selecte
   const before = await exported(page), stored = await storedRecords(page);
   for (const name of ['Settings', 'Version History', 'Area Summary', 'Keyboard Shortcuts', 'Print Preview']) {
     if (name === 'Print Preview') await page.getByRole('button', { name: 'Save', exact: true }).press('ControlOrMeta+p');
+    else if (name === 'Keyboard Shortcuts' && width < 768) await page.getByRole('button', { name: 'Save', exact: true }).press('?');
     else await toolbar(page, name);
     const dialog = await focusInside(page, name);
     if (name === 'Area Summary') {

--- a/tests/browser/walkthrough.spec.ts
+++ b/tests/browser/walkthrough.spec.ts
@@ -237,3 +237,26 @@ test('stationary walkthrough sleeps and wakes for movement, mouse look, fields a
   expect((await gpu(page))[0].draws).toBe(disposedDraws);
   expect(errors).toEqual([]);
 });
+
+// Exercise the browser pointer-lock boundary with the real Three controls.
+test('opening a modal releases walkthrough mouse capture and stops held movement', async ({ page }) => {
+  const errors: string[] = []; page.on('pageerror', e => errors.push(e.message));
+  await openWalkthrough(page, true); await enter(page);
+  await page.keyboard.down('ArrowUp'); await step(page, 100, 3);
+  await page.keyboard.press('ControlOrMeta+k');
+  const dialog = page.getByRole('dialog', { name: 'Command Palette', exact: true });
+  await expect(dialog).toBeVisible();
+  await expect(page.getByRole('combobox', { name: 'Search commands', exact: true })).toBeFocused();
+  expect(await page.evaluate(() => document.pointerLockElement)).toBeNull();
+  const settled = await step(page, 100, 30);
+  await page.evaluate(() => document.dispatchEvent(new MouseEvent('mousemove', { movementX: 180, movementY: 45 })));
+  await page.keyboard.press('ArrowDown');
+  expect(await step(page, 100, 30)).toEqual(settled);
+  await page.keyboard.up('ArrowUp');
+  await page.keyboard.press('Escape'); await expect(dialog).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Enter Walkthrough Mode', exact: true })).toBeVisible();
+  await enter(page);
+  const restarted = await step(page, 100, 30);
+  expect(await step(page, 100, 30)).toEqual(restarted);
+  expect(errors).toEqual([]);
+});

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { activateMeasurementTool, selectedTool, placingFurnitureId, placingStair, placingColumn,
   placingEntourageId, calibrationMode, elevationPickMode, panMode } from '$lib/stores/project';
@@ -10,6 +10,30 @@ function keyEvent(key: string, extra = {}) {
   return { key, preventDefault: vi.fn(), target: { tagName: 'CANVAS' }, ...extra } as unknown as KeyboardEvent;
 }
 beforeEach(() => { selectedTool.set('select'); vi.mocked(manualSave).mockClear(); });
+afterEach(() => vi.unstubAllGlobals());
+
+it('leaves modal keystrokes alone even when a background canvas is the event target', () => {
+  vi.stubGlobal('document', { querySelector: () => ({ open: true }) });
+  selectedTool.set('wall');
+  for (const key of ['Delete', 'Backspace', 'Escape', 'Tab', 'v', 'm', 'n', 'r']) {
+    const event = keyEvent(key);
+    expect(handleGlobalShortcut(event)).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(get(selectedTool)).toBe('wall');
+  }
+  expect(handleGlobalShortcut(keyEvent('s', { ctrlKey: true }))).toBe(false);
+  expect(manualSave).not.toHaveBeenCalled();
+});
+
+it('resumes editor shortcuts after the modal closes', () => {
+  let open = true;
+  vi.stubGlobal('document', { querySelector: () => open ? {} : null });
+  handleGlobalShortcut(keyEvent('w'));
+  expect(get(selectedTool)).toBe('select');
+  open = false;
+  expect(handleGlobalShortcut(keyEvent('w'))).toBe(true);
+  expect(get(selectedTool)).toBe('wall');
+});
 
 it.each(['measure', 'annotate'] as const)('activates %s and disarms conflicting placement modes', tool => {
   placingFurnitureId.set('chair'); placingStair.set(true); placingColumn.set(true);


### PR DESCRIPTION
Pressing Delete while Version History is open can remove the selected object behind the panel. Native Safari reproduced this on the production QA bed. Editor overlays now use native modal focus/inertness, and window/document keyboard handlers pause while a dialog is open, protecting selection, tools, elevation and 3D edit modes.

A shared Tab/Shift+Tab loop keeps visible enabled dialog controls reachable in Safari and restores available prior focus on close. Existing native package/backup dialogs use the same lifecycle with their busy cancellation rules preserved. The command palette exposes its search/results correctly and executes commands after closing; its missing Settings listener is connected and cleaned up. Area Summary includes unfamiliar imported room categories under Uncategorized without rewriting their data, and its subscriptions end when closed. Print preview retains PDF behavior. Opening a dialog releases captured walkthrough mouse input and clears held movement through the existing unlock behavior. No Firebase writes, assets, dependencies or project-format changes are added.

Validation: [final PR CI](https://github.com/laanlabs/openPlan3D/actions/runs/34232748899) passed 647 unit tests, 258 browser workflows (86 per engine), six rendering benchmarks, build and audit with no browser retries. Type checks report zero errors and nine remaining Svelte warnings, down from 22. App Hosting deployed merge 69e72e2, and native Safari on production verified selected-bed preservation and unchanged dimensions under Delete, modal Tab/Shift+Tab, Command Palette → Settings and imported-room Area Summary. Local native Safari also verified real walkthrough mouse release, elevation/3D edit-mode preservation, PDF download and the native print sheet.

The automatic main run exposed an existing large-import test reloading while “Saving…” was still visible. Follow-up #90 waits for the save-completion signal; its full three-engine suite also passes without retries.

Updates NEXT.md and the dated review report.

Closes #88
