### PR TITLE
Wait for local import persistence before the reload regression

### DIFF
--- a/docs/reviews/2026-09-08-modal-keyboard-safety.md
+++ b/docs/reviews/2026-09-08-modal-keyboard-safety.md
@@ -70,5 +70,12 @@ Uncategorized. Area Summary and keyboard help retained focus under Tab/Shift+Tab
 and left the plan unchanged after Delete and Escape. Safari also downloaded a
 valid PDF and displayed the floor plan in its native print sheet.
 
+Automatic main CI also exposed an existing timing race in the large IndexedDB
+import test: the first Firefox trace reloaded while the UI still said Saving.
+The project title appears before the six-megabyte write commits. The persistence
+test now waits for the user-visible Saved confirmation before reloading; it still
+checks the entire retained payload after reload. This follow-up changes only
+validation and does not alter the deployed application or storage behavior.
+
 Physical iPhone/iPad keyboard, touch and share-sheet testing remains part of the
 release backlog. This batch does not change the Firebase cost gates in #30.

--- a/tests/browser/indexeddb.spec.ts
+++ b/tests/browser/indexeddb.spec.ts
@@ -37,6 +37,9 @@ test('legacy migration preserves images and history, then saves beyond the old q
   await page.getByRole('button', { name: 'Import JSON', exact: true }).click();
   await (await chooser).setFiles({ name: 'large.json', mimeType: 'application/json', buffer: Buffer.from(JSON.stringify(large)) });
   await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(large.name);
+  // The title updates before the large IndexedDB write commits. Test reload
+  // persistence after the same completion signal a user sees, not during Saving.
+  await expect(page.getByText('Saved ✓', { exact: true })).toBeVisible();
   await expect(page.getByRole('alert')).toHaveCount(0);
   await page.reload();
   await expect(page.getByTitle('Click to rename', { exact: true })).toHaveText(large.name);


### PR DESCRIPTION
The large local-import regression sometimes reloads after the new project title appears but before its six-megabyte IndexedDB write commits. The Firefox failure trace in [main CI](https://github.com/laanlabs/openPlan3D/actions/runs/34234062425) shows “Saving…” immediately before reload. Firefox passed on retry, while WebKit hit the same reload assertion on both attempts.

Wait for the existing “Saved” confirmation before testing reload persistence. The assertion still verifies the full retained payload, legacy recovery bytes, history and phone-width 3D behavior. This changes only the test and review notes; application and storage behavior are unchanged.

Validation: [PR CI](https://github.com/laanlabs/openPlan3D/actions/runs/34235263774) passed 647 unit tests, 258 browser workflows (86 per engine), six rendering benchmarks, build and audit. Every browser test passed on its first attempt, including large-import persistence. The deployed application changes from #89 passed production native Safari.
