### PR TITLE
Make project library actions keyboard accessible and safe to retry

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -24,7 +24,7 @@ and PR checks for final engine results and merge/release status.
 
 Local validation: **647 web unit tests**; native baseline **53 XCTest tests**
 (unchanged this batch). Production build and audit pass; type checks report zero
-errors and nine remaining Svelte warnings.
+errors and seven remaining Svelte warnings.
 Desktop and phone-width browser checks cover labels, editing, persistence and
 3D. Native source availability remains separate from TestFlight/App Store release.
 
@@ -39,7 +39,10 @@ and 3D resource cleanup; repeatable furnished-home benchmarks and preservation o
 3D views during metadata edits; responsive top-down camera framing; onboarding
 hints that stay within resized viewports; idle 3D animation cleanup measured in
 native Safari; walkthrough timing, held-input recovery and stationary rendering cleanup;
-2D drawing on demand with explicit display/image wakeups. Earlier batches and pause hashes are recorded
+2D drawing on demand with explicit display/image wakeups; modal keyboard protection;
+keyboard-accessible library actions with explicit, recoverable rename/delete dialogs.
+See [the library actions report](docs/reviews/2026-09-08-library-actions.md) and PR checks
+for final browser CI and deployment verification. Earlier batches and pause hashes are recorded
 in the dated review log and git history.
 
 ## 1. Next engineering batch: device measurements and measured editor work
@@ -242,7 +245,7 @@ These are follow-up work areas, not claims that every item is a reproduced bug.
   matrix. Refresh README counts/import features and add contributor guidance,
   fixture-oriented issue/PR templates and a release checklist. Historical review
   findings and original package metadata are not authoritative current status.
-- Reduce the nine remaining Svelte warnings with focused accessibility/component
+- Reduce the seven remaining Svelte warnings with focused accessibility/component
   changes. The CI artifact actions now use pinned Node 24 releases. Continue dependency
   auditing rather than treating the original resolved advisories as still open.
 - Decide whether to publish/license the currently private iOS repository, add a

--- a/docs/reviews/2026-09-05-current-state-and-roadmap.md
+++ b/docs/reviews/2026-09-05-current-state-and-roadmap.md
@@ -534,3 +534,16 @@ remaining warnings. Eight new browser workflows cover desktop/phone keyboard
 protection, field edits, command execution, cancellation, mode preservation and
 printing. See [the report](2026-09-08-modal-keyboard-safety.md) and PR checks for
 final validation and deployment. This adds no Firebase writes or dependencies.
+
+## Thirty-second batch: project library action safety
+
+Issue #91 reproduces a library menu that ignores Escape and retains its armed
+Delete confirmation after dismissal. Actions now have keyboard navigation and
+focus restoration; rename/delete use explicit native dialogs with recoverable
+errors and pending-operation guards. Stable project card IDs preserve focus after
+sorting, and deletion supplies a remaining focus target. Local validation passes
+647 unit tests, the production build and type checking with zero errors and seven
+remaining warnings. Six new browser workflows cover desktop/phone interaction,
+cancellation, storage failure/retry and pending mutations; native Safari verifies
+the reproduced flows. See [the report](2026-09-08-library-actions.md) and PR checks
+for final browser CI and deployment verification. No cloud storage or iOS changes.

--- a/docs/reviews/2026-09-08-library-actions.md
+++ b/docs/reviews/2026-09-08-library-actions.md
@@ -1,0 +1,40 @@
+# Project library action safety
+
+Issue [#91](https://github.com/laanlabs/openPlan3D/issues/91) follows the remaining
+library accessibility warnings. Native Safari reproduced an actions menu that
+stayed open on Escape and a Delete confirmation that remained armed after
+clicking outside and reopening the menu. The previous inline rename input also
+started an asynchronous save from both Enter and blur without a pending guard.
+
+The library actions menu now takes focus, supports arrows, Home/End and first-letter
+navigation, closes on Escape, Tab, outside pointer input or focus leaving, and
+restores its trigger when dismissed by keyboard or selecting an action. Project
+cards use stable IDs so sorting after a rename retains the correct trigger.
+Thumbnail links have project-specific accessible names.
+
+Rename uses a labeled native dialog with explicit Save name and Cancel actions.
+Delete uses a fresh named confirmation whose initial focus is Cancel. Both keep
+their draft/error state on storage failure and disable repeated submissions until
+the actual local transaction finishes. A successful transaction closes the dialog
+before the separate library refresh, so a refresh failure cannot leave an already
+completed mutation available for retry. Copying is also guarded while pending.
+Deleting the focused card moves focus to New Project when its old trigger is gone.
+
+## Validation
+
+- Local production build and **647 unit tests** pass. Svelte check reports **zero
+  errors and seven remaining warnings**, down from nine. No warning suppressions
+  were added.
+- Native Safari confirms arrow navigation, Escape/trigger focus restoration,
+  rename after Tab/Shift-Tab, and Escape/reopen/Enter safely canceling deletion.
+- Six new browser workflows cover desktop and 390px menu/dialog behavior,
+  cancellation with byte-identical project records, failed rename drafts and
+  retry, pending write locks, duplicate submission protection, confirmed deletion,
+  and deletion failure/retry. The existing cross-tab deletion regression now uses
+  the named confirmation. All workflows assert no external HTTP requests or page
+  errors. Full three-engine CI results and production verification are recorded
+  on the pull request before completion.
+
+This batch changes only local library interactions. It adds no Firebase writes,
+uploads, services, assets, dependencies or native format changes. Physical iPhone
+testing and the release/billing gates in issue #30 remain outstanding.

--- a/src/lib/components/ProjectActionsMenu.svelte
+++ b/src/lib/components/ProjectActionsMenu.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+
+  let { name, disabled = false, onaction }: {
+    name: string;
+    disabled?: boolean;
+    onaction: (action: 'open' | 'rename' | 'duplicate' | 'delete') => void;
+  } = $props();
+  const id = $props.id();
+  let open = $state(false);
+  let trigger = $state<HTMLButtonElement>();
+  let menu = $state<HTMLDivElement>();
+  const actions = ['open', 'rename', 'duplicate', 'delete'] as const;
+
+  function close(restore = false) {
+    open = false;
+    if (restore) trigger?.focus({ preventScroll: true });
+  }
+  async function show(last = false) {
+    if (disabled) return;
+    open = true;
+    await tick();
+    const items = menu?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]');
+    items?.[last ? items.length - 1 : 0]?.focus();
+  }
+  function outside(event: Event) {
+    const target = event.target as Node;
+    if (open && !menu?.contains(target) && !trigger?.contains(target)) close();
+  }
+  function keydown(event: KeyboardEvent) {
+    const items = [...(menu?.querySelectorAll<HTMLButtonElement>('[role="menuitem"]') ?? [])];
+    const index = items.indexOf(document.activeElement as HTMLButtonElement);
+    if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); close(true); }
+    else if (event.key === 'Tab') {
+      // Continue the page's normal tab order from the menu button.
+      close(true);
+    } else {
+      let next: number | undefined;
+      if (event.key === 'ArrowDown') next = (index + 1) % items.length;
+      else if (event.key === 'ArrowUp') next = (index - 1 + items.length) % items.length;
+      else if (event.key === 'Home') next = 0;
+      else if (event.key === 'End') next = items.length - 1;
+      else if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        // Repeated letters cycle matching actions (Duplicate / Delete).
+        for (let offset = 1; offset <= items.length; offset++) {
+          const candidate = (index + offset) % items.length;
+          if (items[candidate].textContent?.trim().toLowerCase().startsWith(event.key.toLowerCase())) { next = candidate; break; }
+        }
+      }
+      if (next !== undefined) { event.preventDefault(); items[next]?.focus(); }
+    }
+  }
+</script>
+
+<svelte:window onpointerdown={outside} onfocusin={outside} />
+<button bind:this={trigger} type="button" {disabled}
+  onclick={() => open ? close(true) : show()}
+  onkeydown={(event) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault(); void show(event.key === 'ArrowUp');
+    }
+  }}
+  aria-label={`Project actions for ${name || 'Untitled Project'}`}
+  aria-haspopup="menu" aria-expanded={open} aria-controls={open ? id : undefined}
+  class="absolute top-3 right-3 w-8 h-8 bg-white/90 backdrop-blur rounded-lg shadow-sm border border-gray-200 flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-gray-50 disabled:opacity-40">
+  <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" class="text-gray-500"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>
+</button>
+{#if open}
+  <div bind:this={menu} {id} role="menu" tabindex="-1" aria-label={`Project actions for ${name || 'Untitled Project'}`}
+    onkeydown={keydown} class="absolute top-12 right-3 bg-white rounded-lg shadow-xl border border-gray-200 py-1 w-40 z-50">
+    {#each actions as action}
+      <button type="button" role="menuitem" tabindex="-1"
+        onclick={() => { close(true); onaction(action); }}
+        class="w-full px-3 py-2 text-sm text-left focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-blue-500 {action === 'delete' ? 'text-red-500 hover:bg-red-50 focus:bg-red-50' : 'text-gray-700 hover:bg-gray-50 focus:bg-gray-50'}">
+        {action[0].toUpperCase() + action.slice(1)}
+      </button>
+    {/each}
+  </div>
+{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { modalDialog } from '$lib/utils/modalDialog';
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { localStore, storageErrorMessage, downloadLibraryBackup } from '$lib/services/datastore';
@@ -9,6 +9,7 @@
   import WelcomeScreen from '$lib/components/WelcomeScreen.svelte';
   import LibraryRestoreDialog from '$lib/components/LibraryRestoreDialog.svelte';
   import ProjectPackageDialog from '$lib/components/ProjectPackageDialog.svelte';
+  import ProjectActionsMenu from '$lib/components/ProjectActionsMenu.svelte';
   import { houseTemplates } from '$lib/utils/houseTemplates';
 
   const openingLifetime = new AbortController();
@@ -20,10 +21,12 @@
   let restoreOpen = $state(false);
   let packageOpen = $state(false);
   let loading = $state(true);
-  let confirmDeleteId = $state<string | null>(null);
-  let renamingId = $state<string | null>(null);
+  let actionDialog = $state<{ type: 'rename' | 'delete'; id: string; name: string } | null>(null);
   let renameValue = $state('');
-  let contextMenuId = $state<string | null>(null);
+  let actionError = $state<string | null>(null);
+  let actionBusy = $state(false);
+  let duplicating = $state(false);
+  let newProjectButton = $state<HTMLButtonElement>();
   let showTemplateModal = $state(false);
 
   let libraryError = $state<string | null>(null);
@@ -76,48 +79,52 @@
   function createFromTemplate(index: number) { return createProject(houseTemplates[index].create); }
   function newProject() { return createProject(() => createDefaultProject('Untitled Project')); }
 
-  async function deleteProject(id: string) {
-    await withLibraryError(async () => {
-      await localStore.delete(id);
-      confirmDeleteId = null;
-      projects = (await localStore.list()).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-    });
-  }
-
   async function duplicateProject(id: string) {
+    if (duplicating) return;
+    const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    duplicating = true;
     await withLibraryError(async () => {
       const dup = await localStore.duplicate(id);
-      if (dup) {
-        projects = (await localStore.list()).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-        thumbnails = { ...thumbnails, [dup.id]: await localStore.getThumbnail(dup.id) };
-      }
-      contextMenuId = null;
+      if (!dup) throw new Error('This project was deleted in another tab. Reload the library to see the latest projects.');
     });
+    // Refresh errors must not turn a completed copy into a retryable mutation.
+    if (!libraryError) await withLibraryError(refreshProjects);
+    duplicating = false;
+    await tick();
+    if (document.activeElement === document.body && previous?.isConnected) previous.focus();
   }
 
-  async function startRename(id: string, currentName: string) {
-    renamingId = id;
-    renameValue = currentName;
-    contextMenuId = null;
-    await new Promise(r => setTimeout(r, 50));
-    const input = document.getElementById('rename-input') as HTMLInputElement;
-    input?.focus();
-    input?.select();
+  function openAction(type: 'rename' | 'delete', project: { id: string; name: string }) {
+    actionDialog = { type, id: project.id, name: project.name || 'Untitled Project' };
+    renameValue = project.name;
+    actionError = null;
   }
-
-  async function commitRename(id: string) {
-    await withLibraryError(async () => {
-      if (renameValue.trim()) {
-        const p = await localStore.load(id);
-        if (p) {
-          p.name = renameValue.trim();
-          p.updatedAt = new Date();
-          await localStore.save(p);
-          projects = (await localStore.list()).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-        }
+  function closeAction() { if (!actionBusy) actionDialog = null; }
+  async function submitAction() {
+    const action = actionDialog, name = renameValue.trim();
+    if (!action || actionBusy || (action.type === 'rename' && !name)) return;
+    actionBusy = true; actionError = null;
+    try {
+      if (action.type === 'delete') await localStore.delete(action.id);
+      else {
+        const project = await localStore.load(action.id);
+        if (!project) throw new Error('This project was deleted in another tab. Cancel and reload the library to see the latest projects.');
+        project.name = name;
+        project.updatedAt = new Date();
+        await localStore.save(project);
       }
-      renamingId = null;
-    });
+    } catch (error) {
+      actionError = storageErrorMessage(error);
+      actionBusy = false;
+      return;
+    }
+    actionBusy = false;
+    actionDialog = null;
+    // Close only after the transaction commits, then refresh separately so a
+    // failed list read cannot repeat a successful rename or delete.
+    await withLibraryError(refreshProjects);
+    await tick();
+    if (action.type === 'delete' && document.activeElement === document.body) newProjectButton?.focus();
   }
 
   function formatDate(d: string) {
@@ -134,8 +141,6 @@
     return date.toLocaleDateString();
   }
 </script>
-
-<svelte:window onclick={() => { contextMenuId = null; }} />
 
 {#if showWelcome}
   <WelcomeScreen onRestoreLibrary={openRestore} onImportPackage={openPackage} onDismiss={() => { showWelcome = false; void withLibraryError(refreshProjects); }} />
@@ -161,6 +166,7 @@
           Templates
         </button>
         <button
+          bind:this={newProjectButton}
           onclick={newProject}
           class="px-5 py-2.5 bg-blue-500 text-white rounded-lg hover:bg-blue-600 font-semibold text-sm shadow-lg shadow-blue-500/25 transition-all hover:shadow-blue-500/40 flex items-center gap-2"
         >
@@ -172,6 +178,7 @@
   </div>
 
   <div class="max-w-5xl mx-auto px-6 py-8">
+    {#if duplicating}<p role="status" class="mb-4 text-sm text-gray-500">Duplicating project…</p>{/if}
     <div class="mb-5 flex flex-wrap items-center justify-between gap-3 text-sm text-gray-500">
       <p>Projects and version history are saved in this browser.</p>
       <div class="flex flex-wrap gap-4">
@@ -209,10 +216,10 @@
       </div>
     {:else}
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-        {#each projects as project}
+        {#each projects as project (project.id)}
           <div class="group bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-lg hover:border-gray-300 transition-all duration-200 relative">
             <!-- Thumbnail -->
-            <a href={`${base}/editor?id=${encodeURIComponent(project.id)}`} class="block">
+            <a href={`${base}/editor?id=${encodeURIComponent(project.id)}`} aria-label={`Open ${project.name || 'Untitled Project'}`} class="block">
               <div class="aspect-[4/3] bg-gray-100 relative overflow-hidden">
                 {#if thumbnails[project.id]}
                   <img src={thumbnails[project.id]} alt="" class="w-full h-full object-contain" />
@@ -226,71 +233,51 @@
 
             <!-- Info -->
             <div class="p-4">
-              {#if renamingId === project.id}
-                <input
-                  id="rename-input"
-                  type="text"
-                  bind:value={renameValue}
-                  onblur={() => commitRename(project.id)}
-                  onkeydown={(e) => { if (e.key === 'Enter') commitRename(project.id); if (e.key === 'Escape') renamingId = null; }}
-                  class="font-semibold text-gray-800 text-sm bg-blue-50 border border-blue-300 rounded px-2 py-1 w-full outline-none"
-                />
-              {:else}
-                <a href={`${base}/editor?id=${encodeURIComponent(project.id)}`} class="block">
-                  <h3 class="font-semibold text-gray-800 text-sm truncate">{project.name || 'Untitled Project'}</h3>
-                </a>
-              {/if}
+              <a href={`${base}/editor?id=${encodeURIComponent(project.id)}`} class="block">
+                <h3 class="font-semibold text-gray-800 text-sm truncate">{project.name || 'Untitled Project'}</h3>
+              </a>
               <p class="text-xs text-gray-400 mt-1">{formatDate(project.updatedAt)}</p>
             </div>
 
-            <!-- Actions menu button -->
-            <button
-              onclick={(e) => { e.stopPropagation(); contextMenuId = contextMenuId === project.id ? null : project.id; }}
-              aria-label={`Project actions for ${project.name || 'Untitled Project'}`}
-              aria-expanded={contextMenuId === project.id}
-              class="absolute top-3 right-3 w-8 h-8 bg-white/90 backdrop-blur rounded-lg shadow-sm border border-gray-200 flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:bg-gray-50"
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" class="text-gray-500"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>
-            </button>
-
-            <!-- Context menu -->
-            {#if contextMenuId === project.id}
-              <div
-                class="absolute top-12 right-3 bg-white rounded-lg shadow-xl border border-gray-200 py-1 w-40 z-50"
-                onclick={(e) => e.stopPropagation()}
-              >
-                <button onclick={() => { goto(`${base}/editor?id=${encodeURIComponent(project.id)}`); }} class="w-full px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 text-left flex items-center gap-2">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
-                  Open
-                </button>
-                <button onclick={() => startRename(project.id, project.name)} class="w-full px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 text-left flex items-center gap-2">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                  Rename
-                </button>
-                <button onclick={() => duplicateProject(project.id)} class="w-full px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 text-left flex items-center gap-2">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                  Duplicate
-                </button>
-                <div class="h-px bg-gray-100 my-1"></div>
-                {#if confirmDeleteId === project.id}
-                  <div class="px-3 py-2 flex items-center gap-2">
-                    <span class="text-xs text-gray-500">Delete?</span>
-                    <button onclick={() => deleteProject(project.id)} class="px-2 py-1 bg-red-500 text-white text-xs rounded hover:bg-red-600">Yes</button>
-                    <button onclick={() => confirmDeleteId = null} class="px-2 py-1 bg-gray-200 text-gray-600 text-xs rounded hover:bg-gray-300">No</button>
-                  </div>
-                {:else}
-                  <button onclick={() => { confirmDeleteId = project.id; }} class="w-full px-3 py-2 text-sm text-red-500 hover:bg-red-50 text-left flex items-center gap-2">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
-                    Delete
-                  </button>
-                {/if}
-              </div>
-            {/if}
+            <ProjectActionsMenu name={project.name} disabled={duplicating}
+              onaction={(action) => {
+                if (action === 'open') goto(`${base}/editor?id=${encodeURIComponent(project.id)}`);
+                else if (action === 'duplicate') void duplicateProject(project.id);
+                else openAction(action, project);
+              }} />
           </div>
         {/each}
       </div>
     {/if}
   </div>
+
+  {#if actionDialog}
+    <dialog use:modalDialog aria-labelledby="library-action-title" aria-describedby="library-action-description"
+      oncancel={(event) => { event.preventDefault(); closeAction(); }}
+      class="m-auto w-[28rem] max-w-[calc(100vw-2rem)] max-h-[85vh] overflow-y-auto rounded-2xl bg-white p-5 text-gray-800 shadow-2xl backdrop:bg-black/50">
+      <form onsubmit={(event) => { event.preventDefault(); void submitAction(); }}>
+        <h2 id="library-action-title" class="text-lg font-semibold">{actionDialog.type === 'rename' ? 'Rename project' : 'Delete project'}</h2>
+        <p id="library-action-description" class="mt-2 break-words text-sm text-gray-500">
+          {#if actionDialog.type === 'rename'}Choose a name for {actionDialog.name}.
+          {:else}Delete “{actionDialog.name}” and its version history from this browser? This cannot be undone.{/if}
+        </p>
+        {#if actionDialog.type === 'rename'}
+          <label for="library-project-name" class="mt-4 block text-sm font-medium">Project name</label>
+          <input id="library-project-name" type="text" bind:value={renameValue} disabled={actionBusy} required
+            class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-blue-500" />
+        {/if}
+        {#if actionError}<p role="alert" class="mt-4 rounded-lg bg-red-50 p-3 text-sm text-red-900">{actionError}</p>{/if}
+        {#if actionBusy}<p role="status" class="mt-4 text-sm text-gray-500">{actionDialog.type === 'rename' ? 'Saving name…' : 'Deleting project…'}</p>{/if}
+        <div class="mt-5 flex justify-end gap-3">
+          <button type="button" onclick={closeAction} disabled={actionBusy} class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold disabled:opacity-40">Cancel</button>
+          <button type="submit" disabled={actionBusy || (actionDialog.type === 'rename' && !renameValue.trim())}
+            class="rounded-lg px-4 py-2 text-sm font-semibold text-white disabled:opacity-40 {actionDialog.type === 'rename' ? 'bg-blue-600' : 'bg-red-600'}">
+            {actionDialog.type === 'rename' ? 'Save name' : 'Delete project'}
+          </button>
+        </div>
+      </form>
+    </dialog>
+  {/if}
 
   <!-- Template Modal -->
   {#if showTemplateModal}

--- a/tests/browser/library-actions.spec.ts
+++ b/tests/browser/library-actions.spec.ts
@@ -5,6 +5,9 @@ import { failProjectWrites, savedProjects, storedRecords } from './storage';
 async function seed(page: Page) {
   const project = JSON.parse(await readFile('tests/fixtures/save-conflicts.openplan.json', 'utf8'));
   project.id = 'qa-library-actions'; project.name = 'QA Library Actions';
+  // Use the current door shape so geometry assertions isolate library actions
+  // from the existing legacy import default for flipSide.
+  for (const floor of project.floors) for (const door of floor.doors) door.flipSide ??= false;
   const second = { ...project, id: 'qa-library-second', name: 'Second project' };
   await page.addInitScript(projects => {
     if (!localStorage.getItem('qaLibraryActionsSeeded')) {

--- a/tests/browser/library-actions.spec.ts
+++ b/tests/browser/library-actions.spec.ts
@@ -1,0 +1,179 @@
+import { expect, test, type Page } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { failProjectWrites, savedProjects, storedRecords } from './storage';
+
+async function seed(page: Page) {
+  const project = JSON.parse(await readFile('tests/fixtures/save-conflicts.openplan.json', 'utf8'));
+  project.id = 'qa-library-actions'; project.name = 'QA Library Actions';
+  const second = { ...project, id: 'qa-library-second', name: 'Second project' };
+  await page.addInitScript(projects => {
+    if (!localStorage.getItem('qaLibraryActionsSeeded')) {
+      localStorage.setItem('floorplan_projects', JSON.stringify(Object.fromEntries(projects.map(p => [p.id, JSON.stringify(p)]))));
+      localStorage.setItem('qaLibraryActionsSeeded', 'true');
+    }
+    localStorage.setItem('hasSeenWelcome', 'true');
+  }, [project, second]);
+  await page.goto('/');
+  await expect(page.getByRole('link', { name: project.name, exact: true })).toBeVisible();
+  return project;
+}
+function observe(page: Page) {
+  const errors: string[] = [], external: string[] = [];
+  page.on('pageerror', e => errors.push(e.message));
+  page.on('request', r => { if (/^https?:/.test(r.url()) && new URL(r.url()).origin !== 'http://127.0.0.1:4188') external.push(r.url()); });
+  return () => { expect(errors).toEqual([]); expect(external).toEqual([]); };
+}
+function trigger(page: Page, name = 'QA Library Actions') {
+  return page.getByRole('button', { name: `Project actions for ${name}`, exact: true });
+}
+async function action(page: Page, name: string, projectName?: string) {
+  await trigger(page, projectName).press('Enter');
+  await page.getByRole('menuitem', { name, exact: true }).click();
+}
+async function holdWrites(page: Page) {
+  await page.evaluate(() => new Promise<void>(resolve => {
+    void navigator.locks.request('openplan3d-project-library', () => new Promise<void>(release => {
+      (window as any).releaseLibraryAction = release; resolve();
+    }));
+  }));
+}
+async function releaseWrites(page: Page) {
+  await page.evaluate(() => { (window as any).releaseLibraryAction(); });
+}
+
+for (const width of [1440, 390]) {
+  test(`library menus navigate and cancellation preserves projects at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    const check = observe(page); await seed(page);
+    const before = await storedRecords(page);
+    const button = trigger(page), menu = page.getByRole('menu');
+    await button.press('ArrowDown');
+    await expect(page.getByRole('menuitem', { name: 'Open', exact: true })).toBeFocused();
+    await page.keyboard.press('End');
+    await expect(page.getByRole('menuitem', { name: 'Delete', exact: true })).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('menuitem', { name: 'Open', exact: true })).toBeFocused();
+    await page.keyboard.press('d');
+    await expect(page.getByRole('menuitem', { name: 'Duplicate', exact: true })).toBeFocused();
+    await page.keyboard.press('d');
+    await expect(page.getByRole('menuitem', { name: 'Delete', exact: true })).toBeFocused();
+    await page.keyboard.press('Home'); await page.keyboard.press('ArrowDown');
+    await expect(page.getByRole('menuitem', { name: 'Rename', exact: true })).toBeFocused();
+    await page.keyboard.press('Escape');
+    await expect(menu).toHaveCount(0); await expect(button).toBeFocused();
+    await button.press('ArrowUp');
+    await expect(page.getByRole('menuitem', { name: 'Delete', exact: true })).toBeFocused();
+    await page.keyboard.press('Tab'); await expect(menu).toHaveCount(0);
+    await button.press('Enter'); await page.keyboard.press('Shift+Tab'); await expect(menu).toHaveCount(0);
+    await button.click(); await page.getByRole('heading', { name: 'Floor Plan Editor', exact: true }).click();
+    await expect(menu).toHaveCount(0);
+    // Moving to another project's trigger must dismiss the old menu without stealing focus.
+    await button.press('Enter'); await trigger(page, 'Second project').focus();
+    await expect(menu).toHaveCount(0); await expect(trigger(page, 'Second project')).toBeFocused();
+    await action(page, 'Rename');
+    const rename = page.getByRole('dialog', { name: 'Rename project', exact: true });
+    const field = rename.getByRole('textbox', { name: 'Project name', exact: true });
+    await expect(field).toBeFocused(); await field.fill('Uncommitted draft');
+    await page.keyboard.press('Tab'); await page.keyboard.press('Shift+Tab');
+    await expect(field).toBeFocused();
+    await page.keyboard.press('Escape'); await expect(rename).toHaveCount(0); await expect(button).toBeFocused();
+    await action(page, 'Delete');
+    const deletion = page.getByRole('dialog', { name: 'Delete project', exact: true });
+    await expect(deletion).toContainText('QA Library Actions');
+    await expect(deletion.getByRole('button', { name: 'Cancel', exact: true })).toBeFocused();
+    await testInfo.attach(`library-delete-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+    await page.keyboard.press('Escape'); await expect(deletion).toHaveCount(0); await expect(button).toBeFocused();
+    await action(page, 'Delete');
+    // A fresh confirmation starts at Cancel, so Enter cannot accept an old deletion.
+    await expect(deletion.getByRole('button', { name: 'Cancel', exact: true })).toBeFocused();
+    await page.keyboard.press('Enter'); await expect(deletion).toHaveCount(0);
+    expect(await storedRecords(page)).toEqual(before);
+    await action(page, 'Open'); await expect(page).toHaveURL(/editor\?id=qa-library-actions$/);
+    await expect(page.getByRole('application')).toContainText('4 walls');
+    check();
+  });
+
+  test(`library rename retains failed drafts and submits once at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    const check = observe(page), project = await seed(page), before = await storedRecords(page);
+    await action(page, 'Rename');
+    const dialog = page.getByRole('dialog', { name: 'Rename project', exact: true });
+    const field = dialog.getByRole('textbox', { name: 'Project name', exact: true });
+    const save = dialog.getByRole('button', { name: 'Save name', exact: true });
+    await field.fill('   '); await expect(save).toBeDisabled();
+    await field.fill('  Renamed local project  ');
+    await failProjectWrites(page); await field.press('Enter');
+    await expect(dialog.getByRole('alert')).toContainText('Browser storage is full');
+    await expect(field).toHaveValue('  Renamed local project  ');
+    expect(await storedRecords(page)).toEqual(before);
+    await testInfo.attach(`library-rename-recovery-${width}`, { body: await page.screenshot(), contentType: 'image/png' });
+    await page.evaluate(() => { (window as any).failProjectWrites = false; });
+    await holdWrites(page);
+    await field.press('Enter');
+    await expect(save).toBeDisabled(); await expect(field).toBeDisabled();
+    await expect(dialog.getByRole('button', { name: 'Cancel', exact: true })).toBeDisabled();
+    await page.keyboard.press('Escape'); await expect(dialog).toBeVisible();
+    await page.keyboard.press('Enter'); await page.keyboard.press('Enter');
+    expect(await storedRecords(page)).toEqual(before);
+    await releaseWrites(page);
+    await expect(dialog).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Renamed local project', exact: true })).toBeVisible();
+    await expect(trigger(page, 'Renamed local project')).toBeFocused();
+    const saved = await savedProjects(page);
+    expect(saved[project.id].floors).toEqual(project.floors);
+    expect(Object.keys(saved)).toHaveLength(2);
+    expect((await storedRecords(page))['qa-library-second']).toBe(before['qa-library-second']);
+    await page.reload();
+    await expect(page.getByRole('link', { name: 'Renamed local project', exact: true })).toBeVisible();
+    await expect(page.getByRole('alert')).toHaveCount(0);
+    check();
+  });
+}
+
+test('library copies once while busy and deletes only the confirmed project', async ({ page }) => {
+  const check = observe(page), project = await seed(page), before = await storedRecords(page);
+  await holdWrites(page); await action(page, 'Duplicate');
+  await expect(page.getByRole('status')).toHaveText('Duplicating project…');
+  await expect(trigger(page)).toBeDisabled(); await expect(trigger(page, 'Second project')).toBeDisabled();
+  await page.keyboard.press('Enter'); await page.keyboard.press('Enter');
+  expect(await storedRecords(page)).toEqual(before);
+  await releaseWrites(page);
+  await expect(page.getByRole('link', { name: `${project.name} (Copy)`, exact: true })).toBeVisible();
+  const copied = await savedProjects(page), copy = Object.values(copied).find(p => p.name === `${project.name} (Copy)`)!;
+  expect(Object.keys(copied)).toHaveLength(3); expect(copy.floors).toEqual(project.floors);
+  await action(page, 'Delete', copy.name);
+  const dialog = page.getByRole('dialog', { name: 'Delete project', exact: true });
+  await holdWrites(page);
+  await dialog.getByRole('button', { name: 'Delete project', exact: true }).click();
+  await expect(dialog.getByRole('button', { name: 'Delete project', exact: true })).toBeDisabled();
+  await page.keyboard.press('Escape'); await expect(dialog).toBeVisible();
+  await releaseWrites(page); await expect(dialog).toHaveCount(0);
+  await expect(page.getByRole('link', { name: copy.name, exact: true })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'New Project', exact: true })).toBeFocused();
+  expect(await storedRecords(page)).toEqual(before);
+  await page.reload(); expect(await storedRecords(page)).toEqual(before);
+  check();
+});
+
+test('failed library deletion keeps its confirmation available for retry', async ({ page }) => {
+  const check = observe(page); await seed(page); const before = await storedRecords(page);
+  await action(page, 'Delete');
+  await page.evaluate(() => {
+    (window as any).failLibraryDelete = true;
+    const remove = IDBObjectStore.prototype.delete;
+    IDBObjectStore.prototype.delete = function(...args) {
+      if (this.name === 'projects' && (window as any).failLibraryDelete) throw new DOMException('Unavailable', 'SecurityError');
+      return remove.apply(this, args);
+    };
+  });
+  const dialog = page.getByRole('dialog', { name: 'Delete project', exact: true });
+  await dialog.getByRole('button', { name: 'Delete project', exact: true }).click();
+  await expect(dialog.getByRole('alert')).toContainText('Browser storage is unavailable');
+  expect(await storedRecords(page)).toEqual(before);
+  await page.evaluate(() => { (window as any).failLibraryDelete = false; });
+  await dialog.getByRole('button', { name: 'Delete project', exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  await expect(trigger(page)).toHaveCount(0);
+  expect(await storedRecords(page)).toEqual({ 'qa-library-second': before['qa-library-second'] });
+  check();
+});

--- a/tests/browser/save-conflicts.spec.ts
+++ b/tests/browser/save-conflicts.spec.ts
@@ -94,8 +94,8 @@ test('deleting a library project cannot be undone by an older editor autosave', 
   await expect(page.getByRole('application')).toContainText('1 room');
   await library.goto('/');
   await library.getByRole('button', { name: `Project actions for ${source.name}`, exact: true }).click();
-  await library.getByRole('button', { name: 'Delete', exact: true }).click();
-  await library.getByRole('button', { name: 'Yes', exact: true }).click();
+  await library.getByRole('menuitem', { name: 'Delete', exact: true }).click();
+  await library.getByRole('dialog', { name: 'Delete project', exact: true }).getByRole('button', { name: 'Delete project', exact: true }).click();
   await expect(page.getByRole('alert')).toContainText('deleted in another tab');
   await page.getByRole('button', { name: 'Save', exact: true }).click();
   expect(Object.keys(await saved(page))).toHaveLength(0);


### PR DESCRIPTION
The project library now supports keyboard navigation and reliable cancellation. Previously Escape left the actions menu open, dismissing Delete retained its armed Yes/No prompt, and rename could save from both Enter and blur.

Adds menu focus/navigation, named rename/delete dialogs, recoverable storage errors and pending-operation guards. Stable project cards retain focus after renaming; deletion supplies a remaining focus target. All changes stay local and add no Firebase usage or dependencies.

Validation: [PR CI](https://github.com/laanlabs/openPlan3D/actions/runs/34242128056) passes 647 unit tests, 276 browser checks (92 each in Chromium/Firefox/WebKit), and six rendering benchmarks, with no test retries. Production build and dependency audit pass; Svelte check reports zero errors and seven remaining warnings. Six new workflows cover desktop/390px interaction, preserved records, blocked writes and failure/retry; the existing cross-tab deletion regression uses the new confirmation. One WebKit setup attempt was restarted after slow Ubuntu dependency downloads; no application test had started on that attempt.

Deployed commit `d2649b6b1c12cfe56f5828d2c6bd3df61f5b31ca` and version `1788881285033` are verified. Production Safari confirms menu focus, rename, safe cancellation, copying, explicit deletion and focus afterward. JSON comparison of a disposable studio plan shows rename changed only `name` and `updatedAt`; the copy has a new project ID and identical floor data. Both QA plans and the QA tab were removed afterward. Backlog and implementation details are in `NEXT.md` and `docs/reviews/2026-09-08-library-actions.md`.

Closes #91.

[Final main CI](https://github.com/laanlabs/openPlan3D/actions/runs/34244855351) also passes all 647 unit tests, 276 browser checks and six benchmarks without test retries. The web and unchanged iOS repositories are clean on `main`, and the source branch has been removed locally and remotely.
